### PR TITLE
docs: add community files and dev tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{json,yaml,yml,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Report a bug to help us improve LizyML
+title: "[BUG] "
+labels: bug
+---
+
+## Description
+<!-- A clear description of the bug -->
+
+## Steps to Reproduce
+
+```python
+# Minimal reproducible example
+```
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened (include error messages / tracebacks) -->
+
+## Environment
+
+- LizyML version:
+- Python version:
+- OS:
+- LightGBM version:
+
+## Additional Context
+<!-- Config YAML, dataset characteristics, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for LizyML
+title: "[FEATURE] "
+labels: enhancement
+---
+
+## Problem
+<!-- What problem does this feature solve? -->
+
+## Proposed Solution
+<!-- How should it work? Include Config YAML examples if applicable -->
+
+```yaml
+# Example config
+```
+
+## Alternatives Considered
+<!-- Other approaches you've thought about -->
+
+## Additional Context
+<!-- Use cases, references to similar features in other libraries, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+<!-- 1-3 bullet points describing the change -->
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] `make ci` passes locally
+- [ ] HISTORY.md Proposal added (if spec change)
+- [ ] CHANGELOG.md updated (if user-facing change)
+
+## Test plan
+- [ ] ...

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `scripts/release.py` — automated release script (CHANGELOG validation, commit, push, PR creation)
 - `.github/workflows/auto-release.yml` — auto-tag and GitHub Release on merge to main
 - GitHub Releases for all past versions (v0.1.0–v0.4.0)
+- `CONTRIBUTING.md` — development workflow, quality gates, and spec-first process
+- `SECURITY.md` — vulnerability reporting policy
+- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
+- `Makefile` — unified development commands (`make ci`, `make test`, etc.)
+- `.editorconfig` — cross-editor formatting consistency
+- `.github/dependabot.yml` — automated dependency updates (pip + GitHub Actions)
+- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist template
+- `.github/ISSUE_TEMPLATE/` — bug report and feature request templates
 
 ## [0.4.0] - 2026-03-21
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported via [GitHub Security Advisories](https://github.com/nbx-liz/LizyML/security/advisories/new).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to LizyML
+
+Thank you for your interest in contributing to LizyML!
+
+## Development Setup
+
+```bash
+git clone https://github.com/nbx-liz/LizyML.git
+cd LizyML
+uv sync --frozen --dev
+git config core.hooksPath .githooks
+```
+
+## Workflow
+
+1. **Branch from develop**: `feat/`, `fix/`, `docs/`
+2. **Write tests first** (TDD): RED → GREEN → REFACTOR
+3. **Run quality gates** before pushing: `make ci`
+4. **Create PR** to `develop` (squash merge on GitHub)
+5. **Conventional Commits**: `<type>(<scope>): <description>`
+
+### Commit Types
+
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring (no behavior change) |
+| `docs` | Documentation only |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance tasks |
+| `perf` | Performance improvement |
+| `ci` | CI/CD changes |
+
+## Quality Gates
+
+All of these must pass before a PR can be merged:
+
+```bash
+make ci
+```
+
+This runs:
+
+- `uv run ruff check .` — linting
+- `uv run ruff format --check .` — formatting
+- `uv run mypy lizyml/` — type checking
+- `uv run pytest` — tests (80%+ coverage required)
+
+## Spec-First Development
+
+LizyML follows a **specification-first** workflow. Before implementing changes to:
+
+- Public API (`Model` methods, Config, FitResult, PredictionResult, Artifacts)
+- Split/leakage boundaries
+- Export/simulate formats
+- Persistence format
+
+You **must** add a Proposal to `HISTORY.md` first. See `skills/history-proposals/SKILL.md` for the format.
+
+### Documentation Priority
+
+When specifications conflict, priority is:
+
+1. `BLUEPRINT.md` (structure, contracts, invariants)
+2. `HISTORY.md` (proposals and decisions)
+3. `AGENTS.md` (operational principles)
+4. `skills/*` (implementation procedures)
+5. Implementation code
+
+## Testing Requirements
+
+- **Minimum 80% coverage** for all new code
+- **Contract tests** for public API / Config / Result shape changes
+- **Leak detection tests** for split / calibration changes (must include "should-fail" cases)
+- **Reproducibility tests** with seed pinning for new features
+
+## Language Convention
+
+- `BLUEPRINT.md`, `HISTORY.md`, `PLAN.md`, `CLAUDE.md`: Japanese
+- Code, docstrings, commit messages, PR descriptions: English
+
+## Getting Help
+
+- Open an [issue](https://github.com/nbx-liz/LizyML/issues) for bug reports or feature requests
+- Check `BLUEPRINT.md` for architectural context
+- Check `HISTORY.md` for design decision history

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: install test lint format format-check typecheck ci dev build clean
+
+PACKAGE = lizyml
+
+install:
+	uv sync --frozen --dev
+
+test:
+	uv run pytest --cov=$(PACKAGE) --cov-fail-under=80 -q
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format .
+
+format-check:
+	uv run ruff format --check .
+
+typecheck:
+	uv run mypy $(PACKAGE)/
+
+ci: lint format-check typecheck test  ## Run all CI checks locally
+
+dev:
+	uv run jupyter lab
+
+build:
+	uv build
+	uv run twine check dist/*
+
+clean:
+	rm -rf dist/ build/ *.egg-info .pytest_cache .mypy_cache .ruff_cache coverage.json .coverage

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in LizyML, please report it responsibly:
+
+1. **Do NOT** open a public issue
+2. Use [GitHub Security Advisories](https://github.com/nbx-liz/LizyML/security/advisories/new) to report privately
+3. Include steps to reproduce, impact assessment, and any suggested fixes
+
+We will acknowledge receipt within 48 hours and provide a timeline for resolution.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Previous minor | Best effort |
+| Older versions | No |
+
+## Security Considerations
+
+LizyML processes user-provided data and configuration. Key security areas:
+
+- **Deserialization**: Model artifacts use `joblib`. Only load artifacts from trusted sources.
+- **Code generation**: `export_code()` generates executable Python scripts. Review generated code before running in production.
+- **Dependencies**: We pin minimum versions and use Dependabot for automated updates.


### PR DESCRIPTION
## Summary
- Add community standards: CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md
- Add dev tooling: Makefile (`make ci`), .editorconfig, dependabot.yml
- Add GitHub templates: PR template, bug report, feature request

## Checklist
- [x] No code changes — docs and config only
- [x] `make ci` passes locally
- [x] CHANGELOG.md updated

## Test plan
- [x] `make ci` runs successfully (1264 tests pass)
- [x] All new files render correctly on GitHub