### PR TITLE
feat(H-0057): split-derived OOF coverage for TimeSeriesCV

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -768,10 +768,11 @@ result = model.tune(progress_callback=on_progress)
 - 校正前後も同一フォーマットで返す（binary）。
 - `evaluate_table()` は `evaluate()` が返す固定構造 dict を `pd.DataFrame` に変換する純粋フォーマッタ。ロジックは `evaluation/table_formatter.py` に配置する。
   - 行 = メトリクス名。
-  - `oof`: 全 OOF 集約値（全行ベース）。
+  - `oof`: OOF 集約値（**covered 行ベース**。split で valid に一度も含まれない行は除外。KFold では全行=covered、TimeSeriesCV では先頭行が non-covered）。
   - `fold_0`...`fold_N-1`: 各 outer fold の OOF（valid_idx）値。
   - `if_mean`: IF（train_idx）指標の fold 平均（参考値として保持）。
   - calibrated がある場合は `cal_oof` 列を追加。
+  - `df.attrs["oof_coverage"]`: float (0.0–1.0)。covered 行の割合。KFold では常に `1.0`。TimeSeriesCV では `< 1.0` になりうる。
 
 ## 13.3 可視化
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3682,3 +3682,78 @@ H-0053 で `EstimatorProvider` protocol を導入し、`model.py` のゼロ LGBM
 - カテゴリ D: Parquet / float32 / nullable dtype の E2E が pass。0行/1行/重複列で明確なエラー。
 - カテゴリ E: pairwise 組み合わせ全ケースで fit 完走 or 明確なエラー。
 - 全体: 既存 1007 テストに影響なし。カバレッジ 97%+ 維持。
+
+---
+
+## H-0057: Split-derived OOF Coverage（TimeSeriesCV の OOF メトリクス NaN 解消）
+
+- ID: `H-0057`
+- Status: `implemented`
+- Scope: `Evaluation | Metrics`
+- Related: `BLUEPRINT.md §13.2, §7.1`
+
+### 目的
+
+TimeSeriesCV（expanding window）使用時に、最初の期間のサンプルがどの validation fold にも含まれないため OOF 予測値が NaN のまま残り、`evaluate()` / `evaluate_table()` の全体 OOF メトリクスが NaN になる問題を解消する。
+
+### 背景
+
+- `TimeSeriesSplit(n_splits=K)` では先頭 `n_samples // (K+1)` 行程度が全 fold で train 側にのみ含まれ、validation に一度も現れない。
+- 現行の `Evaluator.evaluate()` は `oof_pred` 全行で metric を計算するため、NaN が混入しメトリクスも NaN になる。
+- NaN マスク（`np.isnan` で除外）は「バグで予測されなかった行」と「仕様上カバーされない行」を区別できず、潜在バグを見落とすリスクがある。
+
+### Proposal: Split-derived OOF Coverage Mask
+
+1. **`compute_oof_valid_mask(splits_outer, n_samples)`** を `oof_assembly.py` に追加。
+   - `SplitIndices.outer` の全 fold の `valid_idx` の和集合から boolean mask を生成。
+   - NaN 検出ではなく、split 構造から決定論的に導出。
+
+2. **`Evaluator.evaluate()` の OOF メトリクス計算を変更**。
+   - mask の True 行のみで `oof` メトリクスを計算。
+   - **カバー行に NaN がある場合は `ValueError`**（予測パイプラインのバグとして検知）。
+   - `oof_per_fold` / IF メトリクスは変更なし。
+
+3. **`metrics["raw"]["oof_coverage"]`** を追加（float, 0.0–1.0）。
+   - KFold: 常に `1.0`。TimeSeriesCV: `< 1.0`。
+
+4. **`evaluate_table()`** で `df.attrs["oof_coverage"]` として公開。
+
+### 影響範囲
+
+| 対象 | 変更内容 |
+|------|---------|
+| `oof_assembly.py` | `compute_oof_valid_mask()` 追加 |
+| `evaluator.py` | mask ベースの OOF 計算 + `oof_coverage` 追加 |
+| `table_formatter.py` | `df.attrs` に `oof_coverage` |
+| `_model_metrics.py` | calibrated パスは `splits` 保持済み → 変更不要 |
+| FitResult | **変更なし**（mask は SplitIndices から導出） |
+
+### 互換性
+
+- **KFold（既存の主要ユースケース）**: 全行カバーのため挙動は完全に同一。
+- **TimeSeriesCV**: `metrics["raw"]["oof"]` が NaN → 有効な数値に変わる（改善のみ）。
+- **`metrics["raw"]` への `oof_coverage` キー追加**: 既存コードは未知キーを参照しない限り影響なし。`filter_metrics()` は非 dict 値をパススルーするため互換。
+
+### 代替案（却下）
+
+- **NaN マスク**: `np.isnan(oof_pred)` で除外。→ バグ由来の NaN も黙殺されるため却下。
+
+### 受け入れ基準
+
+- `compute_oof_valid_mask` が split indices から正しい bool mask を返す（unit test）。
+- カバー行に NaN → `ValueError`（バグ検知テスト）。
+- 非カバー行の NaN は正常スキップ。
+- KFold で `oof_coverage == 1.0`、TimeSeriesCV で `oof_coverage < 1.0`。
+- TimeSeriesCV の OOF メトリクスが finite（NaN でない）。
+- `evaluate_table().attrs["oof_coverage"]` が float。
+- 既存テスト全通し（後方互換）。
+
+### Decision
+
+- Date: 2026-03-17
+- Result: Accepted — split 構造からの決定論的マスク + バグ検知 assertion の方針で実装する。
+
+### 備考
+
+- `metrics["calibrated"]` には `oof_coverage` を含めない（現状維持）。calibrated の cross-fit 分割は `calibration.n_splits` で outer とは独立しており、coverage が異なりうるため、raw の値を流用すると不正確になる。
+- この不整合は H-0058（Outer Split を Calibration で再利用する提案）で構造的に解消される予定。H-0058 が実装されれば calibrated の coverage は raw と一致するため、別途 coverage を公開する必要がなくなる。

--- a/lizyml/core/_model_metrics.py
+++ b/lizyml/core/_model_metrics.py
@@ -77,9 +77,21 @@ def assemble_calibrated_metrics(
         return metrics
 
     cal_oof = fit_result.calibrator.calibrated_oof
-    cal_result = evaluator.evaluate(
-        dataclasses.replace(fit_result, oof_pred=cal_oof),
-        y,
-        metric_names,
+    # Use calibration fold indices for the OOF coverage mask (H-0057).
+    # The calibrated OOF was produced by cross-fit calibration folds,
+    # which may have different coverage from outer CV folds.
+    cal_splits = dataclasses.replace(
+        fit_result.splits,
+        outer=fit_result.calibrator.split_indices,
     )
+    # Build a temporary FitResult with calibration-aligned splits and
+    # dummy IF predictions (evaluator requires them, but we only use OOF).
+    cal_if = [cal_oof[t] for t, _ in fit_result.calibrator.split_indices]
+    cal_fr = dataclasses.replace(
+        fit_result,
+        oof_pred=cal_oof,
+        splits=cal_splits,
+        if_pred_per_fold=cal_if,
+    )
+    cal_result = evaluator.evaluate(cal_fr, y, metric_names)
     return {**metrics, "calibrated": {"oof": cal_result["raw"]["oof"]}}

--- a/lizyml/evaluation/evaluator.py
+++ b/lizyml/evaluation/evaluator.py
@@ -11,6 +11,7 @@ import pandas as pd
 from lizyml.core.types.fit_result import FitResult
 from lizyml.metrics.base import BaseMetric
 from lizyml.metrics.registry import get_metrics_for_task
+from lizyml.training.oof_assembly import compute_oof_valid_mask
 
 TaskType = Literal["regression", "binary", "multiclass"]
 
@@ -120,8 +121,31 @@ class Evaluator:
         metrics = get_metrics_for_task(metric_names, self.task)
         y_arr = np.asarray(y)
 
-        # --- OOF metrics -----------------------------------------------------
-        oof_scores = _compute_metrics(metrics, y_arr, fit_result.oof_pred, self.task)
+        # --- OOF coverage mask (H-0057) --------------------------------------
+        oof_mask = compute_oof_valid_mask(fit_result.splits.outer, len(y_arr))
+        covered_pred = fit_result.oof_pred[oof_mask]
+
+        # Assert no NaN in covered rows — NaN here indicates a pipeline bug,
+        # not a structurally uncovered row (e.g. TimeSeriesCV first period).
+        _nan_flags = np.isnan(covered_pred)
+        # For 2-D predictions (multiclass), collapse to per-row bool.
+        nan_in_covered = (
+            _nan_flags if _nan_flags.ndim == 1 else np.asarray(_nan_flags.any(axis=1))
+        )
+        if nan_in_covered.any():
+            nan_count = int(nan_in_covered.sum())
+            nan_indices = np.where(oof_mask)[0][nan_in_covered]
+            raise ValueError(
+                f"OOF predictions contain NaN in {nan_count} row(s) "
+                f"covered by validation folds (indices: "
+                f"{nan_indices[:5].tolist()}{'...' if nan_count > 5 else ''}). "
+                f"This indicates a bug in the training pipeline."
+            )
+
+        oof_coverage = float(oof_mask.sum()) / len(y_arr) if len(y_arr) > 0 else 0.0
+
+        # --- OOF metrics (covered rows only) ----------------------------------
+        oof_scores = _compute_metrics(metrics, y_arr[oof_mask], covered_pred, self.task)
 
         # --- Per-fold OOF metrics (valid_idx) --------------------------------
         oof_per_fold: list[dict[str, float]] = []
@@ -152,5 +176,6 @@ class Evaluator:
                 "oof_per_fold": oof_per_fold,
                 "if_mean": if_mean,
                 "if_per_fold": if_per_fold,
+                "oof_coverage": oof_coverage,
             }
         }

--- a/lizyml/evaluation/table_formatter.py
+++ b/lizyml/evaluation/table_formatter.py
@@ -50,4 +50,9 @@ def format_metrics_table(metrics: dict[str, Any]) -> pd.DataFrame:
 
     df = pd.DataFrame(data, index=metric_names)
     df.index.name = "metric"
+
+    oof_coverage = raw.get("oof_coverage")
+    if oof_coverage is not None:
+        df.attrs["oof_coverage"] = oof_coverage
+
     return df

--- a/lizyml/training/oof_assembly.py
+++ b/lizyml/training/oof_assembly.py
@@ -69,6 +69,30 @@ def fill_oof(
     oof[valid_idx] = fold_pred
 
 
+def compute_oof_valid_mask(
+    splits_outer: list[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]],
+    n_samples: int,
+) -> npt.NDArray[np.bool_]:
+    """Return boolean mask: True for rows covered by at least one validation fold.
+
+    Derives coverage deterministically from split indices — not from NaN
+    detection — so that bugs (missing predictions in covered rows) are
+    distinguishable from structurally uncovered rows (e.g. first period
+    in TimeSeriesCV).
+
+    Args:
+        splits_outer: Per-fold ``(train_idx, valid_idx)`` tuples.
+        n_samples: Total number of samples in the dataset.
+
+    Returns:
+        Boolean array of shape ``(n_samples,)``.
+    """
+    mask = np.zeros(n_samples, dtype=np.bool_)
+    for _, valid_idx in splits_outer:
+        mask[valid_idx] = True
+    return mask
+
+
 def get_fold_pred(
     estimator: BaseEstimatorAdapter,
     X_valid: pd.DataFrame,

--- a/tests/test_e2e/test_golden_contracts.py
+++ b/tests/test_e2e/test_golden_contracts.py
@@ -95,6 +95,7 @@ class TestFitResultContract:
             "oof_per_fold",
             "if_mean",
             "if_per_fold",
+            "oof_coverage",
         }
 
     def test_calibrator_none_when_no_calibration(self) -> None:

--- a/tests/test_e2e/test_model_facade.py
+++ b/tests/test_e2e/test_model_facade.py
@@ -68,6 +68,7 @@ class TestModelCommon:
             "oof_per_fold",
             "if_mean",
             "if_per_fold",
+            "oof_coverage",
         }
 
     @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])

--- a/tests/test_e2e/test_time_series_full.py
+++ b/tests/test_e2e/test_time_series_full.py
@@ -224,3 +224,71 @@ class TestGroupTimeSeries:
             assert train_groups.isdisjoint(valid_groups), (
                 f"Fold {fold_idx}: groups overlap between train and valid"
             )
+
+
+# ===========================================================================
+# H-0057: OOF coverage — TimeSeriesCV produces valid (non-NaN) metrics
+# ===========================================================================
+
+
+class TestOofCoverage:
+    """Verify split-derived OOF coverage mask produces valid metrics."""
+
+    def test_oof_metrics_not_nan_time_series(self) -> None:
+        """TimeSeriesCV fit produces finite OOF metrics (not NaN)."""
+        df = _make_time_regression_df(n=200)
+        cfg = make_config(
+            "regression",
+            split_method="time_series",
+            n_splits=3,
+            time_col="time",
+        )
+        m = Model(cfg)
+        m.fit(data=df)
+        metrics = m.evaluate(metrics=["rmse", "mae"])
+        for name, val in metrics["raw"]["oof"].items():
+            assert np.isfinite(val), f"OOF metric '{name}' is {val}, expected finite"
+
+    def test_oof_coverage_less_than_one_time_series(self) -> None:
+        """TimeSeriesCV coverage is < 1.0 (first rows are uncovered)."""
+        df = _make_time_regression_df(n=200)
+        cfg = make_config(
+            "regression",
+            split_method="time_series",
+            n_splits=3,
+            time_col="time",
+        )
+        m = Model(cfg)
+        m.fit(data=df)
+        metrics = m.evaluate(metrics=["rmse"])
+        coverage = metrics["raw"]["oof_coverage"]
+        assert 0.0 < coverage < 1.0, f"Expected partial coverage, got {coverage}"
+
+    def test_oof_coverage_equals_one_kfold(self) -> None:
+        """KFold coverage is exactly 1.0."""
+        df = _make_time_regression_df(n=200)
+        cfg = make_config(
+            "regression",
+            split_method="kfold",
+            n_splits=3,
+        )
+        m = Model(cfg)
+        m.fit(data=df)
+        metrics = m.evaluate(metrics=["rmse"])
+        assert metrics["raw"]["oof_coverage"] == 1.0
+
+    def test_evaluate_table_has_coverage_attr(self) -> None:
+        """evaluate_table().attrs contains oof_coverage."""
+        df = _make_time_regression_df(n=200)
+        cfg = make_config(
+            "regression",
+            split_method="time_series",
+            n_splits=3,
+            time_col="time",
+        )
+        m = Model(cfg)
+        m.fit(data=df)
+        table = m.evaluate_table()
+        assert "oof_coverage" in table.attrs
+        assert isinstance(table.attrs["oof_coverage"], float)
+        assert 0.0 < table.attrs["oof_coverage"] < 1.0

--- a/tests/test_evaluation/test_evaluation.py
+++ b/tests/test_evaluation/test_evaluation.py
@@ -108,6 +108,7 @@ class TestEvaluatorStructureRegression:
             "oof_per_fold",
             "if_mean",
             "if_per_fold",
+            "oof_coverage",
         }
 
     def test_oof_keys_match_metrics(self) -> None:
@@ -203,6 +204,7 @@ class TestEvaluatorStructureBinary:
             "oof_per_fold",
             "if_mean",
             "if_per_fold",
+            "oof_coverage",
         }
 
     def test_metric_values_valid(self) -> None:

--- a/tests/test_evaluation/test_oof_coverage_eval.py
+++ b/tests/test_evaluation/test_oof_coverage_eval.py
@@ -1,0 +1,233 @@
+"""Integration tests for Evaluator OOF coverage mask (H-0057).
+
+Uses synthetic FitResult objects with hand-crafted SplitIndices to test:
+- Full coverage (KFold): backward-compatible, oof_coverage == 1.0
+- Partial coverage (TimeSeriesCV): oof metrics finite, oof_coverage < 1.0
+- NaN in covered rows: ValueError (bug detection)
+- NaN in uncovered rows: silently excluded (expected)
+- oof_per_fold / IF metrics unchanged
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from lizyml.core.types.artifacts import DataFingerprint, RunMeta, SplitIndices
+from lizyml.core.types.fit_result import FitResult
+from lizyml.evaluation.evaluator import Evaluator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUN_META = RunMeta(
+    lizyml_version="0.1.0",
+    python_version="3.11",
+    deps_versions={},
+    config_normalized={},
+    config_version=1,
+    run_id="test-coverage",
+    timestamp="2026-01-01T00:00:00",
+)
+
+_FP = DataFingerprint(row_count=0, column_hash="test")
+
+
+def _make_outer(
+    pairs: list[tuple[list[int], list[int]]],
+) -> list[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]]:
+    return [(np.array(t, dtype=np.intp), np.array(v, dtype=np.intp)) for t, v in pairs]
+
+
+def _make_fit_result(
+    oof_pred: npt.NDArray[np.float64],
+    outer: list[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]],
+    if_pred_per_fold: list[npt.NDArray[np.float64]] | None = None,
+) -> FitResult:
+    """Build a minimal synthetic FitResult for Evaluator testing."""
+    if if_pred_per_fold is None:
+        if_pred_per_fold = [oof_pred[train_idx] for train_idx, _ in outer]
+    return FitResult(
+        oof_pred=oof_pred,
+        if_pred_per_fold=if_pred_per_fold,
+        metrics={},
+        models=[],
+        history=[],
+        feature_names=["a"],
+        dtypes={"a": "float64"},
+        categorical_features=[],
+        splits=SplitIndices(outer=outer, inner=None, calibration=None),
+        data_fingerprint=_FP,
+        pipeline_state=None,
+        calibrator=None,
+        run_meta=_RUN_META,
+    )
+
+
+# ---------------------------------------------------------------------------
+# KFold (full coverage) — backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorFullCoverageKFold:
+    """KFold splits where all rows are covered."""
+
+    @pytest.fixture()
+    def kfold_setup(self):
+        rng = np.random.default_rng(42)
+        n = 12
+        y = rng.uniform(0, 10, n)
+        oof_pred = y + rng.normal(0, 0.5, n)  # noisy predictions
+        outer = _make_outer(
+            [
+                ([4, 5, 6, 7, 8, 9, 10, 11], [0, 1, 2, 3]),
+                ([0, 1, 2, 3, 8, 9, 10, 11], [4, 5, 6, 7]),
+                ([0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11]),
+            ]
+        )
+        fr = _make_fit_result(oof_pred, outer)
+        return fr, y
+
+    def test_oof_metrics_finite(self, kfold_setup) -> None:
+        fr, y = kfold_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse", "mae"])
+        for v in out["raw"]["oof"].values():
+            assert np.isfinite(v)
+
+    def test_oof_coverage_is_one(self, kfold_setup) -> None:
+        fr, y = kfold_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert out["raw"]["oof_coverage"] == 1.0
+
+    def test_raw_keys_include_oof_coverage(self, kfold_setup) -> None:
+        fr, y = kfold_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert "oof_coverage" in out["raw"]
+
+    def test_oof_per_fold_unchanged(self, kfold_setup) -> None:
+        """oof_per_fold still uses valid_idx, not mask."""
+        fr, y = kfold_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert len(out["raw"]["oof_per_fold"]) == 3
+        for fold_dict in out["raw"]["oof_per_fold"]:
+            assert "rmse" in fold_dict
+            assert np.isfinite(fold_dict["rmse"])
+
+    def test_if_metrics_unchanged(self, kfold_setup) -> None:
+        """IF metrics are completely independent of OOF coverage."""
+        fr, y = kfold_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert "if_mean" in out["raw"]
+        assert np.isfinite(out["raw"]["if_mean"]["rmse"])
+        assert len(out["raw"]["if_per_fold"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesCV (partial coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorPartialCoverageTimeSeries:
+    """TimeSeriesCV-like splits where first rows are uncovered."""
+
+    @pytest.fixture()
+    def ts_setup(self):
+        rng = np.random.default_rng(42)
+        n = 12
+        y = rng.uniform(0, 10, n)
+        # Rows 0-2 never in valid -> their OOF stays NaN
+        oof_pred = np.full(n, np.nan)
+        oof_pred[3:] = y[3:] + rng.normal(0, 0.5, 9)
+        outer = _make_outer(
+            [
+                ([0, 1, 2], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+                ([0, 1, 2, 3, 4, 5, 6, 7, 8], [9, 10, 11]),
+            ]
+        )
+        fr = _make_fit_result(oof_pred, outer)
+        return fr, y
+
+    def test_oof_metrics_finite(self, ts_setup) -> None:
+        fr, y = ts_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse", "mae"])
+        for v in out["raw"]["oof"].values():
+            assert np.isfinite(v), f"OOF metric should be finite, got {v}"
+
+    def test_oof_coverage_less_than_one(self, ts_setup) -> None:
+        fr, y = ts_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert out["raw"]["oof_coverage"] == pytest.approx(9 / 12)
+
+    def test_oof_coverage_type(self, ts_setup) -> None:
+        fr, y = ts_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert isinstance(out["raw"]["oof_coverage"], float)
+
+    def test_oof_computed_on_covered_rows_only(self, ts_setup) -> None:
+        """OOF metrics should be computed on rows 3-11 only, not 0-11."""
+        fr, y = ts_setup
+        ev = Evaluator(task="regression")
+        out = ev.evaluate(fr, y, ["mae"])
+        # Manually compute expected MAE on covered rows
+        covered_y = y[3:]
+        covered_pred = fr.oof_pred[3:]
+        expected_mae = float(np.mean(np.abs(covered_y - covered_pred)))
+        assert out["raw"]["oof"]["mae"] == pytest.approx(expected_mae)
+
+
+# ---------------------------------------------------------------------------
+# NaN assertion in covered rows (bug detection)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorNanBugDetection:
+    """NaN in covered rows must raise ValueError."""
+
+    def test_nan_in_covered_rows_raises(self) -> None:
+        n = 9
+        rng = np.random.default_rng(0)
+        y = rng.uniform(0, 10, n)
+        oof_pred = y + rng.normal(0, 0.5, n)
+        # Inject NaN in a covered row (row 3 is in valid of fold 0)
+        oof_pred[3] = np.nan
+        outer = _make_outer(
+            [
+                ([0, 1, 2], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+            ]
+        )
+        fr = _make_fit_result(oof_pred, outer)
+        ev = Evaluator(task="regression")
+        with pytest.raises(ValueError, match="covered by validation folds"):
+            ev.evaluate(fr, y, ["rmse"])
+
+    def test_nan_in_uncovered_rows_ok(self) -> None:
+        """NaN in structurally uncovered rows is expected and must not raise."""
+        n = 9
+        rng = np.random.default_rng(0)
+        y = rng.uniform(0, 10, n)
+        oof_pred = np.full(n, np.nan)
+        # Only fill covered rows (3-8)
+        oof_pred[3:] = y[3:] + rng.normal(0, 0.5, 6)
+        outer = _make_outer(
+            [
+                ([0, 1, 2], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+            ]
+        )
+        fr = _make_fit_result(oof_pred, outer)
+        ev = Evaluator(task="regression")
+        # Should not raise
+        out = ev.evaluate(fr, y, ["rmse"])
+        assert np.isfinite(out["raw"]["oof"]["rmse"])

--- a/tests/test_evaluation/test_table_formatter.py
+++ b/tests/test_evaluation/test_table_formatter.py
@@ -109,6 +109,34 @@ class TestFormatMetricsTable:
         df = format_metrics_table({"raw": raw})
         assert df.empty
 
+    def test_oof_coverage_in_attrs(self) -> None:
+        """oof_coverage is surfaced in df.attrs when present (H-0057)."""
+        metrics = {
+            "raw": {
+                "oof": {"rmse": 0.5},
+                "oof_per_fold": [{"rmse": 0.55}],
+                "if_mean": {"rmse": 0.4},
+                "if_per_fold": [{"rmse": 0.38}],
+                "oof_coverage": 0.75,
+            }
+        }
+        df = format_metrics_table(metrics)
+        assert "oof_coverage" in df.attrs
+        assert df.attrs["oof_coverage"] == pytest.approx(0.75)
+
+    def test_oof_coverage_absent_when_not_provided(self) -> None:
+        """No oof_coverage in attrs when not in input dict."""
+        metrics = {
+            "raw": {
+                "oof": {"rmse": 0.5},
+                "oof_per_fold": [],
+                "if_mean": {"rmse": 0.4},
+                "if_per_fold": [],
+            }
+        }
+        df = format_metrics_table(metrics)
+        assert "oof_coverage" not in df.attrs
+
     def test_fold_columns_use_oof_per_fold(self) -> None:
         """fold_N columns must use oof_per_fold, not if_per_fold (H-0045)."""
         metrics = {

--- a/tests/test_training/test_oof_coverage.py
+++ b/tests/test_training/test_oof_coverage.py
@@ -1,0 +1,113 @@
+"""Unit tests for compute_oof_valid_mask (H-0057).
+
+Tests the pure function that derives OOF coverage from split indices,
+NOT from NaN detection. This ensures:
+- KFold-style splits produce full coverage (all True).
+- TimeSeriesCV-style splits produce partial coverage.
+- Edge cases (empty, overlapping, zero samples) are handled.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from lizyml.training.oof_assembly import compute_oof_valid_mask
+
+
+def _make_outer(
+    pairs: list[tuple[list[int], list[int]]],
+) -> list[tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]]:
+    """Helper to build SplitIndices.outer-compatible list."""
+    return [(np.array(t, dtype=np.intp), np.array(v, dtype=np.intp)) for t, v in pairs]
+
+
+class TestComputeOofValidMask:
+    """Tests for compute_oof_valid_mask."""
+
+    def test_full_coverage_kfold(self) -> None:
+        """KFold: every sample appears in exactly one valid fold -> all True."""
+        # 3-fold KFold on 9 samples
+        outer = _make_outer(
+            [
+                ([3, 4, 5, 6, 7, 8], [0, 1, 2]),
+                ([0, 1, 2, 6, 7, 8], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+            ]
+        )
+        mask = compute_oof_valid_mask(outer, n_samples=9)
+        assert mask.dtype == np.bool_
+        assert mask.shape == (9,)
+        assert mask.all()
+
+    def test_partial_coverage_time_series(self) -> None:
+        """TimeSeriesCV: first rows never in valid -> False for those rows."""
+        # Simulates TimeSeriesSplit(n_splits=3) on 12 samples
+        # fold 0: train=[0,1,2], valid=[3,4,5]
+        # fold 1: train=[0..5],  valid=[6,7,8]
+        # fold 2: train=[0..8],  valid=[9,10,11]
+        # -> rows 0,1,2 never in valid
+        outer = _make_outer(
+            [
+                ([0, 1, 2], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+                ([0, 1, 2, 3, 4, 5, 6, 7, 8], [9, 10, 11]),
+            ]
+        )
+        mask = compute_oof_valid_mask(outer, n_samples=12)
+        assert not mask[0] and not mask[1] and not mask[2]
+        assert mask[3:].all()
+        assert mask.sum() == 9
+
+    def test_coverage_ratio(self) -> None:
+        """Coverage ratio matches expected value."""
+        outer = _make_outer(
+            [
+                ([0, 1, 2], [3, 4, 5]),
+                ([0, 1, 2, 3, 4, 5], [6, 7, 8]),
+                ([0, 1, 2, 3, 4, 5, 6, 7, 8], [9, 10, 11]),
+            ]
+        )
+        mask = compute_oof_valid_mask(outer, n_samples=12)
+        coverage = float(mask.sum()) / len(mask)
+        assert coverage == pytest.approx(9 / 12)
+
+    def test_empty_splits(self) -> None:
+        """Empty outer list -> mask is all False."""
+        mask = compute_oof_valid_mask([], n_samples=5)
+        assert mask.shape == (5,)
+        assert not mask.any()
+
+    def test_single_fold(self) -> None:
+        """Single fold covering a subset -> correct mask."""
+        outer = _make_outer([([0, 1, 2], [3, 4])])
+        mask = compute_oof_valid_mask(outer, n_samples=5)
+        expected = np.array([False, False, False, True, True])
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_overlapping_valid_idx(self) -> None:
+        """Overlapping valid indices -> union (no double-counting)."""
+        outer = _make_outer(
+            [
+                ([2, 3, 4], [0, 1]),
+                ([0, 3, 4], [1, 2]),
+            ]
+        )
+        mask = compute_oof_valid_mask(outer, n_samples=5)
+        # Union of {0,1} and {1,2} = {0,1,2}
+        expected = np.array([True, True, True, False, False])
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_n_samples_zero(self) -> None:
+        """n_samples=0 -> returns empty boolean array."""
+        mask = compute_oof_valid_mask([], n_samples=0)
+        assert mask.shape == (0,)
+        assert mask.dtype == np.bool_
+
+    def test_return_type_is_bool_ndarray(self) -> None:
+        """Verify dtype is np.bool_."""
+        outer = _make_outer([([0], [1])])
+        mask = compute_oof_valid_mask(outer, n_samples=2)
+        assert mask.dtype == np.bool_
+        assert isinstance(mask, np.ndarray)


### PR DESCRIPTION
## Summary

- Resolve NaN OOF metrics when using TimeSeriesCV (expanding window) where first-period samples never appear in any validation fold
- Derive coverage mask deterministically from split indices (not NaN detection), raising `ValueError` for NaN in covered rows as a bug signal
- Add `metrics["raw"]["oof_coverage"]` (float 0.0–1.0) and expose via `evaluate_table().attrs["oof_coverage"]`

## Changes

| File | Change |
|------|--------|
| `lizyml/training/oof_assembly.py` | Add `compute_oof_valid_mask()` |
| `lizyml/evaluation/evaluator.py` | Compute OOF metrics on covered rows only + NaN assertion + `oof_coverage` |
| `lizyml/evaluation/table_formatter.py` | Surface `oof_coverage` in `df.attrs` |
| `lizyml/core/_model_metrics.py` | Use calibration `split_indices` for mask in calibrated path |
| `BLUEPRINT.md` | Update §13.2 OOF semantics (covered rows) |
| `HISTORY.md` | H-0057 Proposal (implemented) |

## Test plan

- [x] `compute_oof_valid_mask` unit tests (8 tests): full/partial coverage, edge cases
- [x] Evaluator integration tests (11 tests): coverage key, NaN assertion, backward compat
- [x] E2E tests (4 tests): TimeSeriesCV metrics finite, coverage < 1.0, KFold = 1.0
- [x] Table formatter tests (2 tests): `df.attrs` presence/absence
- [x] Existing tests updated for `oof_coverage` key (4 files)
- [x] Full suite: 1124 passed, 0 failed
- [x] Quality gates: ruff / mypy / pytest all pass

## SKILL

- skills/evaluation-contracts/SKILL.md
- skills/training-cv-and-inner-valid/SKILL.md

## DoD

- [x] HISTORY.md H-0057 Proposal → implemented
- [x] BLUEPRINT.md §13.2 updated
- [x] Split-derived mask (not NaN mask)
- [x] ValueError on NaN in covered rows (bug detection)
- [x] `oof_coverage` in raw metrics
- [x] Calibrated path uses calibration `split_indices`
- [x] FitResult contract unchanged
- [x] 98% coverage maintained

## Note

`metrics["calibrated"]` does not include `oof_coverage` (option A: status quo). This will be structurally resolved by H-0058 (reuse outer splits for calibration cross-fit).