### PR TITLE
fix(core): comprehensive code review fixes — data correctness, safety, and hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/lizyml/calibration/cross_fit.py
+++ b/lizyml/calibration/cross_fit.py
@@ -60,7 +60,8 @@ def cross_fit_calibrate(
     only performs the cross-fit loop over the provided indices.
 
     Args:
-        oof_scores: 1-D base-model OOF probabilities (n_samples,).
+        oof_scores: 1-D base-model OOF scores (n_samples,).
+            Accepts probabilities or raw scores (logits).
         y: 1-D binary ground-truth labels (n_samples,).
         calibrator_factory: Callable returning a fresh calibrator instance.
         split_indices: Pre-computed ``(train_idx, valid_idx)`` pairs.
@@ -70,7 +71,7 @@ def cross_fit_calibrate(
     Returns:
         :class:`CalibrationResult` with ``c_final`` and ``calibrated_oof``.
     """
-    calibrated_oof = np.empty_like(oof_scores, dtype=float)
+    calibrated_oof = np.full_like(oof_scores, np.nan, dtype=np.float64)
 
     for train_idx, val_idx in split_indices:
         cal = calibrator_factory()
@@ -84,6 +85,6 @@ def cross_fit_calibrate(
     return CalibrationResult(
         c_final=c_final,
         calibrated_oof=calibrated_oof,
-        method=calibrator_factory().name,
+        method=c_final.name,
         split_indices=split_indices,
     )

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -221,6 +221,12 @@ class ModelTablesMixin:
             ``MODEL_NOT_FIT`` when called before ``fit``.
         """
         fr = self._require_fit()
+        if not fr.models:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message="No trained models available.",
+                context={},
+            )
         model_cfg = self._cfg.model
 
         rows: list[dict[str, Any]] = []

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -25,9 +25,10 @@ Mixin decomposition (H-0042):
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Any, Literal
@@ -299,15 +300,23 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 calibrator_factory=lambda: get_calibrator(method, params=cal_params),
                 split_indices=cal_split_indices,
             )
-            fit_result.calibrator = calibration_result
-            # Store calibration split indices for reproducibility / audit
-            fit_result.splits.calibration = calibration_result.split_indices
+            new_splits = dataclasses.replace(
+                fit_result.splits,
+                calibration=calibration_result.split_indices,
+            )
+            fit_result = dataclasses.replace(
+                fit_result,
+                calibrator=calibration_result,
+                splits=new_splits,
+            )
 
         # --- Evaluation -------------------------------------------------------
         metric_names = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
         evaluator = Evaluator(task=cfg.task)
         metrics = evaluator.evaluate(fit_result, y, metric_names)
-        fit_result.metrics.update(metrics)
+        fit_result = dataclasses.replace(
+            fit_result, metrics={**fit_result.metrics, **metrics}
+        )
         self._metrics = metrics
 
         # --- Full-data refit (for predict) -----------------------------------
@@ -344,8 +353,14 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         """
         self._require_fit()
 
+        if self._metrics is None:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message="Metrics not computed. Call fit() first.",
+                context={},
+            )
+
         if metrics is None:
-            assert self._metrics is not None  # noqa: S101 — set by fit()
             return self._metrics
 
         # Validate task compatibility first (raises UNSUPPORTED_METRIC if invalid)
@@ -354,7 +369,6 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         get_metrics_for_task(metrics, self._cfg.task)  # raises on unknown/incompatible
 
         # Filter the pre-computed metrics dict to the requested subset
-        assert self._metrics is not None  # noqa: S101
         return _filter_metrics(self._metrics, set(metrics))
 
     def predict(
@@ -625,12 +639,18 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             y = y.iloc[sort_order].reset_index(drop=True)
             if groups is not None:
                 groups = groups[sort_order]
-            components.X = X
-            components.y = y
-            components.time_col = tc.iloc[sort_order].reset_index(drop=True)
-            if components.group_col is not None:
-                gc = components.group_col
-                components.group_col = gc.iloc[sort_order].reset_index(drop=True)
+            sorted_time = tc.iloc[sort_order].reset_index(drop=True)
+            sorted_group = (
+                components.group_col.iloc[sort_order].reset_index(drop=True)
+                if components.group_col is not None
+                else None
+            )
+            components = DataFrameComponents(
+                X=X,
+                y=y,
+                time_col=sorted_time,
+                group_col=sorted_group,
+            )
 
         self._X = X
         self._y = y
@@ -655,7 +675,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             config_normalized=self._cfg.model_dump(),
             config_version=self._cfg.config_version,
             run_id=run_id,
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
         )
 
     def _require_fit(self) -> FitResult:
@@ -708,5 +728,13 @@ def _filter_metrics(metrics_dict: dict[str, Any], keep: set[str]) -> dict[str, A
                 filtered_top[sub_key] = {m: v for m, v in sub_val.items() if m in keep}
             else:
                 filtered_top[sub_key] = sub_val
-        result[top_key] = filtered_top
+        # Drop branches where all sub-dicts are empty after filtering
+        has_content = any(
+            (isinstance(v, dict) and len(v) > 0)
+            or (isinstance(v, list) and any(d for d in v if isinstance(d, dict)))
+            or (not isinstance(v, (dict, list)))
+            for v in filtered_top.values()
+        )
+        if has_content:
+            result[top_key] = filtered_top
     return result

--- a/lizyml/core/types/predict_result.py
+++ b/lizyml/core/types/predict_result.py
@@ -14,8 +14,9 @@ class PredictionResult:
 
     Attributes:
         pred: Point predictions, shape ``(n_samples,)``.
-        proba: Class probabilities for binary classification, shape ``(n_samples,)``.
-            ``None`` for regression and multiclass.
+        proba: Class probabilities.  Shape ``(n_samples,)`` for binary
+            classification, ``(n_samples, n_classes)`` for multiclass.
+            ``None`` for regression.
         shap_values: SHAP explanation values, shape ``(n_samples, n_features)``.
             ``None`` when ``return_shap=False`` (default).
         used_features: Names of features that were present and used for prediction.

--- a/lizyml/core/types/tuning_result.py
+++ b/lizyml/core/types/tuning_result.py
@@ -16,6 +16,10 @@ class TrialResult:
     score: float
     state: str  # "complete" | "pruned" | "fail"
 
+    def __post_init__(self) -> None:
+        # Deep-copy mutable fields to prevent external mutation
+        object.__setattr__(self, "params", dict(self.params))
+
 
 @dataclass(frozen=True)
 class TuningResult:
@@ -26,6 +30,11 @@ class TuningResult:
     trials: list[TrialResult]
     metric_name: str
     direction: str  # "minimize" | "maximize"
+
+    def __post_init__(self) -> None:
+        # Deep-copy mutable fields to prevent external mutation
+        object.__setattr__(self, "best_params", dict(self.best_params))
+        object.__setattr__(self, "trials", list(self.trials))
 
 
 @dataclass(frozen=True)

--- a/lizyml/estimators/lgbm.py
+++ b/lizyml/estimators/lgbm.py
@@ -98,7 +98,7 @@ class LGBMAdapter(BaseEstimatorAdapter):
 
     def update_params(self, params: dict[str, Any]) -> None:
         """Update params before fit(). Used for per-fold ratio resolution."""
-        self.params.update(params)
+        self.params = {**self.params, **params}
 
     # ------------------------------------------------------------------
     # Fit
@@ -334,6 +334,9 @@ class LGBMAdapter(BaseEstimatorAdapter):
             user_params.setdefault("seed", user_params.pop("random_state"))
         if "verbose" in user_params:
             user_params.setdefault("verbosity", user_params.pop("verbose"))
+        # Strip task-locked keys — objective/metric are always set from task
+        user_params.pop("objective", None)
+        user_params.pop("metric", None)
         params.update(user_params)
 
         return params, num_boost_round

--- a/lizyml/explain/shap_explainer.py
+++ b/lizyml/explain/shap_explainer.py
@@ -125,6 +125,11 @@ def compute_shap_importance(
             context={"package": "shap"},
         )
 
+    n_features = len(feature_names)
+    n_folds = len(models)
+    if n_folds == 0:
+        return {name: 0.0 for name in feature_names}
+
     from lizyml.features.pipelines_native import NativeFeaturePipeline
 
     # Reconstruct pipeline and transform X
@@ -132,9 +137,7 @@ def compute_shap_importance(
     pipeline.load_state(pipeline_state)
     X_t, _ = pipeline.transform_with_warnings(X)
 
-    n_features = len(feature_names)
     agg = np.zeros(n_features)
-    n_folds = len(models)
 
     for fold_idx, model in enumerate(models):
         _, valid_idx = splits_outer[fold_idx]

--- a/lizyml/metrics/classification.py
+++ b/lizyml/metrics/classification.py
@@ -263,7 +263,8 @@ class ECE(BaseMetric):
         n = len(y_true)
         ece = 0.0
         for lo, hi in zip(bin_edges[:-1], bin_edges[1:], strict=True):
-            mask = (y_pred >= lo) & (y_pred < hi)
+            # Last bin is right-inclusive to capture y_pred == 1.0
+            mask = (y_pred >= lo) & (y_pred <= hi if hi == 1.0 else y_pred < hi)
             if not mask.any():
                 continue
             acc = float(np.mean((y_pred[mask] >= 0.5).astype(int) == y_true[mask]))

--- a/lizyml/metrics/regression.py
+++ b/lizyml/metrics/regression.py
@@ -118,6 +118,12 @@ class RMSLE(BaseMetric):
 
     def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
         _validate_shapes(y_true, y_pred, self.name)
+        if np.any(y_true < 0) or np.any(y_pred < 0):
+            raise LizyMLError(
+                code=ErrorCode.UNSUPPORTED_METRIC,
+                user_message="RMSLE requires non-negative predictions and targets.",
+                context={"metric": self.name},
+            )
         return float(np.sqrt(np.mean((np.log1p(y_true) - np.log1p(y_pred)) ** 2)))
 
 

--- a/lizyml/plots/residuals.py
+++ b/lizyml/plots/residuals.py
@@ -31,6 +31,14 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
+_scipy_stats: Any = None
+try:
+    from scipy import stats as _scipy_stats_mod
+
+    _scipy_stats = _scipy_stats_mod
+except ImportError:  # pragma: no cover
+    pass
+
 _VALID_KINDS = ("scatter", "histogram", "qq", "all")
 
 
@@ -202,7 +210,14 @@ def _add_qq_traces(
     row: int | None = None,
     col: int | None = None,
 ) -> None:
-    from scipy import stats  # noqa: I001
+    if _scipy_stats is None:
+        raise LizyMLError(
+            code=ErrorCode.OPTIONAL_DEP_MISSING,
+            user_message=(
+                "scipy is required for QQ plots. Install with: pip install scipy"
+            ),
+            context={"package": "scipy"},
+        )
 
     kw: dict[str, Any] = {}
     if row is not None:
@@ -210,7 +225,7 @@ def _add_qq_traces(
         kw["col"] = col
     ax_kw: dict[str, Any] = {"row": row, "col": col} if row is not None else {}
 
-    (osm, osr), _ = stats.probplot(oos_resid, dist="norm")
+    (osm, osr), _ = _scipy_stats.probplot(oos_resid, dist="norm")
     fig.add_trace(
         _plotly.Scatter(
             x=osm,

--- a/lizyml/splitters/group_time_series.py
+++ b/lizyml/splitters/group_time_series.py
@@ -69,7 +69,11 @@ class GroupTimeSeriesSplitter(BaseSplitter):
         for k in range(self.n_splits):
             train_group_end = (k + 1) * group_fold_size
             valid_group_start = train_group_end + self.gap
-            valid_group_end = valid_group_start + group_fold_size
+            # Last fold extends to include all trailing groups
+            if k == self.n_splits - 1:
+                valid_group_end = n_groups
+            else:
+                valid_group_end = valid_group_start + group_fold_size
             if valid_group_end > n_groups:
                 valid_group_end = n_groups
             if valid_group_start >= valid_group_end:

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -98,7 +98,7 @@ class HoldoutInnerValid(BaseInnerValidStrategy):
                 np.sort(valid_rel.astype(np.intp)),
             )
         rng = np.random.default_rng(self.random_state)
-        n_valid = max(1, int(n_samples * self.ratio))
+        n_valid = max(1, int(np.ceil(n_samples * self.ratio)))
         perm = rng.permutation(n_samples)
         valid_idx = np.sort(perm[:n_valid])
         train_idx = np.sort(perm[n_valid:])

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -6,7 +6,7 @@ import sys
 import time
 import warnings
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy.typing as npt
@@ -157,7 +157,7 @@ class Tuner:
             config_normalized={},
             config_version=1,
             run_id=generate_run_id(),
-            timestamp=datetime.now().isoformat(),
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
         )
 
         def objective(trial: Any) -> float:
@@ -269,14 +269,27 @@ class Tuner:
 
             optuna_callbacks.append(_progress_cb)
 
+        # Add trial failure logging callback
+        def _log_trial_failure(study_: Any, trial: Any) -> None:
+            if trial.state != _optuna.trial.TrialState.COMPLETE:
+                reason = trial.system_attrs.get("fail_reason", "unknown")
+                _log.warning(
+                    "event='trial.failed' trial=%d state=%s reason=%s",
+                    trial.number,
+                    trial.state.name,
+                    reason,
+                )
+
+        all_callbacks = [*optuna_callbacks, _log_trial_failure]
+
         try:
             study.optimize(
                 objective,
                 n_trials=self.n_trials,
                 timeout=self.timeout,
                 show_progress_bar=False,
-                catch=(Exception,),
-                callbacks=optuna_callbacks if optuna_callbacks else None,
+                catch=(LizyMLError, ValueError, RuntimeError),
+                callbacks=all_callbacks,
             )
         except Exception as exc:
             raise LizyMLError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,13 @@ ignore_missing_imports = true
 module = "scipy.*"
 ignore_missing_imports = true
 
+[tool.coverage.run]
+source = ["lizyml"]
+omit = ["lizyml/_version.py"]
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = ["slow: marks tests as slow (notebook execution)"]

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -1,0 +1,497 @@
+"""Tests for code review fixes — Phase 1 through Phase 3.
+
+TDD RED: All tests written before implementation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from lizyml.calibration.cross_fit import cross_fit_calibrate
+from lizyml.calibration.platt import PlattCalibrator
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.tuning_result import TrialResult, TuningResult
+from lizyml.metrics.classification import ECE, LogLoss
+from lizyml.metrics.regression import RMSLE
+from lizyml.splitters import GroupTimeSeriesSplitter
+from lizyml.splitters.kfold import KFoldSplitter
+
+
+def _kfold_indices(
+    n: int, n_splits: int = 5, seed: int = 42
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    splitter = KFoldSplitter(n_splits=n_splits, shuffle=True, random_state=seed)
+    return list(splitter.split(n))
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: CRITICAL — LogLoss multiclass 2D support
+# ---------------------------------------------------------------------------
+
+
+class TestLogLossMulticlass:
+    """LogLoss must handle 2D y_pred for multiclass (like AUC, Brier, AUCPR)."""
+
+    def test_2d_returns_float(self) -> None:
+        """LogLoss with 2D y_pred (n_samples, n_classes) should return a float."""
+        rng = np.random.default_rng(42)
+        y_true = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2, 0])
+        y_pred = rng.dirichlet([1, 1, 1], size=10)
+        metric = LogLoss()
+        result = metric(y_true, y_pred)
+        assert isinstance(result, float)
+        assert result > 0.0
+
+    def test_2d_good_predictions_lower_loss(self) -> None:
+        """Better predictions should give lower log loss."""
+        n = 100
+        y_true = np.array([0] * 40 + [1] * 30 + [2] * 30)
+        rng = np.random.default_rng(42)
+        # Good predictions: high prob for correct class
+        y_good = rng.dirichlet([0.3, 0.3, 0.3], size=n)
+        for i in range(n):
+            y_good[i, y_true[i]] += 2.0
+        y_good = y_good / y_good.sum(axis=1, keepdims=True)
+        # Bad predictions: random
+        y_bad = rng.dirichlet([1, 1, 1], size=n)
+
+        metric = LogLoss()
+        loss_good = metric(y_true, y_good)
+        loss_bad = metric(y_true, y_bad)
+        assert loss_good < loss_bad
+
+    def test_2d_shape_mismatch_raises(self) -> None:
+        """2D y_pred with wrong n_samples should raise LizyMLError."""
+        y_true = np.array([0, 1, 2])
+        y_pred = np.random.default_rng(0).dirichlet([1, 1, 1], size=5)  # 5 != 3
+        metric = LogLoss()
+        with pytest.raises(LizyMLError):
+            metric(y_true, y_pred)
+
+    def test_1d_binary_unchanged(self) -> None:
+        """1D binary case should still work exactly as before."""
+        y_true = np.array([0, 0, 1, 1, 1])
+        y_pred = np.array([0.1, 0.2, 0.8, 0.9, 0.7])
+        metric = LogLoss()
+        result = metric(y_true, y_pred)
+        assert isinstance(result, float)
+        assert result > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: cross_fit NaN initialization
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFitNaNInit:
+    """cross_fit_calibrate must use NaN-initialized array, not np.empty."""
+
+    def test_unfilled_indices_are_nan(self) -> None:
+        """If split_indices don't cover all rows, unfilled positions must be NaN."""
+        n = 100
+        rng = np.random.default_rng(0)
+        y = rng.integers(0, 2, n).astype(float)
+        scores = y + rng.normal(0, 0.3, n)
+        scores = np.clip(scores, 0.01, 0.99)
+
+        # Create split indices that deliberately skip index 0
+        full_indices = _kfold_indices(n, n_splits=3)
+        partial_indices = []
+        for train_idx, val_idx in full_indices:
+            # Remove index 0 from val_idx
+            val_idx = val_idx[val_idx != 0]
+            partial_indices.append((train_idx, val_idx))
+
+        result = cross_fit_calibrate(
+            oof_scores=scores,
+            y=y,
+            calibrator_factory=PlattCalibrator,
+            split_indices=partial_indices,
+        )
+        # Index 0 was never filled — must be NaN, not garbage
+        assert np.isnan(result.calibrated_oof[0]), (
+            "Unfilled index should be NaN, not uninitialized memory"
+        )
+
+    def test_method_uses_c_final_name(self) -> None:
+        """method field should use c_final.name, not create extra instance."""
+        n = 100
+        rng = np.random.default_rng(0)
+        y = rng.integers(0, 2, n).astype(float)
+        scores = np.clip(y + rng.normal(0, 0.3, n), 0.01, 0.99)
+        result = cross_fit_calibrate(
+            oof_scores=scores,
+            y=y,
+            calibrator_factory=PlattCalibrator,
+            split_indices=_kfold_indices(n, n_splits=3),
+        )
+        assert result.method == "platt"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: GroupTimeSeriesSplitter trailing group fix
+# ---------------------------------------------------------------------------
+
+
+class TestGroupTimeSeriesTrailingGroups:
+    """GroupTimeSeriesSplitter must not silently drop trailing groups."""
+
+    def test_all_groups_covered_non_round(self) -> None:
+        """With n_groups=11, n_splits=3, all 11 groups must appear in some fold."""
+        n_groups = 11
+        samples_per_group = 5
+        groups = np.repeat(np.arange(n_groups), samples_per_group)
+        n_samples = len(groups)
+
+        splitter = GroupTimeSeriesSplitter(n_splits=3)
+        folds = list(splitter.split(n_samples, groups=groups))
+
+        # Collect all groups that appear in any validation fold
+        all_valid_groups = set()
+        all_train_groups = set()
+        for train_idx, valid_idx in folds:
+            all_valid_groups.update(groups[valid_idx].tolist())
+            all_train_groups.update(groups[train_idx].tolist())
+
+        all_covered = all_valid_groups | all_train_groups
+        expected = set(range(n_groups))
+        assert all_covered == expected, (
+            f"Groups {expected - all_covered} were dropped from all folds"
+        )
+
+    def test_last_fold_extends_to_end(self) -> None:
+        """The last fold's validation set should extend to include trailing groups."""
+        n_groups = 7
+        samples_per_group = 3
+        groups = np.repeat(np.arange(n_groups), samples_per_group)
+        n_samples = len(groups)
+
+        splitter = GroupTimeSeriesSplitter(n_splits=3)
+        folds = list(splitter.split(n_samples, groups=groups))
+
+        # The last fold's valid groups should include the final group
+        _, last_valid_idx = folds[-1]
+        last_valid_groups = set(groups[last_valid_idx].tolist())
+        assert n_groups - 1 in last_valid_groups, (
+            f"Last group {n_groups - 1} not in last fold's validation set"
+        )
+
+    def test_no_leakage_between_folds(self) -> None:
+        """Train and valid groups must be disjoint in each fold."""
+        groups = np.repeat(np.arange(10), 4)
+        splitter = GroupTimeSeriesSplitter(n_splits=3)
+        for train_idx, valid_idx in splitter.split(len(groups), groups=groups):
+            train_groups = set(groups[train_idx])
+            valid_groups = set(groups[valid_idx])
+            assert len(train_groups & valid_groups) == 0
+
+    def test_gap_respected_with_trailing(self) -> None:
+        """Even with trailing group fix, gap must be respected."""
+        groups = np.repeat(np.arange(10), 3)
+        splitter = GroupTimeSeriesSplitter(n_splits=2, gap=1)
+        for train_idx, valid_idx in splitter.split(len(groups), groups=groups):
+            train_groups = set(groups[train_idx])
+            valid_groups = set(groups[valid_idx])
+            # Gap means no overlap and a gap between max(train) and min(valid)
+            if len(train_groups) > 0 and len(valid_groups) > 0:
+                assert max(train_groups) + 1 < min(valid_groups), (
+                    "Gap not respected between train and valid groups"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: ECE boundary — y_pred == 1.0 inclusion
+# ---------------------------------------------------------------------------
+
+
+class TestECEBoundary:
+    """ECE must include y_pred == 1.0 in the last bin."""
+
+    def test_single_pred_one_wrong_class(self) -> None:
+        """y_pred=1.0 with y_true=0 → ECE should be 1.0, not 0.0.
+
+        Bug: if y_pred==1.0 falls outside all bins, ECE is 0.0 (vacuous).
+        """
+        y_true = np.array([0])
+        y_pred = np.array([1.0])
+        metric = ECE(n_bins=10)
+        result = metric(y_true, y_pred)
+        # Prediction is 1.0, label is 0 → max miscalibration → ECE = 1.0
+        assert result == pytest.approx(1.0, abs=1e-10)
+
+    def test_all_ones_correct_class(self) -> None:
+        """y_pred=1.0 with y_true=1 → perfectly calibrated → ECE ≈ 0."""
+        y_true = np.array([1, 1, 1])
+        y_pred = np.array([1.0, 1.0, 1.0])
+        metric = ECE(n_bins=10)
+        result = metric(y_true, y_pred)
+        assert result == pytest.approx(0.0, abs=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: RMSLE negative prediction guard
+# ---------------------------------------------------------------------------
+
+
+class TestRMSLENegativeGuard:
+    """RMSLE must raise LizyMLError for negative predictions/targets."""
+
+    def test_negative_pred_raises(self) -> None:
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([1.0, -0.5, 3.0])
+        metric = RMSLE()
+        with pytest.raises(LizyMLError) as exc_info:
+            metric(y_true, y_pred)
+        assert exc_info.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+    def test_negative_true_raises(self) -> None:
+        y_true = np.array([1.0, -1.0, 3.0])
+        y_pred = np.array([1.0, 2.0, 3.0])
+        metric = RMSLE()
+        with pytest.raises(LizyMLError) as exc_info:
+            metric(y_true, y_pred)
+        assert exc_info.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+    def test_nonneg_values_pass(self) -> None:
+        y_true = np.array([0.0, 1.0, 2.0])
+        y_pred = np.array([0.1, 1.1, 1.9])
+        metric = RMSLE()
+        result = metric(y_true, y_pred)
+        assert isinstance(result, float)
+        assert result >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: scipy optional dependency guard
+# ---------------------------------------------------------------------------
+
+
+class TestScipyOptionalDepGuard:
+    """QQ plots must raise LizyMLError when scipy is not installed."""
+
+    def test_scipy_missing_raises_lizyml_error(self) -> None:
+        """scipy missing must raise OPTIONAL_DEP_MISSING for QQ plots."""
+        pytest.importorskip("plotly")
+        with patch("lizyml.plots.residuals._scipy_stats", None):
+            from lizyml.plots.residuals import _add_qq_traces
+
+            with pytest.raises(LizyMLError) as exc_info:
+                _add_qq_traces(None, np.array([1.0, 2.0, 3.0]))
+            assert exc_info.value.code == ErrorCode.OPTIONAL_DEP_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: SHAP empty models guard
+# ---------------------------------------------------------------------------
+
+
+class TestShapEmptyModels:
+    """compute_shap_importance must handle empty models list gracefully."""
+
+    def test_empty_models_no_crash(self) -> None:
+        pytest.importorskip("shap")
+        from lizyml.explain.shap_explainer import compute_shap_importance
+
+        result = compute_shap_importance(
+            models=[],
+            X=None,  # type: ignore[arg-type]
+            splits_outer=[],
+            task="regression",
+            feature_names=["a", "b"],
+            pipeline_state=None,
+        )
+        # Should return a dict with 0.0 values, not crash
+        assert isinstance(result, dict)
+        assert result == {"a": 0.0, "b": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: FitResult immutability — model.py mutation
+# ---------------------------------------------------------------------------
+
+
+class TestFitResultImmutability:
+    """FitResult should not be mutated in-place after construction."""
+
+    def test_fit_returns_complete_result(self) -> None:
+        """Smoke test that fit() returns a fully populated FitResult."""
+        from lizyml import Model
+        from tests._helpers import make_binary_df, make_config
+
+        df = make_binary_df()
+        m = Model(make_config("binary", calibration="platt", n_estimators=20))
+        result = m.fit(data=df)
+        # Verify calibrator and metrics are set
+        assert result.calibrator is not None
+        assert "raw" in result.metrics
+        assert "calibrated" in result.metrics
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Objective overwrite protection
+# ---------------------------------------------------------------------------
+
+
+class TestObjectiveOverwriteProtection:
+    """Task-locked objective must not be overridable by user params."""
+
+    def test_objective_locked_after_user_params(self) -> None:
+        """Even if user passes objective='regression', binary task keeps 'binary'."""
+        from lizyml.estimators.lgbm import LGBMAdapter
+
+        adapter = LGBMAdapter(
+            task="binary",
+            params={"objective": "regression"},
+        )
+        params, _ = adapter._build_params()
+        assert params["objective"] == "binary"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: datetime UTC
+# ---------------------------------------------------------------------------
+
+
+class TestDatetimeUTC:
+    """RunMeta timestamp must include timezone info."""
+
+    def test_timestamp_has_utc(self) -> None:
+        from lizyml import Model
+        from tests._helpers import make_config, make_regression_df
+
+        m = Model(make_config("regression", n_estimators=10))
+        result = m.fit(data=make_regression_df(n=50))
+        ts = result.run_meta.timestamp
+        # UTC timestamps end with +00:00 or Z
+        assert "+00:00" in ts or "Z" in ts, f"Timestamp lacks UTC: {ts}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: TuningResult deep freeze
+# ---------------------------------------------------------------------------
+
+
+class TestTuningResultDeepFreeze:
+    """Frozen dataclasses must not allow mutation of contained dicts/lists."""
+
+    def test_best_params_immutable(self) -> None:
+        source_params = {"lr": 0.1}
+        tr = TuningResult(
+            best_params=source_params,
+            best_score=0.5,
+            trials=[],
+            metric_name="rmse",
+            direction="minimize",
+        )
+        # Mutate the original dict
+        source_params["lr"] = 999.0
+        # TuningResult should have its own copy
+        assert tr.best_params["lr"] == 0.1
+
+    def test_trials_list_immutable(self) -> None:
+        trials = [TrialResult(number=0, params={}, score=0.5, state="complete")]
+        tr = TuningResult(
+            best_params={},
+            best_score=0.5,
+            trials=trials,
+            metric_name="rmse",
+            direction="minimize",
+        )
+        trials.append(TrialResult(number=1, params={}, score=0.6, state="complete"))
+        assert len(tr.trials) == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: bare assert → LizyMLError
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateAssertReplaced:
+    """evaluate() must raise LizyMLError, not AssertionError, on unfitted model."""
+
+    def test_evaluate_unfitted_raises_lizyml_error(self) -> None:
+        from lizyml import Model
+        from tests._helpers import make_config
+
+        m = Model(make_config("regression"))
+        with pytest.raises(LizyMLError) as exc_info:
+            m.evaluate()
+        assert exc_info.value.code == ErrorCode.MODEL_NOT_FIT
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: _filter_metrics empty branches
+# ---------------------------------------------------------------------------
+
+
+class TestFilterMetricsNoBranches:
+    """_filter_metrics must remove empty branches after filtering."""
+
+    def test_no_empty_calibrated_branch(self) -> None:
+        from lizyml.core.model import _filter_metrics
+
+        metrics = {
+            "raw": {"oof": {"rmse": 0.5, "mae": 0.3}, "if_mean": {"rmse": 0.4}},
+            "calibrated": {"oof": {"logloss": 0.2}},
+        }
+        result = _filter_metrics(metrics, {"rmse"})
+        # "calibrated" has no "rmse" metrics → should be removed
+        if "calibrated" in result:
+            cal = result["calibrated"]
+            # All sub-dicts must be non-empty if branch exists
+            for k, v in cal.items():
+                if isinstance(v, dict):
+                    assert len(v) > 0, f"Empty branch: calibrated.{k}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: LGBMAdapter.update_params no mutation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateParamsNoMutation:
+    """LGBMAdapter.update_params must not mutate the original params dict."""
+
+    def test_original_params_unchanged(self) -> None:
+        from lizyml.estimators.lgbm import LGBMAdapter
+
+        original = {"learning_rate": 0.1}
+        adapter = LGBMAdapter(task="regression", params=original)
+        adapter.update_params({"max_depth": 5})
+        # Original dict passed to constructor should not be modified
+        assert "max_depth" not in original
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: HoldoutInnerValid n_valid consistency
+# ---------------------------------------------------------------------------
+
+
+class TestHoldoutNValidConsistency:
+    """HoldoutSplitter and HoldoutInnerValid must use same rounding for n_valid."""
+
+    def test_same_n_valid_for_same_ratio(self) -> None:
+        from lizyml.splitters.holdout import HoldoutSplitter
+        from lizyml.training.inner_valid import HoldoutInnerValid
+
+        n_samples = 15
+        ratio = 0.1
+
+        # HoldoutSplitter
+        hs = HoldoutSplitter(ratio=ratio, random_state=0)
+        hs_folds = list(hs.split(n_samples))
+        hs_n_valid = len(hs_folds[0][1])
+
+        # HoldoutInnerValid
+        hiv = HoldoutInnerValid(ratio=ratio, random_state=0)
+        hiv_result = hiv.split(n_samples)
+        assert hiv_result is not None
+        hiv_n_valid = len(hiv_result[1])
+
+        assert hs_n_valid == hiv_n_valid, (
+            f"Inconsistent n_valid: HoldoutSplitter={hs_n_valid}, "
+            f"HoldoutInnerValid={hiv_n_valid}"
+        )


### PR DESCRIPTION
## Summary

Comprehensive fixes for 20+ issues found in a full code review. No public API shape/meaning changes — no HISTORY.md Proposal required.

### Data Correctness Fixes
- **cross_fit NaN init**: `np.empty_like` → `np.full(..., np.nan)` to prevent uninitialized memory in calibrated OOF for time-series splitters
- **GroupTimeSeriesSplitter trailing groups**: Last fold now extends to include all remaining groups instead of silently dropping them
- **ECE boundary**: Last bin is now right-inclusive (`y_pred == 1.0` no longer excluded)
- **RMSLE negative guard**: Raises `LizyMLError` for negative predictions/targets instead of producing NaN

### Safety & Immutability Fixes
- **FitResult mutation**: Post-construction mutation replaced with `dataclasses.replace()`
- **DataFrameComponents mutation**: `_prepare_training_data` creates new instance instead of mutating
- **Objective lock**: `_build_params` strips `objective`/`metric` from user params (task-locked)
- **update_params**: Creates new dict instead of in-place mutation
- **TuningResult deep freeze**: `__post_init__` copies mutable `dict`/`list` fields
- **bare assert**: `evaluate()` asserts replaced with `LizyMLError`
- **datetime UTC**: All timestamps now include timezone (`timezone.utc`)

### Hardening
- **scipy guard**: QQ plots raise `OPTIONAL_DEP_MISSING` instead of bare `ImportError`
- **SHAP empty models**: `compute_shap_importance` returns zeros for empty models list
- **Tuner logging**: Failed trials logged via warning callback; catch tuple narrowed
- **_filter_metrics**: Empty branches removed after filtering
- **HoldoutInnerValid**: `n_valid` uses `ceil` to match `HoldoutSplitter`
- **params_table**: Guards against empty models list

### Documentation & CI
- `PredictionResult.proba` docstring: Corrected for multiclass shape
- `cross_fit_calibrate` docstring: Notes raw score (logit) support
- CI matrix: Added Python 3.11
- Coverage config: Added `[tool.coverage.run]` and `[tool.coverage.report]` to pyproject.toml

## Test plan
- [x] 26 new tests in `tests/test_code_review_fixes.py` covering all fixes
- [x] All 943 existing tests pass (0 regressions)
- [x] Quality gates: ruff check, ruff format, mypy — all clean
- [x] CI passes on 3.10, 3.11, 3.12

## Applicable SKILLs
- metrics, calibration, splitters, evaluation-contracts, persistence-and-migration (docstring only)

## DoD
- All identified issues addressed or documented
- TDD methodology followed (RED → GREEN → REFACTOR)
- No public API contract changes