### PR TITLE
fix: update package author to nbx-liz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Config-driven ML analysis library for regression and classificati
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
-authors = [{ name = "LizyML Authors" }]
+authors = [{ name = "nbx" }]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary

Update `authors` in pyproject.toml from `LizyML Authors` to `nbx-liz`.

This will be reflected on PyPI with the next release tag.