### PR TITLE
docs: align specs with H-0050–H-0053 implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -748,15 +748,15 @@ lizyml/
 
 ---
 
-## 現状との差分（実装ロードマップ）
+## 実装状況
 
-現在の実装はこの目標構造に概ね沿っているが、以下の修正が必要:
+以下の移行作業はすべて完了済み（H-0051/H-0052/H-0053）:
 
-| # | 問題 | 目標 Layer ルール違反 | 修正方針 |
+| # | 問題 | 修正内容 | 状態 |
 |---|---|---|---|
-| 1 | `training/` が `evaluation/oof.py` に依存 | L2 → L2 (同層間の依存) | `oof.py` の `fill_oof`, `get_fold_pred` を `training/` に移動 |
-| 2 | `evaluation/` が `calibration/` に依存 | L2 → L1 (逆方向ではないが不要) | calibrated metrics の組み立てを Facade に移動 |
-| 3 | `estimators/` が `config/` に依存 | L1 → L1 (Leaf 間の依存) | `extract_smart_params(LGBMConfig)` を Facade に移動 |
-| 4 | `types/` が `data/` に依存 | L0 → L1 (逆方向) | `DataFingerprint` を `types/` に移動 |
-| 5 | `splitters/` ↔ `specs/` 循環 | 循環 | 死んだ Spec 層を削除 |
-| 6 | デッドコード多数 | — | `TargetTransformer`, `SplitPlan`, 未使用 Spec 等を削除 |
+| 1 | `training/` → `evaluation/oof.py` 依存 | `oof.py` を `training/oof_assembly.py` に移動（H-0052） | ✅ 解消 |
+| 2 | `evaluation/` → `calibration/` 依存 | calibrated metrics 組み立てを Facade に移動（H-0052） | ✅ 解消 |
+| 3 | `estimators/` → `config/` 依存 | `extract_smart_params` を LGBMProvider に移動（H-0053） | ✅ 解消 |
+| 4 | `types/` → `data/` 逆依存 | `DataFingerprint` を `core/types/artifacts.py` に移動（H-0051） | ✅ 解消 |
+| 5 | `splitters/` ↔ `specs/` 循環 | 死んだ Spec 層を削除（H-0051） | ✅ 解消 |
+| 6 | デッドコード多数 | 8 ファイル + Registry + Spec 変換関数を削除（H-0051） | ✅ 解消 |

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -385,7 +385,7 @@ config = {
    - `split.method` が `time_series` / `purged_time_series` / `group_time_series` の場合、`data.time_col` を基準に昇順へ並べた上で分割する。
 3. `InnerValidStrategy` により early stopping 用の `(X_train, y_train), (X_valid, y_valid)` を統一生成する。
 4. `EstimatorAdapter.fit()` を実行する。
-5. OOF / IF を生成する（ロジックは `evaluation/oof.py` に隔離）。
+5. OOF / IF を生成する（ロジックは `training/oof_assembly.py` に隔離）。
 6. 必要なら `Calibrator` を cross-fit 学習する（OOF 予測のみ使用）。
 7. 全データ Refit を実行する（同一の `TrainComponents` を使用し、CV との一貫性を構造的に保証する）。
 8. `FitResult` を返し、Artifacts を保持する。
@@ -1067,6 +1067,8 @@ lizyml/
 │   ├── _model_plots.py             ModelPlotsMixin
 │   ├── _model_tables.py            ModelTablesMixin
 │   ├── _model_persistence.py       ModelPersistenceMixin
+│   ├── train_components.py         TrainComponents (frozen dataclass)
+│   ├── seed.py                     seed 固定ユーティリティ
 │   └── specs/
 │       ├── problem_spec.py         ProblemSpec (data/ が使用)
 │       └── feature_spec.py         FeatureSpec (data/ が使用)
@@ -1091,8 +1093,10 @@ lizyml/
 ├── features/                       ── Layer 1: Features ──
 │   ├── pipeline_base.py            BaseFeaturePipeline
 │   ├── pipelines_native.py         NativeFeaturePipeline
-│   └── encoders/
-│       └── categorical_encoder.py  カテゴリ処理部品
+│   ├── encoders/
+│   │   └── categorical_encoder.py  カテゴリ処理部品
+│   └── transformers/
+│       └── feature_transformer.py  特徴量変換 (passthrough 拡張点)
 │
 ├── estimators/                     ── Layer 1: Estimators ──
 │   ├── base.py                     BaseEstimatorAdapter
@@ -1121,14 +1125,14 @@ lizyml/
 ├── training/                       ── Layer 2: Training ──
 │   ├── cv_trainer.py               CVTrainer (outer CV loop)
 │   ├── refit_trainer.py            RefitTrainer + RefitResult
-│   ├── train_components.py         TrainComponents (frozen dataclass)
 │   ├── inner_valid.py              BaseInnerValidStrategy + 4 concrete
 │   └── oof_assembly.py             fill_oof / get_fold_pred / init_oof
 │
 ├── evaluation/                     ── Layer 2: Evaluation ──
 │   ├── evaluator.py                Evaluator (raw metrics のみ)
 │   ├── table_formatter.py          evaluate_table 整形
-│   └── confusion.py                confusion_matrix_table
+│   ├── confusion.py                confusion_matrix_table
+│   └── thresholding.py             threshold 最適化ユーティリティ
 │
 ├── tuning/                         ── Layer 2: Tuning ──
 │   ├── tuner.py                    Tuner (Optuna study management)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,7 +54,7 @@ PyPI 公開を前提にした場合、build 定義・配布メタデータ・REA
 ## 2026-03-04: Config Schema の全フィールド確定
 
 - ID: `H-0001`
-- Status: `proposed`
+- Status: `accepted`
 - Scope: `Config`
 - Related: `BLUEPRINT.md §5, §3.3`
 
@@ -247,7 +247,7 @@ class CalibrationConfig(BaseModel):
 ## 2026-03-04: FitResult / PredictionResult / Artifacts の全フィールド確定
 
 - ID: `H-0002`
-- Status: `proposed`
+- Status: `accepted`
 - Scope: `Artifacts`
 - Related: `BLUEPRINT.md §7`
 
@@ -360,7 +360,7 @@ class RunMeta:
 ## 2026-03-04: Persistence / Export フォーマット仕様の確定
 
 - ID: `H-0003`
-- Status: `proposed`
+- Status: `accepted`
 - Scope: `Artifacts | Export`
 - Related: `BLUEPRINT.md §14, §15.4`
 
@@ -3178,7 +3178,7 @@ BLUEPRINT §10.1 では「Splitter は外側 CV / early stopping / calibration �
 ## 2026-03-16: デッドコード削除と Foundation 整理
 
 - ID: `H-0051`
-- Status: `proposed`
+- Status: `accepted`
 - Scope: `Architecture | Internal`
 - Related: `BLUEPRINT.md §2, §19, ARCHITECTURE.md`
 


### PR DESCRIPTION
## Summary
- Update HISTORY.md statuses for H-0001/H-0002/H-0003/H-0051 (proposed → accepted)
- Fix BLUEPRINT.md §6.2.5: OOF location reference (evaluation/oof.py → training/oof_assembly.py)
- Fix BLUEPRINT.md §19: directory structure to match actual file locations
- Update ARCHITECTURE.md: mark all 6 migration items as resolved

## Test plan
- [x] Documentation-only changes, no code modified
- [x] Verified file locations match updated §19 entries