### PR TITLE
fix(sync): sync CHANGELOG from main after v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] - 2026-04-03
+
+### Added
+
+- **Codegen feval metric support** (H-0066) — `export_code()` now preserves feval metrics (f1, brier, ece, precision_at_k, accuracy, rmsle, r2) in generated code. Previously, feval metrics were silently dropped during code generation, causing `metric="None"` in config.json and incorrect early stopping behavior.
+  - `config.json` gains a `feval_metrics` field with metric metadata (name, params, greater_is_better, needs_proba)
+  - `train.py` template includes pure numpy/sklearn feval implementations and a `build_feval_from_config()` factory
+  - Backward compatible: empty `feval_metrics` produces identical output to previous versions
+- **New estimator implementation guide** — `docs/add-estimator-guide.md` documents all requirements for adding non-LightGBM estimators: adapter, provider, config, metric bridge, codegen, and test checklist
+
+## [0.7.3] - 2026-04-02
+
+### Fixed
+
+- **Tune → Fit exact identity** — Unified tune objective and fit code paths so both go through `_build_train_components(training_overrides=...)`. Previously, the tune objective rebuilt the estimator factory with pre-smart-resolution params (`merged_model`) when `early_stopping_rounds` was in the search space, causing `num_leaves` and `scale_pos_weight` to be missing. Tune and fit now produce bit-for-bit identical OOF scores.
+
+## [0.7.2] - 2026-04-02
+
+### Fixed
+
+- **Tune → Fit parameter identity** (#76) — `default_fixed_params()` was leaking `auto_num_leaves` (a smart param) into model params during tuning. Additionally, `best_training_params` (`early_stopping_rounds`, `validation_ratio`) from tuning were not applied during subsequent `fit()`. Both issues caused score divergence between tune best trial and fit OOF. After fix, tune and fit produce identical model params and near-identical OOF scores (within LightGBM floating-point tolerance).
+
 ## [0.7.1] - 2026-04-02
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Sync `CHANGELOG.md` from main to develop after v0.8.0 Squash merge

## Why

Squash merge creates a new commit on main that develop doesn't have. This causes CHANGELOG.md to diverge. This PR brings develop's CHANGELOG in sync with main.

## Test plan

- [x] CHANGELOG-only change, no code modifications
