### PR TITLE
ci: add auto-release workflow and release script

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,73 @@
+name: Auto-tag and GitHub Release
+
+# Triggered when a PR with title starting "release:" is merged into main.
+# Creates a git tag and a GitHub Release with notes from CHANGELOG.md.
+# The tag push then triggers the existing release.yml (PyPI publish).
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'release:')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        id: version
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          VERSION=$(echo "$TITLE" | grep -oP 'v\d+\.\d+\.\d+')
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version found in PR title: $TITLE"
+            exit 1
+          fi
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          # Strip 'v' prefix for CHANGELOG lookup
+          echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ steps.version.outputs.tag }} already exists"
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version (between ## [X.Y.Z] and the next ## [)
+          NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="Release ${VERSION}"
+          fi
+          # Write to file for gh release create --notes-file
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "Release notes extracted:"
+          cat /tmp/release-notes.md
+
+      - name: Create tag
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file /tmp/release-notes.md

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Release automation script for LizyML.
+
+Usage:
+    uv run python scripts/release.py v0.5.0
+
+What it does:
+    1. Validates version format and semver increment
+    2. Extracts release notes from CHANGELOG.md
+    3. Commits CHANGELOG (if uncommitted changes exist)
+    4. Pushes develop to origin
+    5. Creates a PR from develop → main with release title and notes
+
+After the PR is merged on GitHub, the auto-release.yml workflow will:
+    - Create a git tag
+    - Create a GitHub Release with notes from CHANGELOG.md
+    - Trigger release.yml (PyPI publish)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+
+def run(cmd: str, *, check: bool = True) -> str:
+    """Run a shell command and return stdout."""
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, check=False
+    )
+    if check and result.returncode != 0:
+        print(f"ERROR: {cmd}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def get_current_version() -> str:
+    """Get the latest git tag version."""
+    tags = run("git tag --sort=-v:refname")
+    for line in tags.splitlines():
+        if re.match(r"^v\d+\.\d+\.\d+$", line):
+            return line
+    return "v0.0.0"
+
+
+def validate_version(new: str, current: str) -> str:
+    """Validate version format and that it's an increment."""
+    if not re.match(r"^v\d+\.\d+\.\d+$", new):
+        print(
+            f"ERROR: Invalid version format: {new} (expected vX.Y.Z)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    def parse(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.lstrip("v").split("."))
+
+    new_parts = parse(new)
+    cur_parts = parse(current)
+
+    if new_parts <= cur_parts:
+        print(
+            f"ERROR: New version {new} must be greater than current {current}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Determine type
+    if new_parts[0] > cur_parts[0]:
+        return "MAJOR"
+    if new_parts[1] > cur_parts[1]:
+        return "MINOR"
+    return "PATCH"
+
+
+def extract_changelog_section(version: str) -> str:
+    """Extract the CHANGELOG.md section for a given version."""
+    ver = version.lstrip("v")
+    try:
+        with open("CHANGELOG.md") as f:
+            content = f.read()
+    except FileNotFoundError:
+        return f"Release {ver}"
+
+    pattern = rf"## \[{re.escape(ver)}\].*?\n(.*?)(?=\n## \[|\Z)"
+    match = re.search(pattern, content, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return f"Release {ver}"
+
+
+def check_branch() -> None:
+    """Ensure we're on develop."""
+    branch = run("git branch --show-current")
+    if branch != "develop":
+        print(
+            f"ERROR: Must be on 'develop' branch, currently on '{branch}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def check_changelog_has_version(version: str) -> None:
+    """Ensure CHANGELOG.md has an entry for this version."""
+    ver = version.lstrip("v")
+    with open("CHANGELOG.md") as f:
+        content = f.read()
+    if f"## [{ver}]" not in content:
+        print(
+            f"ERROR: CHANGELOG.md has no entry for [{ver}]. "
+            f"Add it before running this script.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: uv run python scripts/release.py v0.5.0", file=sys.stderr)
+        sys.exit(1)
+
+    new_version = sys.argv[1]
+
+    # Validate
+    check_branch()
+    current = get_current_version()
+    bump_type = validate_version(new_version, current)
+    check_changelog_has_version(new_version)
+    notes = extract_changelog_section(new_version)
+
+    print(f"Current version: {current}")
+    print(f"New version:     {new_version} ({bump_type})")
+    print(f"Release notes:\n{notes}\n")
+
+    # Commit CHANGELOG if there are uncommitted changes
+    status = run("git status --porcelain CHANGELOG.md", check=False)
+    if status:
+        ver = new_version.lstrip("v")
+        msg = f"docs: update CHANGELOG for v{ver} release"
+        run(f'git add CHANGELOG.md && git commit -m "{msg}"')
+        print("Committed CHANGELOG.md")
+
+    # Push develop
+    run("git push origin develop")
+    print("Pushed develop to origin")
+
+    # Create PR
+    ver = new_version.lstrip("v")
+    pr_title = f"release: {new_version} — LizyML {ver}"
+
+    pr_body = f"""## Summary
+{notes}
+
+## Version
+- Previous: {current}
+- New: {new_version}
+- Type: {bump_type}
+"""
+
+    # Write body to temp file to avoid shell escaping issues
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(pr_body)
+        body_file = f.name
+
+    pr_url = run(
+        f"gh pr create --base main --head develop "
+        f'--title "{pr_title}" '
+        f'--body-file "{body_file}"'
+    )
+    print(f"\nPR created: {pr_url}")
+    print("\nNext: Merge the PR on GitHub.")
+    print("Tag + release will be created automatically.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `.github/workflows/auto-release.yml` — auto-creates git tag + GitHub Release when a PR titled `release: vX.Y.Z` is merged to main
- Add `scripts/release.py` — one-command release automation: validates version, checks CHANGELOG, commits, pushes, creates PR
- Created GitHub Releases for all 8 existing tags (v0.1.0 through v0.4.0) with notes from CHANGELOG.md

## New release flow
```
Claude: uv run python scripts/release.py v0.5.0
  → CHANGELOG validated, committed, pushed, PR created

User: merges PR on GitHub
  → auto-release.yml creates tag + GitHub Release
  → release.yml publishes to PyPI
```

## Test plan
- [x] `scripts/release.py` validates version format (vX.Y.Z)
- [x] `scripts/release.py` validates semver increment (new > current)
- [x] `scripts/release.py` checks CHANGELOG entry exists
- [x] `auto-release.yml` extracts version from PR title
- [x] `auto-release.yml` extracts release notes from CHANGELOG.md
- [x] Past releases created: v0.1.0, v0.1.1, v0.1.2, v0.1.3, v0.1.4, v0.2.0, v0.3.0, v0.4.0