### PR TITLE
docs: add LICENSE, CHANGELOG, and PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check distribution
+        run: |
+          uv sync --frozen --dev
+          uv run twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] - 2026-03-07
+
+### Added
+
+- Config-driven ML pipeline for regression, binary, and multiclass classification
+- LightGBM estimator adapter using native Booster API
+- Cross-validation training with OOF/IF predictions
+- Inner validation (early stopping) support
+- Feature pipeline with leakage prevention
+- Splitters: KFold, StratifiedKFold, GroupKFold, TimeSeriesSplit, Holdout
+- Calibration: Platt, Isotonic, Beta (cross-fit, OOF-only)
+- Evaluation with pre-computed metrics (raw + calibrated)
+- SHAP explanations (optional dependency)
+- Optuna-based tuning with unified search space (optional dependency)
+- Plotly-based visualizations: learning curve, importance, OOF distribution, residuals (optional dependency)
+- Export/load with format_version=1 and metadata
+- Simulate (bootstrap prediction distributions)
+- YAML/JSON config loading with pydantic validation

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 LizyML Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Add files required for PyPI publishing via GitHub Actions + Trusted Publishers.

- `LICENSE`: MIT license
- `CHANGELOG.md`: initial v0.1.0 entry
- `.github/workflows/release.yml`: tag-triggered workflow (`v*`)
  - Builds sdist + wheel with `uv build`
  - Publishes to TestPyPI first, then PyPI (sequential)
  - Uses OIDC Trusted Publishers (no API tokens needed)

## Setup required

1. Register Trusted Publisher on TestPyPI/PyPI (project: `lizyml`, workflow: `release.yml`)
2. Create `testpypi` and `pypi` environments in GitHub repo settings

## Test plan

- [x] `uv build` produces valid sdist + wheel
- [x] `twine check dist/*` passes
- [ ] Tag push triggers workflow and publishes to TestPyPI
- [ ] `pip install -i https://test.pypi.org/simple/ lizyml` installs successfully