### PR TITLE
docs(workflow): simplify release flow — merge commit instead of squash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,15 @@ git config core.hooksPath .githooks
 4. **Create PR** to `develop` (squash merge on GitHub)
 5. **Conventional Commits**: `<type>(<scope>): <description>`
 
+### Release (develop → main)
+
+1. Add a CHANGELOG entry on develop (via a feature PR)
+2. `gh pr create --base main --head develop --title "release: vX.Y.Z"`
+3. Verify CI passes: `gh pr checks <PR#>`
+4. Merge with **Create a merge commit** (NOT squash — squash breaks history sync)
+5. `auto-release.yml` auto-creates tag + GitHub Release
+6. No post-release sync PR needed
+
 ### Commit Types
 
 | Type | Description |


### PR DESCRIPTION
## Summary

- Simplify release workflow: use **merge commit** instead of squash merge for develop → main
- Add release procedure to CONTRIBUTING.md
- Remove release branch requirement (PR directly from develop to main)

## Problem

Squash merge for develop → main caused:
- Git history disconnect between main and develop after every release
- GitHub showing "N commits ahead / M commits behind" permanently
- CHANGELOG.md conflicts requiring manual resolution
- Post-release sync PRs needed every time (#74, #86, #87)

## Solution

| Before | After |
|--------|-------|
| `release/vX.Y.Z` branch from develop | PR directly from develop |
| Squash merge to main | **Merge commit** to main |
| Post-release sync PR needed | **Not needed** |
| CHANGELOG added on release branch | CHANGELOG added on develop first |

## Test plan

- [x] Documentation-only change (CONTRIBUTING.md)
- [x] CLAUDE.md updated locally (gitignored, not in repo)
- [x] Memory files updated for future sessions
