### PR TITLE
fix: apply ruff format to pass CI format check

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -1180,10 +1180,19 @@ class Model:
         # --- Resolved booster params (fold 0) ---
         booster = fr.models[0].get_native_model().booster_
         for k in [
-            "objective", "learning_rate", "max_depth", "num_leaves",
-            "min_data_in_leaf", "min_data_in_bin", "max_bin",
-            "feature_fraction", "bagging_fraction", "bagging_freq",
-            "lambda_l1", "lambda_l2", "num_iterations",
+            "objective",
+            "learning_rate",
+            "max_depth",
+            "num_leaves",
+            "min_data_in_leaf",
+            "min_data_in_bin",
+            "max_bin",
+            "feature_fraction",
+            "bagging_fraction",
+            "bagging_freq",
+            "lambda_l1",
+            "lambda_l2",
+            "num_iterations",
         ]:
             v = booster.params.get(k)
             if v is not None:

--- a/tests/test_coverage/test_edge_cases.py
+++ b/tests/test_coverage/test_edge_cases.py
@@ -72,7 +72,10 @@ class TestBuildSplitter:
         from lizyml.core.specs.split_spec import SplitSpec
 
         defaults: dict[str, Any] = {
-            "n_splits": 3, "random_state": 42, "shuffle": True, "gap": 0,
+            "n_splits": 3,
+            "random_state": 42,
+            "shuffle": True,
+            "gap": 0,
         }
         defaults.update(kw)
         return SplitSpec(method=method, **defaults)
@@ -487,10 +490,12 @@ class TestValidators:
         from lizyml.data.validators import validate_no_target_leakage
 
         # Mixed types that cause comparison issues
-        df = pd.DataFrame({
-            "target": [1, 2, 3],
-            "mixed": [object(), object(), object()],
-        })
+        df = pd.DataFrame(
+            {
+                "target": [1, 2, 3],
+                "mixed": [object(), object(), object()],
+            }
+        )
         # Should not raise, returns empty list
         result = validate_no_target_leakage(df, "target", raise_on_violation=False)
         assert isinstance(result, list)

--- a/tests/test_notebooks/test_notebook_cells.py
+++ b/tests/test_notebooks/test_notebook_cells.py
@@ -24,9 +24,7 @@ TUNING_NB = NOTEBOOKS_DIR / "tutorial_regression_tuning_lgbm.ipynb"
 def _read_code_cells(path: Path) -> str:
     """Concatenate all code cell sources into a single string."""
     nb = nbformat.read(str(path), as_version=4)
-    return "\n".join(
-        cell.source for cell in nb.cells if cell.cell_type == "code"
-    )
+    return "\n".join(cell.source for cell in nb.cells if cell.cell_type == "code")
 
 
 # --- Config keywords required in all 3 main notebooks ---
@@ -45,9 +43,7 @@ CONFIG_KEYWORDS = [
 @pytest.mark.parametrize("keyword", CONFIG_KEYWORDS)
 def test_config_keywords_present(notebook_path: Path, keyword: str) -> None:
     code = _read_code_cells(notebook_path)
-    assert keyword in code, (
-        f"'{keyword}' not found in {notebook_path.name}"
-    )
+    assert keyword in code, f"'{keyword}' not found in {notebook_path.name}"
 
 
 # --- params_table() call required in all 4 notebooks ---

--- a/tests/test_plots/test_tuning_plot.py
+++ b/tests/test_plots/test_tuning_plot.py
@@ -72,16 +72,22 @@ class TestTuningPlotUnit:
             best_score=0.5,
             trials=[
                 TrialResult(
-                    number=0, params={"num_leaves": 8},
-                    score=1.0, state="complete",
+                    number=0,
+                    params={"num_leaves": 8},
+                    score=1.0,
+                    state="complete",
                 ),
                 TrialResult(
-                    number=1, params={"num_leaves": 16},
-                    score=0.5, state="complete",
+                    number=1,
+                    params={"num_leaves": 16},
+                    score=0.5,
+                    state="complete",
                 ),
                 TrialResult(
-                    number=2, params={"num_leaves": 32},
-                    score=0.8, state="pruned",
+                    number=2,
+                    params={"num_leaves": 32},
+                    score=0.8,
+                    state="pruned",
                 ),
             ],
             metric_name="rmse",


### PR DESCRIPTION
## Summary

- Apply `ruff format` to 4 files that failed `ruff format --check .` in CI
- Files: model.py, test_edge_cases.py, test_notebook_cells.py, test_tuning_plot.py

## Skills
- `dev-environment` (ruff format)

## DoD
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy lizyml/` clean
- [x] `uv run pytest` passing (782 tests)

## Test plan
- [x] All quality gates pass locally
- CI will re-run on PR #3 after this is merged to develop