### PR TITLE
Release: Phase 24 — LGBMAdapter Booster API migration

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -670,6 +670,22 @@ get_native_model()  # export用途
 - early stopping の設定吸収
 - SHAP（内蔵寄り）対応
 
+### 14.2.1 Booster API の使用（H-0041）
+
+`LGBMAdapter` は LightGBM の **Booster API**（`lgb.train()`）を使用する。sklearn wrapper（`LGBMRegressor` / `LGBMClassifier`）は使用しない。
+
+理由:
+- sklearn wrapper 内部の `model_to_string()` → `model_from_string()` ラウンドトリップに起因する間欠バグ（microsoft/LightGBM#7186）を回避する。
+- Booster API は `keep_training_booster=True` により上記ラウンドトリップを回避でき、直接的な制御が可能。
+
+制約:
+- `fit()` は `lgb.Dataset` を構築し、`lgb.train()` で学習する。
+- `predict()` / `predict_proba()` / `predict_raw()` は `Booster.predict()` を使用する。
+  - `predict_proba()` の shape 契約（binary: `(n, 2)`, multiclass: `(n, k)`）は維持する。
+- `get_native_model()` は `lgb.Booster` を返す。
+- パラメーター名は Booster API の名前空間に準拠する（`n_estimators` → `num_boost_round` 引数、`random_state` → `seed` パラメーター等の変換を adapter 内で吸収する）。
+- 学習履歴は `evals_result` dict から取得する（sklearn の `evals_result_` 属性ではない）。
+
 ## 14.3 LightGBM デフォルトパラメータープロファイル
 
 `LGBMAdapter` はタスク別のデフォルトパラメーターを提供する。`LGBMConfig.params` で明示指定した値はデフォルトを上書きする。
@@ -691,7 +707,7 @@ get_native_model()  # export用途
 |---|---|---|
 | `boosting` | `gbdt` | |
 | `first_metric_only` | `False` | |
-| `n_estimators` | `1500` | sklearn API 相当の `num_boost_round` |
+| `num_boost_round` | `1500` | `lgb.train()` の引数として渡す |
 | `learning_rate` | `0.001` | 低学習率で early stopping に依存 |
 | `max_depth` | `5` | |
 | `max_bin` | `511` | |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2496,3 +2496,80 @@ TimeSeries 系 split（`time_series` / `purged_time_series` / `group_time_series
 - `split.method: "purged_time_series"` を使う既存 Config は `embargo_pct` を `embargo` に置換する。
 - `time_series` / `purged_time_series` / `group_time_series` を使う既存 Config は `data.time_col` を必ず指定する。
 - 既存の並び替え前提コードは、`time_col` の値が期待どおりの順序を持つことを確認する。
+
+---
+
+## 2026-03-07: LGBMAdapter: sklearn wrapper → Booster API 移行
+
+- ID: `H-0041`
+- Status: `accepted`
+- Scope: `EstimatorAdapter | Training | Persistence`
+- Related: `BLUEPRINT.md §14.2, §14.3`, `PLAN.md Phase 24`
+
+### Context
+
+LightGBM の sklearn wrapper（`LGBMRegressor` / `LGBMClassifier`）に、`early_stopping` callback 併用時に `model_to_string()` が空文字列を返す間欠バグが存在する（microsoft/LightGBM#7186）。
+このバグは sklearn wrapper 内部の後処理（`engine.py:350` で `keep_training_booster=False` 時に実行される `model_from_string(model_to_string())` ラウンドトリップ）に起因し、約 5-10% の確率で `LightGBMError: Model file doesn't specify the number of classes` を発生させる。
+
+LightGBM の Booster API（`lgb.train()`）では `keep_training_booster=True` がデフォルトであり、上記ラウンドトリップが発生しないため、このバグの影響を受けない。実際に 100 回の検証で 0 回の失敗を確認済み。
+
+### Proposal
+
+`LGBMAdapter.fit()` の内部実装を sklearn wrapper（`LGBMRegressor` / `LGBMClassifier`）から LightGBM Booster API（`lgb.train()`）に移行する。
+
+1. **`fit()`**: `lgb.Dataset` を構築し、`lgb.train(params, train_set, valid_sets=[...], callbacks=[...], keep_training_booster=True)` で学習する。
+2. **`predict()`**: `booster.predict(X)` を使用。regression はそのまま返却。classification は `objective` に応じて sigmoid/softmax 適用済みの値が返る。
+3. **`predict_proba()`**: `booster.predict(X)` を使用。binary は `(n,)` → `(n, 2)` に変換。multiclass は `(n, k)` をそのまま返却。
+4. **`predict_raw()`**: `booster.predict(X, raw_score=True)` を使用（現状と同じロジック、`booster_` 経由のアクセスが不要になる）。
+5. **`importance()`**: `booster.feature_importance(importance_type=...)` を直接呼び出す。
+6. **`get_native_model()`**: 戻り値を `lgb.Booster` に変更する。
+7. **`best_iteration`**: `booster.best_iteration` から取得する。
+8. **パラメーター変換**: sklearn 固有のパラメーター名（`n_estimators` → `num_boost_round`、`random_state` → `seed`）を Booster API に適切にマッピングする。
+
+### Impact
+
+- `lizyml/estimators/lgbm.py`（主要変更: fit / predict / predict_proba / get_native_model / _build_params）
+- `lizyml/training/cv_trainer.py`（`evals_result_` → Booster API の `eval_results` への適応）
+- `lizyml/training/refit_trainer.py`（同上）
+- `lizyml/core/model.py`（`params_table()` の `.booster_` アクセスを `.get_native_model()` 直接に変更）
+- `lizyml/explain/shap_explainer.py`（SHAP TreeExplainer は Booster を直接受け取れるため変更不要、ただし確認は必要）
+- `lizyml/persistence/exporter.py`（joblib シリアライズ対象が Booster に変わるため確認）
+- `tests/test_estimators/` `tests/test_e2e/`（`get_native_model()` 戻り値型、`.booster_` アクセスの更新）
+
+### Compatibility
+
+- **公開 API（`get_native_model()`）**: 戻り値が `LGBMRegressor | LGBMClassifier` → `lgb.Booster` に変更される。これは内部型（sklearn wrapper vs Booster）の変更であり、LightGBM 固有の下流コードに影響する。
+- **`predict()` / `predict_proba()` / `predict_raw()` の shape 契約**: 変更なし。同一の入出力 shape を維持する。
+- **`importance()` の shape 契約**: 変更なし。
+- **Persistence**: joblib による `LGBMAdapter` のシリアライズ。`lgb.Booster` の `model_to_string()` / `model_from_string()` による保存・復元が必要。ただし `format_version=1` の互換性を維持するため、既存の保存済みモデル（sklearn wrapper ベース）のロードは引き続きサポートする必要がある。
+- **SHAP**: `TreeExplainer` は `lgb.Booster` を直接受け取れるため互換性あり。
+
+### Alternatives Considered
+
+1. **テスト時に retry を追加して間欠エラーを許容する**
+   - 不採用。根本原因が LightGBM の既知バグである以上、回避策を持つべき。ユーザー利用時にも影響する。
+2. **`model_to_string()` 出力を post-fit で検証し、空の場合に再学習する**
+   - 不採用。`LightGBMError` は `model_from_string()` 内部で raise されるため、post-fit 検証が間に合わない。
+3. **`keep_training_booster=True` を sklearn wrapper に渡す**
+   - 不採用。sklearn wrapper は `keep_training_booster` を外部パラメーターとして公開していない。
+4. **LightGBM バージョンを制約する**
+   - 不採用。4.3〜4.6 のすべてで再現するため、特定バージョンの除外では解決しない。
+
+### Acceptance Criteria
+
+- regression / binary / multiclass の全タスクで `lgb.train()` 経由の学習が動作する。
+- `predict()` / `predict_proba()` / `predict_raw()` の出力 shape が移行前と同一である。
+- `importance(kind="split")` / `importance(kind="gain")` が移行前と同一の結果を返す。
+- `get_native_model()` が `lgb.Booster` を返す。
+- `best_iteration` が正しく取得される。
+- early stopping が正常に動作する（inner valid あり / なしの両方）。
+- 学習履歴（`eval_history`）が cv_trainer / refit_trainer で正しく記録される。
+- SHAP（`TreeExplainer`）が Booster 直接入力で動作する。
+- 既存の persistence（export / load）が動作する。
+- 既存テスト（782件）が回帰しない。
+- notebook テスト（`tutorial_regression_tuning_lgbm.ipynb`）の間欠エラーが解消される。
+
+### Migration
+
+- `get_native_model()` の戻り値を `LGBMRegressor | LGBMClassifier` → `lgb.Booster` に変更。既存コードで `.booster_` 経由でアクセスしていた箇所は `.get_native_model()` 直接に変更する。
+- `format_version=1` の既存保存モデルのロード互換は維持する（移行期間中は旧形式を検出して復元可能にする）。

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,6 +35,7 @@ BLUEPRINT.md に基づき、Config駆動のML分析ライブラリ LizyML をゼ
 | 21 | LightGBM パラメーター強化 | LGBMConfig スマートパラメーター, デフォルトプロファイル, TuningResult + tuning_table(), デフォルト Tuning Space, Notebook 更新 | Phase 8, 9, 11, 12 |
 | 22 | 監査乖離の是正 + 追加開発 | load 後診断 API, Config デフォルト修正, tuning_plot, fit_result プロパティ, Notebook 全項目 Config, params_table, n_rows inner train 基準, ドキュメント整合 | Phase 20, 21 |
 | 23 | Calibration 強化・時系列拡張 | raw score Calibration, Beta Calibration, PurgedTimeSeries/GroupTimeSeries Config 接続, split_summary, 時系列 Notebook, Logging 統一 | Phase 22 |
+| 24 | LGBMAdapter Booster API 移行 | sklearn wrapper → `lgb.train()` 移行, predict/proba/raw shape 維持, get_native_model 戻り値変更, 学習履歴適応, persistence 互換 | Phase 23 |
 
 ---
 
@@ -1986,6 +1987,118 @@ Requirements Audit で検出された未実装項目（Beta Calibration、Purged
 - 23-I: `train_size_max` / `test_size_max` が 3 メソッドで有効に動作し、各 split 境界テストが pass する。
 - 23-J: `embargo` が正式キーとして動作し、`embargo_pct` は警告付き互換で同等動作、移行テストが pass する。
 - 既存の leakage 防止・split_summary・Notebook 実行テストに回帰がない。
+
+---
+
+## Phase 24: LGBMAdapter Booster API 移行
+
+**HISTORY:** H-0041
+**SKILL:** skills/add-estimator-adapter/SKILL.md
+**依存:** Phase 23
+
+### 背景
+
+LightGBM の sklearn wrapper（`LGBMRegressor` / `LGBMClassifier`）に、`early_stopping` callback 併用時に `model_to_string()` が空文字列を返す間欠バグが存在する（microsoft/LightGBM#7186）。Booster API（`lgb.train()`）では `keep_training_booster=True` によりこのバグを回避できる。
+
+### 24-A: LGBMAdapter.fit() を Booster API に移行
+
+1. `lizyml/estimators/lgbm.py`:
+   - `fit()`: `LGBMRegressor(**params).fit(...)` → `lgb.Dataset` 構築 + `lgb.train(params, train_set, valid_sets=..., callbacks=..., keep_training_booster=True)` に置換。
+   - `_model` の型を `LGBMRegressor | LGBMClassifier | None` → `lgb.Booster | None` に変更。
+   - `_build_params()`: sklearn 固有パラメーター名（`n_estimators`, `random_state`, `verbose`）を Booster API 名（`num_boost_round` は引数、`seed`、`verbosity`）に変換。`num_boost_round` はパラメーター dict から分離して `lgb.train()` の引数として渡す。
+   - `best_iteration`: `booster.best_iteration` から取得。
+   - `evals_result` dict をコールバック経由で収集（`lgb.record_evaluation(evals_result)` を使用）。
+2. テスト:
+   - regression / binary / multiclass の全タスクで `lgb.train()` 経由の学習が動作する。
+   - `best_iteration` が正しく取得される。
+   - early stopping が inner valid あり / なしの両方で動作する。
+
+### 24-B: predict / predict_proba / predict_raw の適応
+
+1. `lizyml/estimators/lgbm.py`:
+   - `predict()`: `booster.predict(X)` を使用。regression はそのまま返却。
+   - `predict_proba()`: `booster.predict(X)` を使用。binary は `(n,)` → `np.column_stack([1-p, p])` で `(n, 2)` に変換。multiclass は `(n, k)` をそのまま返却。
+   - `predict_raw()`: `booster.predict(X, raw_score=True)` を直接使用（`booster_` 経由のアクセスが不要になる）。
+   - `_require_fitted()` の戻り値型を `lgb.Booster` に変更。
+2. テスト:
+   - 全タスクで `predict()` / `predict_proba()` / `predict_raw()` の出力 shape が移行前と同一。
+   - binary `predict_proba()` が `(n, 2)` を返す。
+
+### 24-C: importance / get_native_model の適応
+
+1. `lizyml/estimators/lgbm.py`:
+   - `importance()`: `booster.feature_importance(importance_type=...)` を直接使用。
+   - `get_native_model()`: 戻り値型を `lgb.Booster` に変更。
+2. `lizyml/core/model.py`:
+   - `params_table()`: `.get_native_model().booster_` → `.get_native_model()` に変更（Booster を直接使用）。
+3. テスト:
+   - `importance(kind="split")` / `importance(kind="gain")` が動作する。
+   - `get_native_model()` が `lgb.Booster` インスタンスを返す。
+
+### 24-D: cv_trainer / refit_trainer の学習履歴適応
+
+1. `lizyml/training/cv_trainer.py`:
+   - `native.evals_result_` → `evals_result` dict（`LGBMAdapter` から取得する方法に変更）。
+   - `LGBMAdapter` に `eval_result` プロパティを追加し、`lgb.record_evaluation()` で収集した結果を返す。
+2. `lizyml/training/refit_trainer.py`:
+   - 同上。
+3. テスト:
+   - 学習曲線プロットが移行前と同様に動作する。
+
+### 24-E: SHAP / Persistence の確認と適応
+
+1. `lizyml/explain/shap_explainer.py`:
+   - `TreeExplainer` が `lgb.Booster` を直接受け取ることを確認。必要に応じて型ヒントを調整。
+2. `lizyml/persistence/exporter.py` / `loader.py`:
+   - `lgb.Booster` の joblib シリアライズが動作することを確認。
+   - `format_version=1` の既存保存モデルのロード互換を確認（旧形式の sklearn wrapper ベースのモデルも復元可能にする）。
+3. テスト:
+   - SHAP が Booster 直接入力で動作する。
+   - export / load のラウンドトリップが動作する。
+   - 既存の persistence テストに回帰がない。
+
+### 24-F: テスト更新と回帰確認
+
+1. `tests/test_estimators/test_estimators.py`:
+   - `get_native_model()` の戻り値型チェックを `lgb.Booster` に更新。
+   - `.booster_` 経由のアクセスを直接 Booster アクセスに更新。
+2. `tests/test_e2e/test_model_facade.py`:
+   - `params_table()` テストの `.booster_` アクセスを更新。
+3. 全テスト（782件）の pass を確認。
+4. notebook テスト（`tutorial_regression_tuning_lgbm.ipynb`）の間欠エラー解消を確認（複数回実行）。
+
+### DoD
+
+- 24-A: `lgb.train()` 経由で regression / binary / multiclass が学習でき、`best_iteration` / early stopping が動作する。
+- 24-B: `predict()` / `predict_proba()` / `predict_raw()` の出力 shape が移行前と同一であり、全タスクのテストが pass する。
+- 24-C: `importance()` / `get_native_model()` が Booster 直接で動作し、`params_table()` が回帰しない。
+- 24-D: `eval_result` による学習履歴収集が cv_trainer / refit_trainer で動作し、学習曲線プロットが回帰しない。
+- 24-E: SHAP / export / load が回帰しない。
+- 24-F: 全テスト（861件）が pass し、notebook テストの間欠エラーが解消される（notebook 5/5 pass 確認済み）。
+- 24-G: `_build_params()` が Booster 名称へ完全正規化し、対応ユニットテストが pass する。
+- 24-H: テスト件数が実測値で記録される。
+- 24-I: `H-0041` の Status が `accepted` に更新される。
+
+### Phase 24 残タスク（Requirements Audit 2026-03-07）
+
+**HISTORY:** H-0041
+**SKILL:** skills/add-estimator-adapter/SKILL.md, skills/testing/SKILL.md, skills/spec-update/SKILL.md
+
+1. **24-G: Booster パラメーター名正規化の補完**
+   - `lizyml/estimators/lgbm.py::_build_params()` で `params.random_state` / `params.verbose` を `seed` / `verbosity` に正規化する。
+   - `seed` / `verbosity` が同時指定された場合の優先順位を実装・テストで固定する。
+   - `_build_params()` 後に Booster 非推奨キー（`random_state`, `verbose`, `n_estimators`）が残らないことをテストで担保する。
+2. **24-H: 完了判定用テスト基準の更新**
+   - Phase 24 DoD の「全テスト（782件）」を現行件数に更新し、実測 pass 結果で固定する。
+   - `tests/test_notebooks/test_notebook_execution.py -k tuning` を複数回実行し、間欠エラー非再発を記録する。
+3. **24-I: 仕様記録の状態整合**
+   - Phase 24 DoD 達成後に `HISTORY.md` の `H-0041` を `proposed` から `accepted` に更新する。
+
+### Phase 24 残タスク DoD
+
+- 24-G: `_build_params()` が Booster 名称へ完全正規化し、対応ユニットテストが pass する。
+- 24-H: 現行テスト件数ベースのフルテストが pass し、tuning notebook 実行テストの複数回 pass を確認できる。
+- 24-I: `H-0041` の Status が `accepted` になり、PLAN/BLUEPRINT/HISTORY の記載が矛盾しない。
 
 ---
 

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -1342,7 +1342,7 @@ class Model:
             rows.append({"parameter": "validation_ratio", "value": es.validation_ratio})
 
         # --- Resolved booster params (fold 0) ---
-        booster = fr.models[0].get_native_model().booster_
+        booster = fr.models[0].get_native_model()
         for k in [
             "objective",
             "learning_rate",

--- a/lizyml/estimators/base.py
+++ b/lizyml/estimators/base.py
@@ -87,3 +87,12 @@ class BaseEstimatorAdapter(ABC):
     def best_iteration(self) -> int | None:
         """Best iteration from early stopping (``None`` if not applicable)."""
         return None
+
+    @property
+    def eval_results(self) -> dict[str, Any]:
+        """Evaluation results collected during training.
+
+        Returns an empty dict by default. Subclasses should override to
+        return the actual evaluation history.
+        """
+        return {}

--- a/lizyml/estimators/lgbm.py
+++ b/lizyml/estimators/lgbm.py
@@ -18,7 +18,6 @@ from lizyml.estimators.base import BaseEstimatorAdapter, ImportanceKind
 
 try:
     import lightgbm as lgb
-    from lightgbm import LGBMClassifier, LGBMRegressor
 except ImportError as e:  # pragma: no cover
     raise LizyMLError(
         code=ErrorCode.OPTIONAL_DEP_MISSING,
@@ -60,7 +59,10 @@ _COMMON_DEFAULTS: dict[str, Any] = {
 
 @EstimatorRegistry.register("lgbm")
 class LGBMAdapter(BaseEstimatorAdapter):
-    """LightGBM adapter supporting regression, binary, and multiclass tasks.
+    """LightGBM adapter using the Booster API (``lgb.train``).
+
+    Uses the native Booster API instead of the sklearn wrapper to avoid
+    an intermittent ``model_to_string()`` bug (microsoft/LightGBM#7186).
 
     Args:
         task: ML task type.
@@ -89,9 +91,10 @@ class LGBMAdapter(BaseEstimatorAdapter):
         self.verbose_eval = verbose_eval
         self.random_state = random_state
 
-        self._model: LGBMRegressor | LGBMClassifier | None = None
+        self._model: lgb.Booster | None = None
         self._best_iteration: int | None = None
         self._feature_names: list[str] = []
+        self._eval_results: dict[str, Any] = {}
 
     def update_params(self, params: dict[str, Any]) -> None:
         """Update params before fit(). Used for per-fold ratio resolution."""
@@ -110,7 +113,7 @@ class LGBMAdapter(BaseEstimatorAdapter):
         categorical_feature: list[str] | None = None,
         **kwargs: Any,
     ) -> LGBMAdapter:
-        """Fit the LightGBM model.
+        """Fit the LightGBM model via Booster API.
 
         Args:
             X_train: Training features.
@@ -118,21 +121,43 @@ class LGBMAdapter(BaseEstimatorAdapter):
             X_valid: Optional validation features for early stopping.
             y_valid: Optional validation target for early stopping.
             categorical_feature: List of categorical column names.
-            **kwargs: Forwarded to the underlying LightGBM estimator's ``fit``.
+            **kwargs: Additional keyword arguments. ``sample_weight`` is
+                extracted and passed to ``lgb.Dataset(weight=...)``.
         """
         self._feature_names = list(X_train.columns)
-        base_params = self._build_params()
-        base_params.update(self.params)
+        params, num_boost_round = self._build_params()
+
+        cat_feature: list[str] | Literal["auto"] = categorical_feature or "auto"
+        sample_weight = kwargs.pop("sample_weight", None)
+
+        train_set = lgb.Dataset(
+            X_train,
+            label=y_train,
+            weight=sample_weight,
+            categorical_feature=cat_feature,
+            free_raw_data=False,
+        )
 
         callbacks: list[Any] = []
+        valid_sets: list[lgb.Dataset] | None = None
+        valid_names: list[str] | None = None
+
         if self.verbose_eval == -1:
             callbacks.append(lgb.log_evaluation(period=-1))
         elif self.verbose_eval > 0:
             callbacks.append(lgb.log_evaluation(period=self.verbose_eval))
 
-        eval_set = None
         if X_valid is not None and y_valid is not None:
-            eval_set = [(X_valid, y_valid)]
+            valid_set = lgb.Dataset(
+                X_valid,
+                label=y_valid,
+                reference=train_set,
+                categorical_feature=cat_feature,
+                free_raw_data=False,
+            )
+            valid_sets = [valid_set]
+            valid_names = ["valid_0"]
+
             if self.early_stopping_rounds is not None:
                 callbacks.append(
                     lgb.early_stopping(
@@ -141,24 +166,21 @@ class LGBMAdapter(BaseEstimatorAdapter):
                     )
                 )
 
-        cat_feature = categorical_feature or "auto"
+        self._eval_results = {}
+        callbacks.append(lgb.record_evaluation(self._eval_results))
 
-        if self.task == "regression":
-            self._model = LGBMRegressor(**base_params)
-        else:
-            self._model = LGBMClassifier(**base_params)
-
-        self._model.fit(
-            X_train,
-            y_train,
-            eval_set=eval_set,  # type: ignore[arg-type]
-            categorical_feature=cat_feature,  # type: ignore[arg-type]
+        self._model = lgb.train(
+            params,
+            train_set,
+            num_boost_round=num_boost_round,
+            valid_sets=valid_sets,
+            valid_names=valid_names,
             callbacks=callbacks,
-            **kwargs,
+            keep_training_booster=True,
         )
 
-        if hasattr(self._model, "best_iteration_") and self._model.best_iteration_ > 0:
-            self._best_iteration = int(self._model.best_iteration_)
+        if self._model.best_iteration > 0:
+            self._best_iteration = self._model.best_iteration
 
         return self
 
@@ -167,10 +189,19 @@ class LGBMAdapter(BaseEstimatorAdapter):
     # ------------------------------------------------------------------
 
     def predict(self, X: pd.DataFrame) -> npt.NDArray[np.float64]:
-        """Return raw predictions."""
-        model = self._require_fitted()
-        result: npt.NDArray[np.float64] = model.predict(X)
-        return result
+        """Return predictions (regression values or class labels)."""
+        booster = self._require_fitted()
+        if self.task == "regression":
+            raw = booster.predict(X)
+            result: npt.NDArray[np.float64] = np.asarray(raw, dtype=np.float64)
+            return result
+        raw_proba = booster.predict(X)
+        proba: npt.NDArray[np.float64] = np.asarray(raw_proba, dtype=np.float64)
+        if self.task == "binary":
+            labels: npt.NDArray[np.float64] = (proba > 0.5).astype(np.float64)
+            return labels
+        labels_mc: npt.NDArray[np.float64] = np.argmax(proba, axis=1).astype(np.float64)
+        return labels_mc
 
     def predict_proba(self, X: pd.DataFrame) -> npt.NDArray[np.float64]:
         """Return class probabilities.
@@ -188,15 +219,14 @@ class LGBMAdapter(BaseEstimatorAdapter):
                 user_message="predict_proba is not available for regression tasks.",
                 context={"task": self.task},
             )
-        clf = self._require_fitted()
-        if not isinstance(clf, LGBMClassifier):
-            raise LizyMLError(  # pragma: no cover
-                code=ErrorCode.UNSUPPORTED_TASK,
-                user_message="predict_proba requires a classifier.",
-                context={"task": self.task},
-            )
-        result: npt.NDArray[np.float64] = clf.predict_proba(X)
-        return result
+        booster = self._require_fitted()
+        raw = booster.predict(X)
+        proba: npt.NDArray[np.float64] = np.asarray(raw, dtype=np.float64)
+        if self.task == "binary":
+            result: npt.NDArray[np.float64] = np.column_stack([1.0 - proba, proba])
+            return result
+        # multiclass: already (n, k)
+        return proba
 
     def predict_raw(self, X: pd.DataFrame) -> npt.NDArray[np.float64]:
         """Return raw scores (logits) before sigmoid/softmax.
@@ -206,10 +236,9 @@ class LGBMAdapter(BaseEstimatorAdapter):
         """
         if self.task == "regression":
             return self.predict(X)
-        model = self._require_fitted()
-        result: npt.NDArray[np.float64] = model.booster_.predict(  # type: ignore[assignment]
-            X, raw_score=True
-        )
+        booster = self._require_fitted()
+        raw = booster.predict(X, raw_score=True)
+        result: npt.NDArray[np.float64] = np.asarray(raw, dtype=np.float64)
         return result
 
     # ------------------------------------------------------------------
@@ -222,9 +251,9 @@ class LGBMAdapter(BaseEstimatorAdapter):
         Args:
             kind: ``"split"`` or ``"gain"``.
         """
-        model = self._require_fitted()
+        booster = self._require_fitted()
         importance_type = "split" if kind == "split" else "gain"
-        values = model.booster_.feature_importance(importance_type=importance_type)
+        values = booster.feature_importance(importance_type=importance_type)
         return {
             name: float(val)
             for name, val in zip(self._feature_names, values, strict=True)
@@ -234,7 +263,7 @@ class LGBMAdapter(BaseEstimatorAdapter):
     # Native model
     # ------------------------------------------------------------------
 
-    def get_native_model(self) -> LGBMRegressor | LGBMClassifier:
+    def get_native_model(self) -> lgb.Booster:
         return self._require_fitted()
 
     # ------------------------------------------------------------------
@@ -245,23 +274,71 @@ class LGBMAdapter(BaseEstimatorAdapter):
     def best_iteration(self) -> int | None:
         return self._best_iteration
 
+    @property
+    def eval_results(self) -> dict[str, Any]:
+        """Evaluation results collected during training via ``record_evaluation``.
+
+        Structure: ``{"valid_0": {"metric_name": [val_per_iter, ...]}}``.
+        Empty dict when no validation set was used.
+        """
+        return self._eval_results
+
+    # ------------------------------------------------------------------
+    # Serialization (backward compat with sklearn wrapper models)
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict[str, Any]:
+        return self.__dict__.copy()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        # Old format may lack _eval_results
+        if not hasattr(self, "_eval_results"):
+            object.__setattr__(self, "_eval_results", {})
+        # Migrate old sklearn wrapper (_model = LGBMRegressor/LGBMClassifier)
+        model = self._model
+        if model is not None and hasattr(model, "booster_"):
+            self._model = model.booster_
+            if hasattr(model, "best_iteration_") and model.best_iteration_ > 0:
+                self._best_iteration = int(model.best_iteration_)
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
 
-    def _build_params(self) -> dict[str, Any]:
+    def _build_params(self) -> tuple[dict[str, Any], int]:
+        """Build LightGBM params dict and num_boost_round.
+
+        Returns:
+            ``(params_dict, num_boost_round)`` tuple.
+            ``params_dict`` uses Booster API naming (``seed``, ``verbosity``).
+            ``num_boost_round`` is extracted from ``n_estimators``.
+        """
         params: dict[str, Any] = {
             "objective": _TASK_OBJECTIVE[self.task],
             "metric": _TASK_METRIC[self.task],
-            **_COMMON_DEFAULTS,
-            "random_state": self.random_state,
-            "verbose": -1,
+            **{k: v for k, v in _COMMON_DEFAULTS.items() if k != "n_estimators"},
+            "seed": self.random_state,
+            "verbosity": -1,
         }
         if self.task == "multiclass" and self.num_class is not None:
             params["num_class"] = self.num_class
-        return params
 
-    def _require_fitted(self) -> LGBMRegressor | LGBMClassifier:
+        # Extract num_boost_round from user params (n_estimators) or use default
+        user_params = dict(self.params)
+        num_boost_round = int(
+            user_params.pop("n_estimators", _COMMON_DEFAULTS["n_estimators"])
+        )
+        # Normalize sklearn param names → Booster API names
+        if "random_state" in user_params:
+            user_params.setdefault("seed", user_params.pop("random_state"))
+        if "verbose" in user_params:
+            user_params.setdefault("verbosity", user_params.pop("verbose"))
+        params.update(user_params)
+
+        return params, num_boost_round
+
+    def _require_fitted(self) -> lgb.Booster:
         if self._model is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,

--- a/lizyml/training/cv_trainer.py
+++ b/lizyml/training/cv_trainer.py
@@ -206,10 +206,7 @@ class CVTrainer:
             if_pred_per_fold.append(fold_train_pred)
 
             # --- Collect history ----------------------------------------------
-            native = estimator.get_native_model()
-            eval_hist: dict[str, Any] = {}
-            if hasattr(native, "evals_result_"):
-                eval_hist = dict(native.evals_result_)
+            eval_hist: dict[str, Any] = dict(estimator.eval_results)
             history.append(
                 {
                     "best_iteration": estimator.best_iteration,

--- a/lizyml/training/refit_trainer.py
+++ b/lizyml/training/refit_trainer.py
@@ -132,10 +132,7 @@ class RefitTrainer:
 
         train_pred = get_fold_pred(estimator, X_t, self.task)
 
-        native = estimator.get_native_model()
-        eval_hist: dict[str, Any] = {}
-        if hasattr(native, "evals_result_"):
-            eval_hist = dict(native.evals_result_)
+        eval_hist: dict[str, Any] = dict(estimator.eval_results)
 
         return RefitResult(
             model=estimator,

--- a/tests/test_e2e/test_model_facade.py
+++ b/tests/test_e2e/test_model_facade.py
@@ -403,7 +403,7 @@ class TestRatioParamsInnerTrainSize:
         # Expected: n_outer_train ≈ 200 (300 * 2/3), inner_train ≈ 160 (200 * 0.8)
         # min_data_in_leaf = ceil(160 * 0.1) = 16
         # NOT ceil(300 * 0.1) = 30
-        booster = m.fit_result.models[0].get_native_model().booster_
+        booster = m.fit_result.models[0].get_native_model()
         mdil = int(booster.params["min_data_in_leaf"])
 
         # Full dataset would give ceil(300 * 0.1) = 30

--- a/tests/test_estimators/test_estimators.py
+++ b/tests/test_estimators/test_estimators.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import lightgbm as lgb
 import numpy as np
 import pandas as pd
 import pytest
@@ -135,6 +136,7 @@ class TestLGBMRegression:
         adapter = LGBMAdapter(task="regression", random_state=0)
         adapter.fit(X, y)
         native = adapter.get_native_model()
+        assert isinstance(native, lgb.Booster)
         assert hasattr(native, "predict")
 
 

--- a/tests/test_estimators/test_lgbm_defaults.py
+++ b/tests/test_estimators/test_lgbm_defaults.py
@@ -7,67 +7,104 @@ from lizyml.estimators.lgbm import LGBMAdapter
 
 class TestTaskDefaults:
     def test_regression_objective_huber(self) -> None:
-        adapter = LGBMAdapter(task="regression")
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["objective"] == "huber"
 
     def test_regression_metric_list(self) -> None:
-        adapter = LGBMAdapter(task="regression")
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["metric"] == ["huber", "mae", "mape"]
 
     def test_binary_objective(self) -> None:
-        adapter = LGBMAdapter(task="binary")
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="binary")._build_params()
         assert params["objective"] == "binary"
 
     def test_binary_metric_list(self) -> None:
-        adapter = LGBMAdapter(task="binary")
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="binary")._build_params()
         assert params["metric"] == ["auc", "binary_logloss"]
 
     def test_multiclass_objective(self) -> None:
-        adapter = LGBMAdapter(task="multiclass", num_class=3)
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="multiclass", num_class=3)._build_params()
         assert params["objective"] == "multiclass"
 
     def test_multiclass_metric_list(self) -> None:
-        adapter = LGBMAdapter(task="multiclass", num_class=3)
-        params = adapter._build_params()
+        params, _ = LGBMAdapter(task="multiclass", num_class=3)._build_params()
         assert params["metric"] == ["auc_mu", "multi_logloss"]
 
 
 class TestCommonDefaults:
     def test_learning_rate(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["learning_rate"] == 0.001
 
     def test_max_depth(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["max_depth"] == 5
 
     def test_max_bin(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["max_bin"] == 511
 
-    def test_n_estimators(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
-        assert params["n_estimators"] == 1500
+    def test_num_boost_round(self) -> None:
+        _, num_boost_round = LGBMAdapter(task="regression")._build_params()
+        assert num_boost_round == 1500
 
     def test_feature_fraction(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["feature_fraction"] == 0.7
 
     def test_bagging_fraction(self) -> None:
-        params = LGBMAdapter(task="regression")._build_params()
+        params, _ = LGBMAdapter(task="regression")._build_params()
         assert params["bagging_fraction"] == 0.7
+
+    def test_seed_from_random_state(self) -> None:
+        params, _ = LGBMAdapter(task="regression", random_state=99)._build_params()
+        assert params["seed"] == 99
+        assert "random_state" not in params
+
+    def test_verbosity(self) -> None:
+        params, _ = LGBMAdapter(task="regression")._build_params()
+        assert params["verbosity"] == -1
+        assert "verbose" not in params
 
 
 class TestUserOverride:
     def test_params_override_defaults(self) -> None:
         adapter = LGBMAdapter(task="regression", params={"learning_rate": 0.1})
-        adapter._feature_names = ["a"]
-        built = adapter._build_params()
-        built.update(adapter.params)
-        assert built["learning_rate"] == 0.1
-        assert built["max_depth"] == 5  # non-overridden default remains
+        params, _ = adapter._build_params()
+        assert params["learning_rate"] == 0.1
+        assert params["max_depth"] == 5  # non-overridden default remains
+
+    def test_n_estimators_override(self) -> None:
+        adapter = LGBMAdapter(task="regression", params={"n_estimators": 500})
+        params, num_boost_round = adapter._build_params()
+        assert num_boost_round == 500
+        assert "n_estimators" not in params
+
+    def test_random_state_in_user_params_normalized(self) -> None:
+        params, _ = LGBMAdapter(
+            task="regression", params={"random_state": 77}
+        )._build_params()
+        assert params["seed"] == 77
+        assert "random_state" not in params
+
+    def test_verbose_in_user_params_normalized(self) -> None:
+        params, _ = LGBMAdapter(
+            task="regression", params={"verbose": 1}
+        )._build_params()
+        assert params["verbosity"] == 1
+        assert "verbose" not in params
+
+    def test_seed_takes_priority_over_random_state(self) -> None:
+        params, _ = LGBMAdapter(
+            task="regression", params={"random_state": 77, "seed": 88}
+        )._build_params()
+        assert params["seed"] == 88
+        assert "random_state" not in params
+
+    def test_no_deprecated_keys_in_output(self) -> None:
+        params, _ = LGBMAdapter(
+            task="regression",
+            params={"n_estimators": 500, "random_state": 1, "verbose": 0},
+        )._build_params()
+        for key in ("n_estimators", "random_state", "verbose"):
+            assert key not in params


### PR DESCRIPTION
## Summary

Merge develop into main. Includes Phase 24: migration of LGBMAdapter from sklearn wrapper to native Booster API.

### Included changes

- **Phase 24 (PR #8):** Replace `LGBMRegressor`/`LGBMClassifier` with `lgb.train()` + `keep_training_booster=True` to fix intermittent `model_to_string()` bug
  - `_build_params()` returns `(params, num_boost_round)` with sklearn name normalization
  - Binary `predict_proba()`: `(n,)` → `(n, 2)` conversion
  - Eval history via `lgb.record_evaluation()` callback
  - Backward compat `__setstate__` for old sklearn wrapper models
  - BLUEPRINT §14.2.1, HISTORY H-0041 (accepted), PLAN Phase 24

## Test plan

- [x] All 861 tests pass
- [x] Notebooks 5/5 pass
- [x] Quality gate (ruff / mypy / pytest) clear