### PR TITLE
fix: resolve CI lint errors and notebook execution timeout

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -206,11 +206,13 @@ class Model:
         ):
             _leaf_ratio = model_cfg.min_data_in_leaf_ratio
             _bin_ratio = model_cfg.min_data_in_bin_ratio
-            ratio_resolver = lambda n: resolve_ratio_params(
-                min_data_in_leaf_ratio=_leaf_ratio,
-                min_data_in_bin_ratio=_bin_ratio,
-                n_rows=n,
-            )
+
+            def ratio_resolver(n: int) -> dict[str, int]:
+                return resolve_ratio_params(
+                    min_data_in_leaf_ratio=_leaf_ratio,
+                    min_data_in_bin_ratio=_bin_ratio,
+                    n_rows=n,
+                )
 
         def make_pipeline() -> NativeFeaturePipeline:
             return NativeFeaturePipeline()
@@ -1158,12 +1160,16 @@ class Model:
 
         # --- Config smart params ---
         if isinstance(model_cfg, LGBMConfig):
-            rows.append({"parameter": "auto_num_leaves", "value": model_cfg.auto_num_leaves})
-            rows.append({"parameter": "num_leaves_ratio", "value": model_cfg.num_leaves_ratio})
-            rows.append({"parameter": "min_data_in_leaf_ratio", "value": model_cfg.min_data_in_leaf_ratio})
-            rows.append({"parameter": "min_data_in_bin_ratio", "value": model_cfg.min_data_in_bin_ratio})
-            rows.append({"parameter": "balanced", "value": model_cfg.balanced})
-            rows.append({"parameter": "feature_weights", "value": model_cfg.feature_weights})
+            smart = {
+                "auto_num_leaves": model_cfg.auto_num_leaves,
+                "num_leaves_ratio": model_cfg.num_leaves_ratio,
+                "min_data_in_leaf_ratio": model_cfg.min_data_in_leaf_ratio,
+                "min_data_in_bin_ratio": model_cfg.min_data_in_bin_ratio,
+                "balanced": model_cfg.balanced,
+                "feature_weights": model_cfg.feature_weights,
+            }
+            for k, v in smart.items():
+                rows.append({"parameter": k, "value": v})
 
         # --- Config training params ---
         es = self._cfg.training.early_stopping

--- a/lizyml/estimators/base.py
+++ b/lizyml/estimators/base.py
@@ -72,6 +72,7 @@ class BaseEstimatorAdapter(ABC):
         Used by CVTrainer for per-fold ratio parameter resolution (H-0036).
         Subclasses should override if they store params internally.
         """
+        return  # noqa: B027 — intentional no-op default
 
     @property
     def best_iteration(self) -> int | None:

--- a/lizyml/training/refit_trainer.py
+++ b/lizyml/training/refit_trainer.py
@@ -107,11 +107,8 @@ class RefitTrainer:
 
         # Resolve n_rows-dependent ratio params using inner_train size (H-0036)
         if self.ratio_param_resolver is not None:
-            if iv_result is not None:
-                n_inner_train = len(iv_result[0])  # inner_train_rel
-            else:
-                n_inner_train = n_samples
-            estimator.update_params(self.ratio_param_resolver(n_inner_train))
+            n_inner = len(iv_result[0]) if iv_result is not None else n_samples
+            estimator.update_params(self.ratio_param_resolver(n_inner))
 
         if iv_result is not None:
             inner_train_rel, inner_valid_rel = iv_result

--- a/notebooks/tutorial_regression_tuning_lgbm.ipynb
+++ b/notebooks/tutorial_regression_tuning_lgbm.ipynb
@@ -138,7 +138,7 @@
   {
    "cell_type": "code",
    "id": "2d1s2iy81qy",
-   "source": "# Feature weights (resolved) — only displayed when feature_weights is configured\nbooster = model.fit_result.models[0]\nfw = booster.params.get(\"feature_weights\")\nif fw is not None:\n    feature_names = model.fit_result.feature_names\n    print(\"Resolved feature_weights (Fold 0):\")\n    for name, w in zip(feature_names, fw):\n        print(f\"  {name}: {w}\")\nelse:\n    print(\"feature_weights: not configured (all features equally weighted)\")",
+   "source": "# Feature weights (resolved) — only displayed when feature_weights is configured\nbooster = model.fit_result.models[0]\nfw = booster.params.get(\"feature_weights\")\nif fw is not None:\n    feature_names = model.fit_result.feature_names\n    print(\"Resolved feature_weights (Fold 0):\")\n    for name, w in zip(feature_names, fw, strict=False):\n        print(f\"  {name}: {w}\")\nelse:\n    print(\"feature_weights: not configured (all features equally weighted)\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/tests/test_coverage/test_edge_cases.py
+++ b/tests/test_coverage/test_edge_cases.py
@@ -19,7 +19,6 @@ import pytest
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 
-
 # ============================================================================
 # 1. splitters/holdout.py  (60% -> 95%+)
 # ============================================================================
@@ -138,9 +137,11 @@ class TestNormalizeShapOutput:
         mock_explainer = MagicMock()
         mock_explainer.shap_values.return_value = [arr0, arr1]
 
-        with patch("lizyml.explain.shap_explainer._shap") as mock_shap:
+        _patch = patch("lizyml.explain.shap_explainer._shap")
+        with _patch as mock_shap:
             mock_shap.TreeExplainer.return_value = mock_explainer
-            result = compute_shap_values(mock_model, pd.DataFrame(np.zeros((10, 5))), "binary")
+            X = pd.DataFrame(np.zeros((10, 5)))
+            result = compute_shap_values(mock_model, X, "binary")
         np.testing.assert_array_equal(result, arr1)
 
     def test_legacy_list_multiclass(self) -> None:
@@ -151,9 +152,11 @@ class TestNormalizeShapOutput:
         mock_explainer = MagicMock()
         mock_explainer.shap_values.return_value = arrs
 
-        with patch("lizyml.explain.shap_explainer._shap") as mock_shap:
+        _patch = patch("lizyml.explain.shap_explainer._shap")
+        with _patch as mock_shap:
             mock_shap.TreeExplainer.return_value = mock_explainer
-            result = compute_shap_values(mock_model, pd.DataFrame(np.zeros((10, 5))), "multiclass")
+            X = pd.DataFrame(np.zeros((10, 5)))
+            result = compute_shap_values(mock_model, X, "multiclass")
         assert result.shape == (10, 5)
         expected = np.mean(np.abs(np.stack(arrs, axis=0)), axis=0)
         np.testing.assert_allclose(result, expected)
@@ -163,12 +166,13 @@ class TestNormalizeShapOutput:
 
         mock_model = MagicMock()
         mock_explainer = MagicMock()
-        # Return a tuple (not list, not ndarray) to trigger fallback
         mock_explainer.shap_values.return_value = ((1.0, 2.0), (3.0, 4.0))
 
-        with patch("lizyml.explain.shap_explainer._shap") as mock_shap:
+        _patch = patch("lizyml.explain.shap_explainer._shap")
+        with _patch as mock_shap:
             mock_shap.TreeExplainer.return_value = mock_explainer
-            result = compute_shap_values(mock_model, pd.DataFrame(np.zeros((2, 2))), "regression")
+            X = pd.DataFrame(np.zeros((2, 2)))
+            result = compute_shap_values(mock_model, X, "regression")
         assert isinstance(result, np.ndarray)
 
 
@@ -212,18 +216,20 @@ class TestExportError:
         mock_fr.metrics = {}
         mock_fr.feature_names = ["a"]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("lizyml.persistence.exporter.joblib") as mock_jl:
-                mock_jl.dump.side_effect = IOError("disk full")
-                with pytest.raises(LizyMLError) as exc_info:
-                    export(
-                        path=tmpdir,
-                        fit_result=mock_fr,
-                        refit_result=MagicMock(),
-                        config={"task": "regression"},
-                        task="regression",
-                    )
-                assert exc_info.value.code == ErrorCode.SERIALIZATION_FAILED
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("lizyml.persistence.exporter.joblib") as mock_jl,
+        ):
+            mock_jl.dump.side_effect = OSError("disk full")
+            with pytest.raises(LizyMLError) as exc_info:
+                export(
+                    path=tmpdir,
+                    fit_result=mock_fr,
+                    refit_result=MagicMock(),
+                    config={"task": "regression"},
+                    task="regression",
+                )
+            assert exc_info.value.code == ErrorCode.SERIALIZATION_FAILED
 
 
 # ============================================================================
@@ -236,7 +242,8 @@ class TestLoadErrors:
         from lizyml.persistence.loader import load
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            (Path(tmpdir) / "metadata.json").write_text("NOT VALID JSON{{{", encoding="utf-8")
+            meta_path = Path(tmpdir) / "metadata.json"
+            meta_path.write_text("NOT VALID JSON{{{", encoding="utf-8")
             with pytest.raises(LizyMLError) as exc_info:
                 load(tmpdir)
             assert exc_info.value.code == ErrorCode.DESERIALIZATION_FAILED
@@ -253,7 +260,8 @@ class TestLoadErrors:
                 "config": {},
                 "run_id": "test",
             }
-            (Path(tmpdir) / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+            meta_path = Path(tmpdir) / "metadata.json"
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
             (Path(tmpdir) / "fit_result.pkl").write_bytes(b"corrupt data")
             (Path(tmpdir) / "refit_model.pkl").write_bytes(b"corrupt data")
             with pytest.raises(LizyMLError) as exc_info:
@@ -272,7 +280,8 @@ class TestLoadErrors:
                 "config": {},
                 "run_id": "test",
             }
-            (Path(tmpdir) / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+            meta_path = Path(tmpdir) / "metadata.json"
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
             # Create valid pkl for fit_result and refit but corrupt analysis_context
             import joblib
 

--- a/tests/test_notebooks/test_notebook_execution.py
+++ b/tests/test_notebooks/test_notebook_execution.py
@@ -33,8 +33,10 @@ def test_notebook_executes(notebook_name: str) -> None:
     assert path.exists(), f"Notebook not found: {path}"
 
     nb = nbformat.read(str(path), as_version=4)
+    # Tuning notebook runs Optuna trials — needs more time on CI
+    cell_timeout = 600 if "tuning" in notebook_name else 180
     ep = nbconvert_pp.ExecutePreprocessor(
-        timeout=180,
+        timeout=cell_timeout,
         kernel_name="python3",
     )
     ep.preprocess(nb, {"metadata": {"path": str(NOTEBOOKS_DIR)}})


### PR DESCRIPTION
## Summary

- Fix 7 ruff lint errors (E731, E501, B027, SIM108, SIM117, I001, B905) across 6 files
- Increase notebook execution timeout to 600s for tuning notebook (was 180s, times out on CI)

## Skills
- `dev-environment` (ruff lint), `git-workflow`

## DoD
- [x] `uv run ruff check .` clean
- [x] `uv run mypy lizyml/` clean
- [x] `uv run pytest` passing (782 tests)

## Test plan
- [x] All 782 tests pass locally
- [x] ruff/mypy clean
- CI will re-run on PR #3 after this is merged to develop