### PR TITLE
Release: adopt hatch-vcs for automated versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ __pycache__/
 *.so
 
 # =========================
-# Distributions & Packaging
+# Distributions & Packaging (hatch-vcs auto-generated)
 # =========================
+lizyml/_version.py
 build/
 develop-eggs/
 dist/

--- a/lizyml/__init__.py
+++ b/lizyml/__init__.py
@@ -1,7 +1,6 @@
 """LizyML: config-driven ML analysis library."""
 
-__version__ = "0.1.0"
-
+from lizyml._version import __version__, __version_tuple__
 from lizyml.core.model import Model
 
-__all__ = ["Model", "__version__"]
+__all__ = ["Model", "__version__", "__version_tuple__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lizyml"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Config-driven ML analysis library for regression and classification"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -53,6 +53,12 @@ dev = [
     "nbconvert>=7.0",
     "ipykernel>=6.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "lizyml/_version.py"
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,6 @@ wheels = [
 
 [[package]]
 name = "lizyml"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },
@@ -1103,7 +1102,7 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'calibration'", specifier = ">=1.10" },
     { name = "shap", marker = "extra == 'explain'", specifier = ">=0.44" },
 ]
-provides-extras = ["tuning", "explain", "plots", "calibration"]
+provides-extras = ["calibration", "explain", "plots", "tuning"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Merge develop into main. Includes hatch-vcs adoption for git-tag-based versioning.

### Included changes

- **PR #12:** Replace static `version = "0.1.0"` with hatch-vcs (dynamic version from git tags)

## Next steps

Future releases only require `git tag vX.Y.Z && git push origin vX.Y.Z`.