### PR TITLE
release: v0.9.0

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -767,6 +767,9 @@ SearchDim にカテゴリ属性を持たせ、Tuner がパラメーターの適�
 | `best_score` | `float \| None` | これまでの最良スコア（complete trial なしの場合 `None`） |
 | `latest_score` | `float \| None` | 直近 trial のスコア（fail/pruned の場合 `None`） |
 | `latest_state` | `str` | `"complete"` / `"pruned"` / `"fail"` |
+| `round` | `int` | 現在のラウンド番号（1-indexed）。H-0068 で追加 |
+| `cumulative_trials` | `int` | 全ラウンド通算の試行数。H-0068 で追加 |
+| `expanded_dims` | `tuple[str, ...]` | このラウンドで拡張された次元名。H-0068 で追加 |
 
 ### TuneProgressCallback
 
@@ -778,7 +781,8 @@ TuneProgressCallback = Callable[[TuneProgressInfo], None]
 
 ```python
 def on_progress(info: TuneProgressInfo) -> None:
-    print(f"Trial {info.current_trial}/{info.total_trials} "
+    print(f"[Round {info.round}] Trial {info.current_trial}/{info.total_trials} "
+          f"(cumulative {info.cumulative_trials}) "
           f"score={info.latest_score} best={info.best_score}")
 
 result = model.tune(progress_callback=on_progress)
@@ -791,7 +795,108 @@ result = model.tune(progress_callback=on_progress)
 - Optuna の `study.optimize(callbacks=[...])` を活用し、各 trial 完了時に通知する。
 - `TuneProgressInfo` と `TuneProgressCallback` は `lizyml/__init__.py` の公開面に含める。
 
-## 11.5 リーク回避方針（必須で明文化）
+## 11.5 Re-tune: Study Resume + 境界検知拡張（H-0068）
+
+初回 tuning 後に追加探索を行い、さらなる精度向上を目指す。
+
+### Model.tune() の拡張パラメーター
+
+| パラメーター | デフォルト | 説明 |
+|---|---|---|
+| `resume` | `False` | `True`: 前回 Study を再利用して追加試行 |
+| `n_trials` | `None` | 追加試行数（`None` → config 値） |
+| `expand_boundary` | `None` | 境界拡張。`None`: デフォルト空間→`True`、ユーザー空間→`False` |
+| `boundary_threshold` | `0.05` | 端判定閾値（0.0〜1.0） |
+
+### 境界検知ルール
+
+- **linear 空間**: `(best - low) / (high - low) < threshold` → 下限近傍
+- **log 空間**: 対数空間で同一計算
+- **categorical**: 拡張不可（ログ通知のみ）
+
+### 非対称拡張ルール
+
+- linear: 端方向に `(high - low)` を追加（range 2 倍）
+- log: 端方向に対数空間で 3 倍に拡張
+- `IntDim`: `max(1, new_low)` で下限ガード
+- 反対側の端は据え置き
+
+### RoundSummary / BoundaryReport
+
+```python
+@dataclass(frozen=True)
+class RoundSummary:
+    round: int                        # 1-indexed
+    n_trials: int
+    best_score_before: float | None
+    best_score_after: float
+    expanded_dims: tuple[str, ...]
+    space_snapshot: tuple[SearchDim, ...]
+
+@dataclass(frozen=True)
+class BoundaryDimStatus:
+    name: str
+    best_value: float | int | str | None
+    low: float | int | None
+    high: float | int | None
+    position_pct: float | None
+    edge: str                    # "lower" | "upper" | "none"
+    expanded: bool
+    new_low: float | int | None
+    new_high: float | int | None
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    dims: tuple[BoundaryDimStatus, ...]
+    expanded_names: tuple[str, ...]
+```
+
+### TuningResult 拡張
+
+```python
+# 追加フィールド
+rounds: tuple[RoundSummary, ...]        # デフォルト: (RoundSummary(round=1, ...),)
+boundary_report: BoundaryReport | None  # resume 時のみ設定
+```
+
+### TrialResult 拡張
+
+```python
+round: int  # 追加: どのラウンドの試行か (1-indexed)。デフォルト 1
+```
+
+### tuning_table() 拡張
+
+`round` 列と `state` 列を追加。
+
+### boundary_table() 新設
+
+`BoundaryReport` を DataFrame に変換。列: `dim`, `best`, `low`, `high`, `position`, `edge`, `expanded`, `new_low`, `new_high`。
+
+### plot_tuning_history() 拡張
+
+- ラウンド境界に縦の破線
+- ラウンドごとのアノテーション（拡張次元名）
+- best score 累積線はラウンドをまたいで連続
+
+### Widget / Studio 連携
+
+LizyML Core は callback + 結果型でデータを提供し、Widget/Studio が消費する設計。
+
+| 消費者 | 情報源 | 用途 |
+|---|---|---|
+| Widget（リアルタイム） | `TuneProgressInfo.round`, `.cumulative_trials`, `.expanded_dims` | 進捗バー、拡張パネル |
+| Studio（ダッシュボード） | `TuningResult.rounds`, `.boundary_report` | Round History、Search Space Evolution、収束判定 |
+
+収束判定（`expanded_dims` 空 + 改善微小 → fit 推奨）は Widget/Studio 側の責務。Core は判断材料のみ提供する。
+
+### 制約
+
+- `resume=False` は現在と同一動作（完全後方互換）
+- `resume=True` で未 tune → `LizyMLError(TUNING_FAILED)`
+- Tuner は study オブジェクトの受け取り・返却に対応するが、study の永続化（RDB storage 等）は対象外
+
+## 11.6 リーク回避方針（必須で明文化）
 
 - 最適化に使った CV で最終性能を主張しない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Re-tune: Study Resume + Boundary Expansion** (H-0068)
+  - `Model.tune(resume=True)` resumes from the previous Optuna Study with additional trials; TPE sampler reuses knowledge from prior trials and previous best params are enqueued as a warm-start trial
+  - Automatic boundary detection identifies dimensions where best params are near the search space edge
+  - Asymmetric space expansion extends promising directions only (linear: 2× range, log: 3× in log space)
+  - `TuningResult.rounds` tracks per-round history (`RoundSummary` with scores, expanded dims, space snapshots)
+  - `TuningResult.boundary_report` provides dimension-by-dimension boundary analysis (`BoundaryReport` / `BoundaryDimStatus`)
+  - `Model.boundary_table()` returns boundary detection results as a DataFrame
+  - `TuneProgressInfo` gains `round`, `cumulative_trials`, `expanded_dims` for real-time progress monitoring
+  - `TrialResult.round` indicates which re-tune round each trial belongs to
+  - `tuning_table()` includes `round` and `state` columns
+  - `plot_tuning_history()` shows round boundary separators with expanded dimension annotations
+  - New public types exported from `lizyml`: `BoundaryReport`, `BoundaryDimStatus`, `RoundSummary`
+  - Fully backward compatible: `tune()` with no new parameters behaves identically to previous versions
+
 ## [0.8.1] - 2026-04-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.9.0] - 2026-04-12
 
 ### Added
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5067,3 +5067,272 @@ H-0064 で導入された feval metric（f1, brier, ece, precision_at_k, accurac
 - 各バグに対する回帰テスト（16 件追加）
 - 既存テスト 1478 件が引き続き PASS（テスト総数 1495）
 - 品質ゲート（ruff / mypy / pytest）全 PASS
+
+## H-0068: Re-tune（Study Resume + 境界検知拡張）
+
+- **ステータス**: Accepted
+- **起票日**: 2026-04-11
+- **スコープ**: Public API | Tuning | Types
+- **関連**: BLUEPRINT.md §11, H-0048 (Progress Callback), H-0050 (TuningResult 3分割)
+
+### 目的
+
+初回 tuning 後に追加探索を行い、さらなる精度向上を目指す re-tune 機能を提供する。主に以下の 2 つの機能で構成する:
+
+1. **Study Resume**: 前回の Optuna Study を保持し、追加試行を行う（TPE が過去試行から学習済み）
+2. **境界検知 + 非対称拡張**: best params が探索空間の端に張り付いている次元を自動検知し、有望方向にのみ探索空間を拡張する
+
+狭めるのではなく「まだ見ていない有望領域を探しに行く」発想。
+
+### 背景・調査結果
+
+- **Optuna**: `study.optimize()` 再呼び出しで試行追加可能。TPE sampler は過去試行を自動活用。`enqueue_trial()` で前回 best を初期候補に注入可能。
+- **FLAML**: `points_to_evaluate` + progressive widening（低コスト→高コスト）。
+- **PBT (DeepMind)**: best の ×0.8/×1.2 摂動で次世代生成。探索空間に明示境界なし。
+- **共通リスク**: 同一 validation fold での繰り返し評価は過適合を招く。LizyML は OOF 評価のため単純リークはないが、試行数増加による選択バイアスは残る。
+
+### Proposal
+
+#### 1. `Model.tune()` API 拡張
+
+```python
+def tune(
+    self,
+    data: pd.DataFrame | None = None,
+    *,
+    resume: bool = False,
+    n_trials: int | None = None,
+    expand_boundary: bool | None = None,
+    boundary_threshold: float = 0.05,
+    progress_callback: TuneProgressCallback | None = None,
+) -> TuningResult:
+```
+
+| パラメーター | デフォルト | 説明 |
+|---|---|---|
+| `resume` | `False` | `True` の場合、前回の Study を再利用して追加試行を行う |
+| `n_trials` | `None` | 追加試行数。`None` の場合 `config.tuning.optuna.params.n_trials` を使用 |
+| `expand_boundary` | `None` | 境界拡張の有無。`None` の場合、デフォルト空間では `True`、ユーザー指定空間では `False` |
+| `boundary_threshold` | `0.05` | 端判定の閾値（0.0〜1.0）。best の位置が端から threshold 以内なら拡張候補 |
+
+制約:
+- `resume=False` は現在と同一動作（完全な後方互換）
+- `resume=True` で `tune()` 未呼び出しの場合は `LizyMLError(TUNING_FAILED)` を送出
+- `expand_boundary=True` でユーザー指定空間の場合も動作する（明示許可）
+
+#### 2. 境界検知ロジック
+
+`tuning/search_space.py` に `detect_boundary()` と `expand_dims()` を追加。
+
+**検知ルール**:
+- `FloatDim` / `IntDim`（linear）: `(best - low) / (high - low) < threshold` → 下限近傍、`(high - best) / (high - low) < threshold` → 上限近傍
+- `FloatDim` / `IntDim`（log）: 対数空間で同一の計算を行う
+- `CategoricalDim`: 拡張不可（ログで通知のみ）
+
+**拡張ルール**:
+- linear: 端方向に `(high - low)` を追加（つまり range を 2 倍に拡張）
+- log: 端方向に対数空間で 3 倍に拡張（例: low=0.0001 → low=0.0000333）
+- `IntDim`: 拡張後の値を int に丸める。low は `max(1, new_low)` で下限ガード
+- 反対側の端は据え置き（非対称拡張）
+
+**戻り値型**:
+
+```python
+@dataclass(frozen=True)
+class BoundaryDimStatus:
+    name: str
+    best_value: float | int | str | None
+    low: float | int | None
+    high: float | int | None
+    position_pct: float | None   # 0.0〜1.0
+    edge: str                    # "lower" | "upper" | "none"
+    expanded: bool
+    new_low: float | int | None
+    new_high: float | int | None
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    dims: tuple[BoundaryDimStatus, ...]
+    expanded_names: tuple[str, ...]
+```
+
+#### 3. Tuner の Study 保持
+
+`Tuner.tune()` に `study` 引数を追加（省略時は従来通り新規作成）。`enqueue_trial` で前回 best を注入。
+
+```python
+def tune(
+    self,
+    objective: Any,
+    metric_name: str = "rmse",
+    *,
+    study: Any | None = None,
+    enqueue_params: dict[str, Any] | None = None,
+) -> tuple[TuningResult, Any]:
+    # Returns (result, study) — study を Model が保持して resume に使う
+```
+
+#### 4. TuningResult 拡張
+
+```python
+@dataclass(frozen=True)
+class RoundSummary:
+    round: int                        # 1-indexed
+    n_trials: int
+    best_score_before: float | None   # ラウンド開始前の best
+    best_score_after: float           # ラウンド終了時の best
+    expanded_dims: tuple[str, ...]
+    space_snapshot: tuple[SearchDim, ...]
+
+@dataclass(frozen=True)
+class TuningResult:
+    # --- 既存（変更なし） ---
+    best_model_params: dict[str, Any]
+    best_smart_params: dict[str, Any]
+    best_training_params: dict[str, Any]
+    best_score: float
+    trials: list[TrialResult]
+    metric_name: str
+    direction: str
+    # --- 追加 ---
+    rounds: tuple[RoundSummary, ...]
+    boundary_report: BoundaryReport | None
+```
+
+- `rounds` のデフォルトは `(RoundSummary(round=1, ...),)`（初回 tune でも 1 要素）
+- `boundary_report` は `resume=True` 時のみ設定。初回 tune では `None`
+
+#### 5. TuneProgressInfo 拡張
+
+```python
+@dataclass(frozen=True)
+class TuneProgressInfo:
+    # --- 既存 ---
+    current_trial: int
+    total_trials: int
+    elapsed_seconds: float
+    best_score: float | None
+    latest_score: float | None
+    latest_state: str
+    # --- 追加 ---
+    round: int                          # 1-indexed
+    cumulative_trials: int              # 全ラウンド通算
+    expanded_dims: tuple[str, ...]      # このラウンドで拡張された次元名
+```
+
+#### 6. TrialResult 拡張
+
+```python
+@dataclass(frozen=True)
+class TrialResult:
+    number: int
+    params: dict[str, Any]
+    score: float
+    state: str
+    round: int  # 追加: どのラウンドの試行か (1-indexed)
+```
+
+#### 7. tuning_table() 拡張
+
+`round` 列と `state` 列を追加:
+
+```
+trial  round  rmse     learning_rate  num_leaves  state
+0      1      0.312    0.005          128         complete
+...
+50     2      0.283    0.00008        300         complete
+```
+
+#### 8. boundary_table() 新設
+
+`_model_tables.py` に `boundary_table()` メソッドを追加:
+
+```
+dim               best     low       high     position  edge   expanded  new_low  new_high
+learning_rate     0.00015  0.0001    0.1      1.1%      lower  True      0.00001  0.1
+num_leaves        251      16        256      97.9%     upper  True      16       512
+feature_fraction  0.72     0.5       1.0      44.0%     none   False     —        —
+```
+
+#### 9. plot_tuning_history() 拡張
+
+- ラウンド境界に縦の破線を追加
+- ラウンドごとにアノテーション（拡張された次元名）
+- best score の累積線はラウンドをまたいで連続描画
+
+#### 10. ログ出力
+
+```
+INFO  tune.resume: expanding 2 of 5 dims
+        learning_rate: lower bound 0.0001 → 0.00001 (best 0.00015 near lower edge)
+        num_leaves: upper bound 256 → 512 (best 251 near upper edge)
+INFO  tune.resume: enqueued previous best as initial trial
+INFO  tune.resume: starting 30 additional trials (80 cumulative)
+```
+
+#### 11. Widget / Studio 連携仕様
+
+LizyML Core は callback + 結果型でデータを提供し、Widget/Studio が消費する。
+
+**Widget（リアルタイムモニタ）向け情報**:
+
+| Widget 要素 | 情報源 |
+|---|---|
+| Round 表示 | `TuneProgressInfo.round` |
+| 進捗バー | `TuneProgressInfo.cumulative_trials` |
+| 改善幅 | `best_score` vs `RoundSummary.best_score_before` |
+| 拡張パネル | `TuneProgressInfo.expanded_dims` |
+| Score History | callback 呼び出しごとに蓄積 |
+
+**Studio（ダッシュボード）向け情報**:
+
+| Studio 要素 | 情報源 |
+|---|---|
+| Round History テーブル | `TuningResult.rounds` |
+| Search Space Evolution | `RoundSummary.space_snapshot` |
+| 収束判定 | `expanded_dims == ()` AND 改善 < threshold |
+| boundary_table() | `TuningResult.boundary_report` |
+
+収束判定ロジック自体は LizyML Core には含めず、Studio/Widget 側の責務とする。Core は判断材料のみを提供する。
+
+### 影響範囲
+
+- `lizyml/core/types/tuning_result.py` — TuningResult, TuneProgressInfo, TrialResult 拡張 + RoundSummary, BoundaryReport, BoundaryDimStatus 追加
+- `lizyml/tuning/search_space.py` — detect_boundary(), expand_dims() 追加
+- `lizyml/tuning/tuner.py` — study 引数追加、enqueue_trial 対応
+- `lizyml/core/model.py` — tune() に resume/n_trials/expand_boundary/boundary_threshold 追加、`_study` 保持
+- `lizyml/core/_model_tables.py` — tuning_table() に round/state 列追加、boundary_table() 新設
+- `lizyml/plots/tuning.py` — plot_tuning_history() にラウンド区切り線追加
+- `lizyml/__init__.py` — 新型の公開面追加
+
+### 互換性
+
+- `tune()` のデフォルト動作は変更なし（`resume=False`）→ 完全後方互換
+- `TuningResult` に `rounds` と `boundary_report` フィールドが追加される。既存コードで positional args を使っている場合は影響があるが、frozen dataclass は keyword-only 使用が慣例
+- `TuneProgressInfo` に 3 フィールド追加。callback が属性アクセスで使用している場合は影響なし（追加方向）
+- `TrialResult` に `round` フィールド追加（デフォルト `1`）。追加方向
+- `tuning_table()` に `round` と `state` 列が追加される（追加方向）
+- `plot_tuning_history()` は初回 tune のみの場合、区切り線なしで従来と同一表示
+
+### 代替案
+
+1. **Space Narrowing（探索空間絞り込み）**: best 周辺に範囲を狭める。真の最適が範囲外にある場合に見逃すリスクが高い。過適合リスクも拡張型より高い。
+2. **Successive Halving**: n_estimators を段階的に増やす多段評価。LizyML の CV ベース評価とは設計思想が異なる。
+3. **拡張なしの純粋 Resume のみ**: 実装は簡単だが、探索空間の端に張り付いた場合に改善の余地がない。
+
+### 受け入れ基準（テスト観点）
+
+1. `resume=False` で既存テストが全 PASS（後方互換）
+2. `resume=True` で累計試行数が正しく増加し、best_score が悪化しない
+3. 境界検知: 端に張り付いた次元が正しく検知される（linear/log/categorical 各ケース）
+4. 非対称拡張: 端方向のみ拡張され、反対側は据え置き
+5. `TuningResult.rounds` が正しい RoundSummary を含む
+6. `TuneProgressInfo` の追加フィールドが正しく報告される
+7. `TrialResult.round` が正しいラウンド番号を持つ
+8. `tuning_table()` に `round` / `state` 列が存在する
+9. `boundary_table()` が BoundaryReport を正しく DataFrame に変換する
+10. `plot_tuning_history()` でラウンド境界が描画される
+11. ユーザー指定空間 + `expand_boundary=None` → 拡張されない
+12. デフォルト空間 + `expand_boundary=None` → 拡張される
+13. `resume=True` で未 tune → `TUNING_FAILED` エラー
+14. 品質ゲート（ruff / mypy / pytest）全 PASS

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,10 @@ def tune(
     self,
     data: pd.DataFrame | None = None,
     *,
+    resume: bool = False,
+    n_trials: int | None = None,
+    expand_boundary: bool | None = None,
+    boundary_threshold: float = 0.05,
     progress_callback: TuneProgressCallback | None = None,
 ) -> TuningResult
 ```
@@ -77,16 +81,27 @@ def tune(
 Runs Optuna-based hyperparameter search. Best params are stored internally and
 applied automatically on the next `fit()` call.
 
+Call with `resume=True` after an initial `tune()` to add trials to the existing
+Optuna study. The TPE sampler reuses knowledge from previous trials, and the
+previous best params are enqueued as a warm-start trial. When `expand_boundary`
+is enabled, dimensions whose best params are near the search space edge are
+automatically expanded in the promising direction (H-0068).
+
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `data` | `pd.DataFrame \| None` | Training DataFrame. |
+| `resume` | `bool` | If `True`, resume from the previous Study and add trials. Requires a prior `tune()` call. |
+| `n_trials` | `int \| None` | Number of trials. `None` uses the config value. |
+| `expand_boundary` | `bool \| None` | Auto-expand dims near boundary. `None` means `True` for default space, `False` for user-specified space. |
+| `boundary_threshold` | `float` | Edge detection threshold (0.0–0.5). Best values within this fraction of the range from either edge trigger expansion. |
 | `progress_callback` | `TuneProgressCallback \| None` | Called after each trial with a `TuneProgressInfo`. Exceptions inside the callback are caught and emitted as `RuntimeWarning`; tuning is never aborted. |
 
 **Returns:** [`TuningResult`](#tuningresult)
 
 **Raises:**
-- `LizyMLError(CONFIG_INVALID)` — no `tuning` section in config.
+- `LizyMLError(CONFIG_INVALID)` — no `tuning` section in config, or `boundary_threshold` out of range.
 - `LizyMLError(OPTIONAL_DEP_MISSING)` — `optuna` not installed.
+- `LizyMLError(TUNING_FAILED)` — `resume=True` without prior `tune()` call.
 - `LizyMLError(TUNING_FAILED)` — study failure.
 
 ---
@@ -289,7 +304,8 @@ artifact).
 | `residuals()` | regression | OOF residuals `(y_true - oof_pred)`, shape `(n_samples,)`. |
 | `split_summary()` | all | Per-fold split sizes as a DataFrame. |
 | `params_table()` | all | Resolved model parameters as a single-column DataFrame. |
-| `tuning_table()` | all | All tuning trial results; requires `tune()` first. |
+| `tuning_table()` | all | All tuning trial results with `round` and `state` columns; requires `tune()` first. |
+| `boundary_table()` | all | Boundary detection results per dimension; requires `tune(resume=True, expand_boundary=True)` (H-0068). |
 | `residuals_plot()` | regression | Plotly residual diagnostic plots. |
 | `roc_curve_plot()` | binary/multiclass | OOF ROC curve. |
 | `calibration_plot()` | binary | Calibration reliability diagram. |
@@ -360,9 +376,73 @@ Result of a full hyperparameter search.
 | `best_smart_params` | `dict` | Best smart parameters (e.g. `pos_weight_ratio`). |
 | `best_training_params` | `dict` | Best training parameters (e.g. `num_boost_round`). |
 | `best_score` | `float` | Best OOF score achieved. |
-| `trials` | `list[TrialResult]` | All trial results (number, params, score, state). |
+| `trials` | `list[TrialResult]` | All trial results (number, params, score, state, round). |
 | `metric_name` | `str` | Name of the metric used for optimization. |
 | `direction` | `str` | `"minimize"` or `"maximize"`. |
+| `rounds` | `tuple[RoundSummary, ...]` | Per-round tuning history (H-0068). Empty tuple for single-round tuning. |
+| `boundary_report` | `BoundaryReport \| None` | Boundary detection results (H-0068). Set only when `resume=True` with `expand_boundary` enabled. |
+
+### TrialResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `number` | `int` | Trial index (0-based). |
+| `params` | `dict` | Parameters sampled in this trial. |
+| `score` | `float` | Objective value (NaN if failed). |
+| `state` | `str` | `"complete"`, `"pruned"`, or `"fail"`. |
+| `round` | `int` | Which re-tune round this trial belongs to (1-indexed, H-0068). |
+
+### RoundSummary
+
+Summary of a single tuning round (H-0068).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `round` | `int` | Round number (1-indexed). |
+| `n_trials` | `int` | Number of trials in this round. |
+| `best_score_before` | `float \| None` | Best score at start of round (`None` for round 1). |
+| `best_score_after` | `float` | Best score at end of round. |
+| `expanded_dims` | `tuple[str, ...]` | Names of dimensions expanded before this round. |
+| `space_snapshot` | `tuple[SearchDim, ...]` | Search space used in this round. |
+
+### BoundaryReport
+
+Boundary detection results for all dimensions (H-0068).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dims` | `tuple[BoundaryDimStatus, ...]` | Per-dimension boundary analysis. |
+| `expanded_names` | `tuple[str, ...]` | Names of dimensions that were expanded. |
+
+### BoundaryDimStatus
+
+Per-dimension boundary analysis (H-0068).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Dimension name. |
+| `best_value` | `float \| int \| str \| None` | Best parameter value found. |
+| `low` / `high` | `float \| int \| None` | Search range bounds (`None` for categorical). |
+| `position_pct` | `float \| None` | Relative position of best in [0.0, 1.0] (`None` for categorical). |
+| `edge` | `str` | `"lower"`, `"upper"`, or `"none"`. |
+| `expanded` | `bool` | Whether this dim was expanded. |
+| `new_low` / `new_high` | `float \| int \| None` | New bounds after expansion (`None` if not expanded). |
+
+### TuneProgressInfo
+
+Progress information emitted after each tuning trial (H-0048, H-0068).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `current_trial` | `int` | Current trial number in this round (1-indexed). |
+| `total_trials` | `int` | Total trials in this round. |
+| `elapsed_seconds` | `float` | Time elapsed since `tune()` started. |
+| `best_score` | `float \| None` | Best score so far. |
+| `latest_score` | `float \| None` | Score of the latest trial (`None` if fail/pruned). |
+| `latest_state` | `str` | `"complete"`, `"pruned"`, or `"fail"`. |
+| `round` | `int` | Current round number (1-indexed, H-0068). |
+| `cumulative_trials` | `int` | Total trials across all rounds (H-0068). |
+| `expanded_dims` | `tuple[str, ...]` | Dimensions expanded in this round (H-0068). |
 
 ---
 

--- a/lizyml/__init__.py
+++ b/lizyml/__init__.py
@@ -2,10 +2,19 @@
 
 from lizyml._version import __version__, __version_tuple__
 from lizyml.core.model import Model
-from lizyml.core.types.tuning_result import TuneProgressCallback, TuneProgressInfo
+from lizyml.core.types.tuning_result import (
+    BoundaryDimStatus,
+    BoundaryReport,
+    RoundSummary,
+    TuneProgressCallback,
+    TuneProgressInfo,
+)
 
 __all__ = [
+    "BoundaryDimStatus",
+    "BoundaryReport",
     "Model",
+    "RoundSummary",
     "TuneProgressCallback",
     "TuneProgressInfo",
     "__version__",

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -207,10 +207,52 @@ class ModelTablesMixin:
         for t in tr.trials:
             row: dict[str, Any] = {
                 "trial": t.number,
+                "round": t.round,
                 tr.metric_name: t.score,
                 **t.params,
+                "state": t.state,
             }
             rows.append(row)
+        return pd.DataFrame(rows)
+
+    def boundary_table(self) -> pd.DataFrame:
+        """Return a DataFrame of boundary detection results (H-0068).
+
+        Columns: ``dim``, ``best``, ``low``, ``high``, ``position``,
+        ``edge``, ``expanded``, ``new_low``, ``new_high``.
+
+        Returns:
+            DataFrame with one row per search dimension.
+
+        Raises:
+            LizyMLError with MODEL_NOT_FIT when ``tune(resume=True)`` has
+            not been called or no boundary report exists.
+        """
+        if self._tuning_result is None or self._tuning_result.boundary_report is None:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message=(
+                    "No boundary report available. "
+                    "Run tune(resume=True) to generate a boundary report."
+                ),
+                context={},
+            )
+        report = self._tuning_result.boundary_report
+        rows = []
+        for s in report.dims:
+            rows.append(
+                {
+                    "dim": s.name,
+                    "best": s.best_value,
+                    "low": s.low,
+                    "high": s.high,
+                    "position": s.position_pct,
+                    "edge": s.edge,
+                    "expanded": s.expanded,
+                    "new_low": s.new_low,
+                    "new_high": s.new_high,
+                }
+            )
         return pd.DataFrame(rows)
 
     def params_table(self) -> pd.DataFrame:

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -188,7 +188,8 @@ class ModelTablesMixin:
     def tuning_table(self) -> pd.DataFrame:
         """Return a DataFrame of all tuning trial results.
 
-        Columns: ``trial``, metric name, and each searched parameter name.
+        Columns: ``trial``, ``round``, metric name, each searched parameter
+        name, and ``state``.
 
         Returns:
             DataFrame with one row per trial.

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -57,7 +57,12 @@ from lizyml.core.train_components import TrainComponents
 from lizyml.core.types.artifacts import RunMeta
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.predict_result import PredictionResult
-from lizyml.core.types.tuning_result import TuneProgressCallback, TuningResult
+from lizyml.core.types.tuning_result import (
+    BoundaryReport,
+    RoundSummary,
+    TuneProgressCallback,
+    TuningResult,
+)
 from lizyml.data import dataframe_builder, datasource
 from lizyml.data.dataframe_builder import DataFrameComponents
 from lizyml.data.fingerprint import compute as fp_compute
@@ -67,6 +72,8 @@ from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
 from lizyml.training.refit_trainer import RefitResult, RefitTrainer
 from lizyml.tuning.search_space import (
+    detect_boundary,
+    expand_dims,
     parse_space,
     split_by_category,
     suggest_params,
@@ -130,6 +137,12 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         self._X: pd.DataFrame | None = None  # transient; not persisted
         self._provider: EstimatorProvider | None = None  # set by fit/tune
         self._block_values: npt.NDArray[Any] | None = None  # _prepare_training_data
+        # H-0068: re-tune state
+        self._study: Any = None  # Optuna study for resume
+        self._round_number: int = 0  # completed rounds count
+        self._rounds: list[RoundSummary] = []  # round history
+        self._space: list[Any] | None = None  # last search space used
+        self._used_default_space: bool = False  # track for expand_boundary default
 
     # ------------------------------------------------------------------
     # Public API
@@ -364,9 +377,13 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         self,
         data: pd.DataFrame | None = None,
         *,
+        resume: bool = False,
+        n_trials: int | None = None,
+        expand_boundary: bool | None = None,
+        boundary_threshold: float = 0.05,
         progress_callback: TuneProgressCallback | None = None,
     ) -> TuningResult:
-        """Run hyperparameter search with optuna.
+        """Run hyperparameter search with optuna (H-0068: resume + expand).
 
         Requires ``tuning`` section in the config.  Best params are stored
         internally and used automatically in the next ``fit()`` call.
@@ -374,11 +391,15 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         Args:
             data: Training DataFrame.  Overrides any data from construction
                 or ``data.path`` in config.
+            resume: If True, resume from the previous Study and add trials.
+                The TPE sampler reuses knowledge from previous trials.
+            n_trials: Number of trials to run.  Defaults to
+                ``config.tuning.optuna.params.n_trials`` if None.
+            expand_boundary: Whether to auto-expand search space dimensions
+                whose best params are near the boundary.  None means True
+                for default space, False for user-specified space.
+            boundary_threshold: Edge detection threshold (0.0–1.0).
             progress_callback: Optional callback invoked after each trial.
-                Receives a :class:`TuneProgressInfo` with current trial,
-                total trials, elapsed time, best/latest score, and state.
-                Exceptions raised inside the callback are caught and emitted
-                as ``RuntimeWarning``; tuning is never aborted.
 
         Returns:
             :class:`~lizyml.core.types.tuning_result.TuningResult` with
@@ -387,7 +408,8 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         Raises:
             LizyMLError with CONFIG_INVALID when no ``tuning`` config is set.
             LizyMLError with OPTIONAL_DEP_MISSING when optuna is not installed.
-            LizyMLError with TUNING_FAILED on study failure.
+            LizyMLError with TUNING_FAILED on study failure or resume without
+                prior tune().
         """
         cfg = self._cfg
         if cfg.tuning is None:
@@ -400,7 +422,25 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 context={},
             )
 
-        _log.info("event='tune.start' task=%s", cfg.task)
+        if resume and self._study is None:
+            raise LizyMLError(
+                code=ErrorCode.TUNING_FAILED,
+                user_message=(
+                    "Cannot resume tuning: no previous tune() call. "
+                    "Run tune() first, then tune(resume=True)."
+                ),
+                context={},
+            )
+
+        optuna_cfg = cfg.tuning.optuna.params
+        actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
+
+        _log.info(
+            "event='tune.start' task=%s resume=%s n_trials=%d",
+            cfg.task,
+            resume,
+            actual_n_trials,
+        )
 
         self._ensure_run_dir(generate_run_id())
         X, y, groups, _ = self._prepare_training_data(data)
@@ -417,17 +457,58 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         )
         base_model_params, base_smart_params = self._merge_params(provider)
 
-        user_space = parse_space(cfg.tuning.optuna.space)
-        if user_space:
-            space = user_space
-            fixed: dict[str, Any] = {}
+        # --- Resolve search space ------------------------------------------------
+        if resume and self._space is not None:
+            space = list(self._space)
+            used_default = self._used_default_space
         else:
-            space = provider.default_space(cfg.task)
-            fixed = provider.default_fixed_params(cfg.task)
+            user_space = parse_space(cfg.tuning.optuna.space)
+            if user_space:
+                space = user_space
+                used_default = False
+            else:
+                space = provider.default_space(cfg.task)
+                used_default = True
 
-        optuna_cfg = cfg.tuning.optuna.params
+        fixed: dict[str, Any] = (
+            provider.default_fixed_params(cfg.task) if used_default else {}
+        )
+
+        # --- H-0068: boundary detection + expansion ------------------------------
+        boundary_report: BoundaryReport | None = None
+        expanded_names: tuple[str, ...] = ()
+        if resume and self._tuning_result is not None:
+            should_expand = expand_boundary
+            if should_expand is None:
+                should_expand = used_default
+
+            if should_expand:
+                boundary_report = detect_boundary(
+                    space, self._tuning_result.best_params, boundary_threshold
+                )
+                expanded_names = boundary_report.expanded_names
+                if expanded_names:
+                    space = expand_dims(space, boundary_report)
+                    for name in expanded_names:
+                        status = next(s for s in boundary_report.dims if s.name == name)
+                        _log.info(
+                            "event='tune.expand' dim=%s edge=%s "
+                            "old=[%s, %s] new=[%s, %s] best=%s",
+                            name,
+                            status.edge,
+                            status.low,
+                            status.high,
+                            status.new_low,
+                            status.new_high,
+                            status.best_value,
+                        )
+                else:
+                    _log.info("event='tune.resume' no dims near boundary")
+            else:
+                _log.info("event='tune.resume' expand_boundary=False")
+
+        # --- Metric & evaluator setup --------------------------------------------
         metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
-        # Extract the first metric name for optimisation scoring
         from lizyml.metrics.registry import parse_metric_entry
 
         first_entry = metric_entries[0]
@@ -437,14 +518,12 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         fingerprint = fp_compute(X, file_path=None)
         run_meta = self._build_run_meta(generate_run_id())
 
-        # --- Build objective closure (H-0050: uses _build_train_components) ---
+        # --- Build objective closure (H-0050: uses _build_train_components) -------
         def objective(trial: Any) -> float:
             trial_params = suggest_params(trial, space)
             model_p, smart_p, training_p = split_by_category(trial_params, space)
 
-            # Merge: fixed + base config + trial model params
             merged_model = {**base_model_params, **fixed, **model_p}
-            # Merge: base smart + trial smart params
             merged_smart = {**base_smart_params, **smart_p}
 
             tc = self._build_train_components(
@@ -477,19 +556,100 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             score: float = metrics["raw"]["oof"][metric_name]
             return score
 
+        # --- Run tuner ------------------------------------------------------------
+        round_number = self._round_number + 1
+        prior_trials = (
+            len(self._study.trials) if resume and self._study is not None else 0
+        )
+        best_score_before = (
+            self._tuning_result.best_score
+            if resume and self._tuning_result is not None
+            else None
+        )
+
+        # Enqueue previous best for warm-start (H-0068)
+        enqueue = (
+            dict(self._tuning_result.best_params)
+            if resume and self._tuning_result is not None
+            else None
+        )
+
         tuner = Tuner(
             dims=space,
-            n_trials=optuna_cfg.n_trials,
+            n_trials=actual_n_trials,
             direction=optuna_cfg.direction,
             timeout=optuna_cfg.timeout,
             seed=cfg.training.seed,
             progress_callback=progress_callback,
         )
 
-        result = tuner.tune(objective, metric_name=metric_name)
-        self._tuning_result = result
-        _log.info("event='tune.done' best_params=%s", result.best_params)
-        return result
+        result, study = tuner.tune(
+            objective,
+            metric_name=metric_name,
+            study=self._study if resume else None,
+            enqueue_params=enqueue,
+            round_number=round_number,
+            prior_trials=prior_trials,
+            expanded_dims=expanded_names,
+        )
+
+        # --- Build round summary and fix trial round numbers ---------------------
+        round_summary = RoundSummary(
+            round=round_number,
+            n_trials=actual_n_trials,
+            best_score_before=best_score_before,
+            best_score_after=result.best_score,
+            expanded_dims=expanded_names,
+            space_snapshot=tuple(space),
+        )
+
+        # Preserve previous rounds + add current
+        all_rounds = tuple(self._rounds) + (round_summary,)
+
+        # Fix up trial round numbers: trials from previous rounds keep their
+        # original round, new trials get current round_number
+        fixed_trials = []
+        for t in result.trials:
+            if t.number < prior_trials:
+                # Find which round this trial belonged to
+                trial_round = 1
+                cumulative = 0
+                for rs in self._rounds:
+                    cumulative += rs.n_trials
+                    if t.number < cumulative:
+                        trial_round = rs.round
+                        break
+                fixed_trials.append(dataclasses.replace(t, round=trial_round))
+            else:
+                fixed_trials.append(dataclasses.replace(t, round=round_number))
+
+        # Rebuild result with rounds and boundary_report
+        final_result = TuningResult(
+            best_model_params=result.best_model_params,
+            best_smart_params=result.best_smart_params,
+            best_training_params=result.best_training_params,
+            best_score=result.best_score,
+            trials=fixed_trials,
+            metric_name=result.metric_name,
+            direction=result.direction,
+            rounds=all_rounds,
+            boundary_report=boundary_report,
+        )
+
+        # --- Update internal state -----------------------------------------------
+        self._tuning_result = final_result
+        self._study = study
+        self._round_number = round_number
+        self._rounds = list(all_rounds)
+        self._space = space
+        self._used_default_space = used_default
+
+        _log.info(
+            "event='tune.done' round=%d best_params=%s",
+            round_number,
+            final_result.best_params,
+        )
+        return final_result
 
     # ------------------------------------------------------------------
     # Properties

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -568,21 +568,16 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
         # --- Run tuner ------------------------------------------------------------
         round_number = self._round_number + 1
-        prior_trials = (
-            len(self._study.trials) if resume and self._study is not None else 0
-        )
-        best_score_before = (
-            self._tuning_result.best_score
-            if resume and self._tuning_result is not None
-            else None
-        )
-
-        # Enqueue previous best for warm-start (H-0068)
-        enqueue = (
-            dict(self._tuning_result.best_params)
-            if resume and self._tuning_result is not None
-            else None
-        )
+        prior_trials = 0
+        best_score_before: float | None = None
+        enqueue: dict[str, Any] | None = None
+        if resume:
+            # Guaranteed non-None: validated at the top of tune()
+            assert self._study is not None
+            assert self._tuning_result is not None
+            prior_trials = len(self._study.trials)
+            best_score_before = self._tuning_result.best_score
+            enqueue = dict(self._tuning_result.best_params)
 
         tuner = Tuner(
             dims=space,

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -432,6 +432,16 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 context={},
             )
 
+        if not 0.0 < boundary_threshold < 0.5:
+            raise LizyMLError(
+                code=ErrorCode.CONFIG_INVALID,
+                user_message=(
+                    f"boundary_threshold must be in (0.0, 0.5), "
+                    f"got {boundary_threshold}."
+                ),
+                context={"boundary_threshold": boundary_threshold},
+            )
+
         optuna_cfg = cfg.tuning.optuna.params
         actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
 

--- a/lizyml/core/types/tuning_result.py
+++ b/lizyml/core/types/tuning_result.py
@@ -1,10 +1,87 @@
-"""TuningResult — result types for hyperparameter tuning (H-0023, H-0048)."""
+"""TuningResult — result types for hyperparameter tuning (H-0023, H-0048, H-0068)."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+from lizyml.core.types.search_dim import SearchDim
+
+# ---------------------------------------------------------------------------
+# Boundary detection types (H-0068)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoundaryDimStatus:
+    """Boundary analysis for a single search dimension (H-0068).
+
+    Attributes:
+        name: Dimension name.
+        best_value: Best parameter value found.
+        low: Lower bound of the search range (None for categorical).
+        high: Upper bound of the search range (None for categorical).
+        position_pct: Relative position of best in [0.0, 1.0] (None for categorical).
+        edge: Which edge is near — "lower", "upper", or "none".
+        expanded: Whether this dim was expanded in the current round.
+        new_low: New lower bound after expansion (None if not expanded).
+        new_high: New upper bound after expansion (None if not expanded).
+    """
+
+    name: str
+    best_value: float | int | str | None
+    low: float | int | None
+    high: float | int | None
+    position_pct: float | None
+    edge: str  # "lower" | "upper" | "none"
+    expanded: bool
+    new_low: float | int | None
+    new_high: float | int | None
+
+
+@dataclass(frozen=True)
+class BoundaryReport:
+    """Boundary detection results for all dimensions (H-0068).
+
+    Attributes:
+        dims: Per-dimension boundary analysis.
+        expanded_names: Names of dimensions that were expanded.
+    """
+
+    dims: tuple[BoundaryDimStatus, ...]
+    expanded_names: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Round summary (H-0068)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoundSummary:
+    """Summary of a single tuning round (H-0068).
+
+    Attributes:
+        round: Round number (1-indexed).
+        n_trials: Number of trials in this round.
+        best_score_before: Best score at start of round (None for round 1).
+        best_score_after: Best score at end of round.
+        expanded_dims: Names of dimensions expanded before this round.
+        space_snapshot: Search space used in this round.
+    """
+
+    round: int
+    n_trials: int
+    best_score_before: float | None
+    best_score_after: float
+    expanded_dims: tuple[str, ...]
+    space_snapshot: tuple[SearchDim, ...]
+
+
+# ---------------------------------------------------------------------------
+# Trial result
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -15,15 +92,24 @@ class TrialResult:
     params: dict[str, Any]
     score: float
     state: str  # "complete" | "pruned" | "fail"
+    round: int = 1  # H-0068: which round this trial belongs to
 
     def __post_init__(self) -> None:
         # Deep-copy mutable fields to prevent external mutation
         object.__setattr__(self, "params", dict(self.params))
 
 
+# ---------------------------------------------------------------------------
+# Tuning result
+# ---------------------------------------------------------------------------
+
+
 @dataclass(frozen=True)
 class TuningResult:
-    """Result of a full hyperparameter search (H-0050: category-split params)."""
+    """Result of a full hyperparameter search (H-0050, H-0068).
+
+    H-0068 adds ``rounds`` and ``boundary_report`` for re-tune support.
+    """
 
     best_model_params: dict[str, Any]
     best_smart_params: dict[str, Any]
@@ -32,6 +118,9 @@ class TuningResult:
     trials: list[TrialResult]
     metric_name: str
     direction: str  # "minimize" | "maximize"
+    # H-0068: re-tune tracking
+    rounds: tuple[RoundSummary, ...] = ()
+    boundary_report: BoundaryReport | None = None
 
     def __post_init__(self) -> None:
         # Deep-copy mutable fields to prevent external mutation
@@ -52,17 +141,17 @@ class TuningResult:
         }
 
 
+# ---------------------------------------------------------------------------
+# Progress callback (H-0048, H-0068)
+# ---------------------------------------------------------------------------
+
+
 @dataclass(frozen=True)
 class TuneProgressInfo:
-    """Progress information emitted after each tuning trial (H-0048).
+    """Progress information emitted after each tuning trial (H-0048, H-0068).
 
-    Attributes:
-        current_trial: Current trial number (1-indexed).
-        total_trials: Total number of trials.
-        elapsed_seconds: Seconds elapsed since tune() started.
-        best_score: Best score so far (None if no complete trial yet).
-        latest_score: Score of the latest trial (None if fail/pruned).
-        latest_state: State of the latest trial ("complete"|"pruned"|"fail").
+    H-0068 adds round, cumulative_trials, and expanded_dims fields for
+    re-tune progress monitoring.
     """
 
     current_trial: int
@@ -71,6 +160,10 @@ class TuneProgressInfo:
     best_score: float | None
     latest_score: float | None
     latest_state: str  # "complete" | "pruned" | "fail"
+    # H-0068: re-tune progress fields
+    round: int = 1
+    cumulative_trials: int = field(default=0)
+    expanded_dims: tuple[str, ...] = ()
 
 
 TuneProgressCallback = Callable[[TuneProgressInfo], None]

--- a/lizyml/plots/tuning.py
+++ b/lizyml/plots/tuning.py
@@ -1,4 +1,4 @@
-"""Tuning history plot: trial scores and best-score progression."""
+"""Tuning history plot: trial scores, best-score progression, and round separators."""
 
 from __future__ import annotations
 
@@ -39,6 +39,9 @@ _STATE_COLORS: dict[str, str] = {
 
 def plot_tuning_history(tuning_result: TuningResult) -> Any:
     """Plot trial-by-trial score with best-score cumulative line.
+
+    When the result contains multiple rounds (H-0068), vertical dashed lines
+    are drawn at round boundaries with annotations showing expanded dims.
 
     Args:
         tuning_result: Result from ``Model.tune()``.
@@ -93,6 +96,37 @@ def plot_tuning_history(tuning_result: TuningResult) -> Any:
                 line={"color": "crimson", "width": 2, "dash": "dash"},
             )
         )
+
+    # H-0068: Round boundary separators
+    if tuning_result.rounds and len(tuning_result.rounds) > 1:
+        cumulative = 0
+        for rs in tuning_result.rounds[:-1]:
+            cumulative += rs.n_trials
+            # Vertical line at the boundary between rounds
+            fig.add_vline(
+                x=cumulative - 0.5,
+                line_dash="dot",
+                line_color="gray",
+                line_width=1,
+                opacity=0.7,
+            )
+
+        # Annotate each round
+        cumulative = 0
+        for rs in tuning_result.rounds:
+            mid_x = cumulative + rs.n_trials / 2
+            label = f"Round {rs.round}"
+            if rs.expanded_dims:
+                label += f" ({', '.join(rs.expanded_dims)})"
+            fig.add_annotation(
+                x=mid_x,
+                y=1.0,
+                yref="paper",
+                text=label,
+                showarrow=False,
+                font={"size": 10, "color": "gray"},
+            )
+            cumulative += rs.n_trials
 
     fig.update_layout(
         title="Tuning History",

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -7,6 +7,7 @@ re-exported here for backward compatibility.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
@@ -17,12 +18,17 @@ from lizyml.core.types.search_dim import (
     IntDim,
     SearchDim,
 )
+from lizyml.core.types.tuning_result import BoundaryDimStatus, BoundaryReport
 
 __all__ = [
+    "BoundaryDimStatus",
+    "BoundaryReport",
     "CategoricalDim",
     "FloatDim",
     "IntDim",
     "SearchDim",
+    "detect_boundary",
+    "expand_dims",
     "parse_space",
     "split_by_category",
     "suggest_params",
@@ -176,3 +182,194 @@ def suggest_params(trial: Any, dims: list[SearchDim]) -> dict[str, Any]:
         else:  # CategoricalDim
             params[dim.name] = trial.suggest_categorical(dim.name, dim.choices)
     return params
+
+
+# ---------------------------------------------------------------------------
+# Boundary detection and expansion (H-0068)
+# ---------------------------------------------------------------------------
+
+
+_LOG_EXPANSION_FACTOR = 3.0
+"""Expansion factor for log-scale dimensions (applied in log space)."""
+
+
+def _position_pct(best: float, low: float, high: float, *, log: bool) -> float:
+    """Compute relative position of *best* within [low, high] as 0.0–1.0."""
+    if log and low > 0 and high > 0 and best > 0:
+        log_low, log_high, log_best = math.log(low), math.log(high), math.log(best)
+        span = log_high - log_low
+        if span <= 0:
+            return 0.5
+        return (log_best - log_low) / span
+    span = high - low
+    if span <= 0:
+        return 0.5
+    return (best - low) / span
+
+
+def _detect_edge(position: float, threshold: float) -> str:
+    """Return 'lower', 'upper', or 'none' based on position and threshold."""
+    if position < threshold:
+        return "lower"
+    if position > (1.0 - threshold):
+        return "upper"
+    return "none"
+
+
+def _expand_range(
+    low: float,
+    high: float,
+    edge: str,
+    *,
+    log: bool,
+) -> tuple[float, float]:
+    """Expand *low*/*high* asymmetrically toward *edge*."""
+    if edge == "lower":
+        new_low = low / _LOG_EXPANSION_FACTOR if log and low > 0 else low - (high - low)
+        return new_low, high
+    if edge == "upper":
+        new_high = (
+            high * _LOG_EXPANSION_FACTOR if log and high > 0 else high + (high - low)
+        )
+        return low, new_high
+    return low, high
+
+
+def detect_boundary(
+    dims: list[SearchDim],
+    best_params: dict[str, Any],
+    threshold: float = 0.05,
+) -> BoundaryReport:
+    """Detect which dimensions have best params near their boundary (H-0068).
+
+    Args:
+        dims: Current search space dimensions.
+        best_params: Best parameter values from the previous tuning round.
+        threshold: Edge detection threshold (0.0–1.0). A best value within
+            this fraction of the range from either edge is considered near
+            the boundary.
+
+    Returns:
+        BoundaryReport with per-dimension analysis.
+    """
+    statuses: list[BoundaryDimStatus] = []
+    expanded_names: list[str] = []
+
+    for dim in dims:
+        best_val = best_params.get(dim.name)
+
+        if isinstance(dim, CategoricalDim):
+            statuses.append(
+                BoundaryDimStatus(
+                    name=dim.name,
+                    best_value=best_val,
+                    low=None,
+                    high=None,
+                    position_pct=None,
+                    edge="none",
+                    expanded=False,
+                    new_low=None,
+                    new_high=None,
+                )
+            )
+            continue
+
+        # FloatDim or IntDim
+        low: float = float(dim.low)
+        high: float = float(dim.high)
+        is_log = dim.log
+        best_num = float(best_val) if best_val is not None else (low + high) / 2
+
+        position = _position_pct(best_num, low, high, log=is_log)
+        edge = _detect_edge(position, threshold)
+        should_expand = edge != "none"
+
+        new_low: float | int | None = None
+        new_high: float | int | None = None
+        if should_expand:
+            nl, nh = _expand_range(low, high, edge, log=is_log)
+            if isinstance(dim, IntDim):
+                nl = max(1, int(math.floor(nl)))
+                nh = int(math.ceil(nh))
+            new_low = nl
+            new_high = nh
+            expanded_names.append(dim.name)
+
+        statuses.append(
+            BoundaryDimStatus(
+                name=dim.name,
+                best_value=best_val,
+                low=dim.low,
+                high=dim.high,
+                position_pct=round(position, 4),
+                edge=edge,
+                expanded=should_expand,
+                new_low=new_low,
+                new_high=new_high,
+            )
+        )
+
+    return BoundaryReport(
+        dims=tuple(statuses),
+        expanded_names=tuple(expanded_names),
+    )
+
+
+def expand_dims(
+    dims: list[SearchDim],
+    report: BoundaryReport,
+) -> list[SearchDim]:
+    """Return a new list of SearchDim with boundary-expanded ranges (H-0068).
+
+    Only dimensions flagged ``expanded=True`` in *report* are modified.
+    Non-expanded dimensions are returned unchanged.
+
+    Args:
+        dims: Original search space dimensions.
+        report: Boundary report from :func:`detect_boundary`.
+
+    Returns:
+        New list of SearchDim with expanded ranges where applicable.
+    """
+    expansion_map: dict[str, BoundaryDimStatus] = {
+        s.name: s for s in report.dims if s.expanded
+    }
+    new_dims: list[SearchDim] = []
+    for dim in dims:
+        status = expansion_map.get(dim.name)
+        if status is None:
+            new_dims.append(dim)
+            continue
+
+        if (
+            isinstance(dim, FloatDim)
+            and status.new_low is not None
+            and status.new_high is not None
+        ):
+            new_dims.append(
+                FloatDim(
+                    name=dim.name,
+                    low=float(status.new_low),
+                    high=float(status.new_high),
+                    log=dim.log,
+                    category=dim.category,
+                )
+            )
+        elif (
+            isinstance(dim, IntDim)
+            and status.new_low is not None
+            and status.new_high is not None
+        ):
+            new_dims.append(
+                IntDim(
+                    name=dim.name,
+                    low=int(status.new_low),
+                    high=int(status.new_high),
+                    log=dim.log,
+                    category=dim.category,
+                )
+            )
+        else:
+            new_dims.append(dim)
+
+    return new_dims

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -21,8 +21,6 @@ from lizyml.core.types.search_dim import (
 from lizyml.core.types.tuning_result import BoundaryDimStatus, BoundaryReport
 
 __all__ = [
-    "BoundaryDimStatus",
-    "BoundaryReport",
     "CategoricalDim",
     "FloatDim",
     "IntDim",

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -218,9 +218,9 @@ class Tuner:
                 params=dict(t.params),
                 score=t.value if t.value is not None else float("nan"),
                 state=t.state.name.lower(),
-                round=round_number
-                if t.number >= _prior
-                else _trial_round(t.number, _prior),
+                # Prior-round trials get sentinel round=1; Model.tune() reassigns
+                # correct round numbers via dataclasses.replace().
+                round=round_number if t.number >= _prior else 1,
             )
             for t in study.trials
         ]
@@ -236,17 +236,3 @@ class Tuner:
             direction=self.direction,
         )
         return result, study
-
-
-def _trial_round(trial_number: int, current_round_start: int) -> int:
-    """Determine round for a trial from a previous round.
-
-    For simplicity, trials before the current round start are assigned
-    round numbers based on the assumption that they are from earlier rounds.
-    This is a heuristic — the precise mapping is maintained by Model.
-    """
-    # Trials before current_round_start belong to earlier rounds.
-    # We don't have full round boundary info here, so return 0 as sentinel.
-    # Model._build_tuning_result will fix up round numbers.
-    _ = trial_number, current_round_start
-    return 1  # Default for trials from resumed study (overridden by Model)

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -122,8 +122,6 @@ class Tuner:
 
         # Build optuna callbacks for progress reporting (H-0048, H-0068)
         optuna_callbacks: list[Any] = []
-        # Capture prior_trials for use in both callback and trial list
-        _prior = prior_trials
 
         if self.progress_callback is not None:
             t0 = time.monotonic()
@@ -141,7 +139,7 @@ class Tuner:
                 except ValueError:
                     best = None
                 # trial.number is 0-indexed across the whole study
-                current_in_round = trial.number - _prior + 1
+                current_in_round = trial.number - prior_trials + 1
                 info = TuneProgressInfo(
                     current_trial=current_in_round,
                     total_trials=n_total,
@@ -220,7 +218,7 @@ class Tuner:
                 state=t.state.name.lower(),
                 # Prior-round trials get sentinel round=1; Model.tune() reassigns
                 # correct round numbers via dataclasses.replace().
-                round=round_number if t.number >= _prior else 1,
+                round=round_number if t.number >= prior_trials else 1,
             )
             for t in study.trials
         ]

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -1,9 +1,10 @@
-"""Tuner — optuna-backed hyperparameter optimisation (H-0050: study management only).
+"""Tuner — optuna-backed hyperparameter optimisation (H-0050, H-0068).
 
 The Tuner is responsible for:
 - Creating and running an Optuna study
 - Managing progress callbacks and failure logging
 - Collecting trial results into a TuningResult
+- Accepting an existing study for resume (H-0068)
 
 The Tuner does NOT know about LightGBM, smart params, CVTrainer, or any
 model-specific logic.  The objective closure is built externally (by Model)
@@ -71,17 +72,31 @@ class Tuner:
         self,
         objective: Any,
         metric_name: str = "rmse",
-    ) -> TuningResult:
-        """Run hyperparameter search and return a TuningResult.
+        *,
+        study: Any | None = None,
+        enqueue_params: dict[str, Any] | None = None,
+        round_number: int = 1,
+        prior_trials: int = 0,
+        expanded_dims: tuple[str, ...] = (),
+    ) -> tuple[TuningResult, Any]:
+        """Run hyperparameter search and return a TuningResult + study.
 
         Args:
             objective: Callable ``(optuna.Trial) -> float`` that evaluates a
                 single trial.  Built externally by Model.tune().
             metric_name: Name of the metric being optimised (stored in
                 TuningResult for downstream display/logging).
+            study: Optional existing Optuna study to resume (H-0068).
+                If None, a new study is created.
+            enqueue_params: Optional params dict to enqueue as initial trial
+                (H-0068). Typically the previous best params.
+            round_number: Current round number (1-indexed, H-0068).
+            prior_trials: Number of trials from previous rounds (H-0068).
+            expanded_dims: Dimensions expanded in this round (H-0068).
 
         Returns:
-            TuningResult with best params, best score, and trial history.
+            Tuple of (TuningResult, study). The study is returned so that
+            Model can hold it for future resume calls.
 
         Raises:
             LizyMLError with OPTIONAL_DEP_MISSING if optuna is not installed.
@@ -97,15 +112,25 @@ class Tuner:
                 context={"package": "optuna"},
             )
 
-        sampler = _optuna.samplers.TPESampler(seed=self.seed)
-        study = _optuna.create_study(direction=self.direction, sampler=sampler)
+        if study is None:
+            sampler = _optuna.samplers.TPESampler(seed=self.seed)
+            study = _optuna.create_study(direction=self.direction, sampler=sampler)
 
-        # Build optuna callbacks for progress reporting (H-0048)
+        # Enqueue previous best as initial trial (H-0068)
+        if enqueue_params is not None:
+            study.enqueue_trial(enqueue_params)
+
+        # Build optuna callbacks for progress reporting (H-0048, H-0068)
         optuna_callbacks: list[Any] = []
+        # Capture prior_trials for use in both callback and trial list
+        _prior = prior_trials
+
         if self.progress_callback is not None:
             t0 = time.monotonic()
             user_cb = self.progress_callback
             n_total = self.n_trials
+            rnd = round_number
+            exp_dims = expanded_dims
 
             def _progress_cb(study_: Any, trial: Any) -> None:
                 state_name: str = trial.state.name.lower()
@@ -115,13 +140,18 @@ class Tuner:
                     best = study_.best_value
                 except ValueError:
                     best = None
+                # trial.number is 0-indexed across the whole study
+                current_in_round = trial.number - _prior + 1
                 info = TuneProgressInfo(
-                    current_trial=trial.number + 1,
+                    current_trial=current_in_round,
                     total_trials=n_total,
                     elapsed_seconds=time.monotonic() - t0,
                     best_score=best,
                     latest_score=latest_score,
                     latest_state=state_name,
+                    round=rnd,
+                    cumulative_trials=trial.number + 1,
+                    expanded_dims=exp_dims,
                 )
                 try:
                     user_cb(info)
@@ -175,9 +205,10 @@ class Tuner:
             )
 
         _log.info(
-            "event='tune.done' best_value=%.4f n_trials=%d",
+            "event='tune.done' best_value=%.4f n_trials=%d round=%d",
             study.best_value,
             len(study.trials),
+            round_number,
         )
 
         dims = self.dims
@@ -187,12 +218,15 @@ class Tuner:
                 params=dict(t.params),
                 score=t.value if t.value is not None else float("nan"),
                 state=t.state.name.lower(),
+                round=round_number
+                if t.number >= _prior
+                else _trial_round(t.number, _prior),
             )
             for t in study.trials
         ]
         best_flat = dict(study.best_params)
         best_model, best_smart, best_training = split_by_category(best_flat, dims)
-        return TuningResult(
+        result = TuningResult(
             best_model_params=best_model,
             best_smart_params=best_smart,
             best_training_params=best_training,
@@ -201,3 +235,18 @@ class Tuner:
             metric_name=metric_name,
             direction=self.direction,
         )
+        return result, study
+
+
+def _trial_round(trial_number: int, current_round_start: int) -> int:
+    """Determine round for a trial from a previous round.
+
+    For simplicity, trials before the current round start are assigned
+    round numbers based on the assumption that they are from earlier rounds.
+    This is a heuristic — the precise mapping is maintained by Model.
+    """
+    # Trials before current_round_start belong to earlier rounds.
+    # We don't have full round boundary info here, so return 0 as sentinel.
+    # Model._build_tuning_result will fix up round numbers.
+    _ = trial_number, current_round_start
+    return 1  # Default for trials from resumed study (overridden by Model)

--- a/notebooks/tutorial_regression_tuning_lgbm.ipynb
+++ b/notebooks/tutorial_regression_tuning_lgbm.ipynb
@@ -4,22 +4,7 @@
    "cell_type": "markdown",
    "id": "oq3qg00884",
    "metadata": {},
-   "source": [
-    "# LizyML Tutorial: Regression with LightGBM + Tuning\n",
-    "\n",
-    "This notebook demonstrates hyperparameter tuning with LizyML:\n",
-    "\n",
-    "1. Data preparation (Diamonds dataset with categorical columns)\n",
-    "2. Config with search space\n",
-    "3. Model tuning — Optuna-backed hyperparameter search\n",
-    "4. Tuning table — explore all trial results\n",
-    "5. Model fit — best params auto-applied\n",
-    "6. Evaluate — IS/OOS metrics + learning curve\n",
-    "\n",
-    "**Dataset**: Diamonds (~54,000 rows)\n",
-    "**Target**: `price` (USD)\n",
-    "**Categorical features**: `cut`, `color`, `clarity`"
-   ]
+   "source": "# LizyML Tutorial: Regression with LightGBM + Tuning\n\nThis notebook demonstrates hyperparameter tuning with LizyML:\n\n1. Data preparation (Diamonds dataset with categorical columns)\n2. Config with search space\n3. Model tuning — Optuna-backed hyperparameter search\n4. Tuning table — explore all trial results\n5. Model fit — best params auto-applied\n6. Evaluate — IS/OOS metrics + learning curve\n7. **Re-tune with Resume** — add trials, boundary detection, space expansion (H-0068)\n\n**Dataset**: Diamonds (~54,000 rows)\n**Target**: `price` (USD)\n**Categorical features**: `cut`, `color`, `clarity`"
   },
   {
    "cell_type": "markdown",
@@ -250,8 +235,11 @@
     "def show_progress(info: TuneProgressInfo) -> None:\n",
     "    best = f\"{info.best_score:.4f}\" if info.best_score is not None else \"N/A\"\n",
     "    latest = f\"{info.latest_score:.4f}\" if info.latest_score is not None else \"N/A\"\n",
+    "    # H-0068: round and cumulative_trials are available for re-tune monitoring\n",
     "    print(\n",
+    "        f\"[Round {info.round}] \"\n",
     "        f\"Trial {info.current_trial}/{info.total_trials} \"\n",
+    "        f\"(cumulative {info.cumulative_trials}) \"\n",
     "        f\"[{info.elapsed_seconds:.1f}s] \"\n",
     "        f\"state={info.latest_state} \"\n",
     "        f\"score={latest} best={best}\"\n",
@@ -396,6 +384,121 @@
    "source": [
     "model.plot_learning_curve()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3149d64",
+   "metadata": {},
+   "source": "## 7. Re-tune with Resume (H-0068)\n\nAfter an initial `tune()`, you can call `tune(resume=True)` to add more trials\nto the existing Optuna study. The TPE sampler reuses knowledge from prior trials,\nand the previous best params are enqueued as a warm-start trial.\n\nWhen `expand_boundary` is enabled (default for default search space), dimensions\nwhere the best params are near the search space edge are automatically expanded\nin the promising direction — **widening** the search rather than narrowing it."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e9398b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resume tuning with 3 additional trials + boundary expansion\n",
+    "result2 = model.tune(\n",
+    "    data=df,\n",
+    "    resume=True,\n",
+    "    n_trials=3,\n",
+    "    expand_boundary=True,\n",
+    "    progress_callback=show_progress,\n",
+    ")\n",
+    "\n",
+    "print(f\"\\nRound 2 best score (mae): {result2.best_score:.4f}\")\n",
+    "print(f\"Total trials: {len(result2.trials)}\")\n",
+    "print(f\"Rounds completed: {len(result2.rounds)}\")\n",
+    "\n",
+    "# Check improvement\n",
+    "improvement = result.best_score - result2.best_score\n",
+    "print(f\"Improvement from re-tune: {improvement:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94022884",
+   "metadata": {},
+   "source": "### 7.1 Round Summary\n\n`TuningResult.rounds` shows per-round history: how many trials ran, whether\ndimensions were expanded, and how the best score progressed."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bd980a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "rounds_data = []\n",
+    "for r in result2.rounds:\n",
+    "    rounds_data.append(\n",
+    "        {\n",
+    "            \"round\": r.round,\n",
+    "            \"n_trials\": r.n_trials,\n",
+    "            \"best_before\": r.best_score_before,\n",
+    "            \"best_after\": r.best_score_after,\n",
+    "            \"expanded\": \", \".join(r.expanded_dims) if r.expanded_dims else \"(none)\",\n",
+    "        }\n",
+    "    )\n",
+    "pd.DataFrame(rounds_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfd32a3e",
+   "metadata": {},
+   "source": "### 7.2 Boundary Table\n\n`model.boundary_table()` shows per-dimension boundary analysis — which dimensions\nhad their best params near the edge and were expanded."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1c97132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.boundary_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b865b007",
+   "metadata": {},
+   "source": "### 7.3 Tuning Table with Round Info\n\nThe tuning table now includes `round` and `state` columns to distinguish\nwhich trials belong to which re-tune round."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69054cf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.tuning_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "467e1c3e",
+   "metadata": {},
+   "source": "### 7.4 Tuning Plot with Round Separators\n\nWhen multiple rounds have been run, `tuning_plot()` automatically shows\nvertical dashed lines at round boundaries with annotations for expanded dimensions."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2ac480c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = model.tuning_plot()\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b18a543",
+   "metadata": {},
+   "source": "### 7.5 When to Stop Re-tuning\n\nTwo convergence signals help decide when to stop:\n\n1. **`expanded_dims` is empty** — All best params are well within the search space, so the space is sufficient.\n2. **Score improvement is minimal** — Diminishing returns from additional trials.\n\nWhen both conditions are met, proceed to `fit()` with the final best params."
   }
  ],
  "metadata": {

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -23,6 +23,7 @@ from lizyml import Model
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.search_dim import CategoricalDim, FloatDim, IntDim
 from lizyml.core.types.tuning_result import (
+    BoundaryDimStatus,
     BoundaryReport,
     RoundSummary,
     TrialResult,
@@ -468,3 +469,258 @@ class TestBoundaryTable:
         assert "edge" in table.columns
         assert "expanded" in table.columns
         assert len(table) == 2  # 2 dims in space
+
+
+# ---------------------------------------------------------------------------
+# Edge case and branch coverage tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryEdgeCases:
+    """Edge cases for boundary detection and expansion."""
+
+    def test_zero_span_linear_returns_center(self) -> None:
+        """Degenerate dim with low==high → position 0.5 → no expansion."""
+        dims = [FloatDim("x", low=5.0, high=5.0)]
+        report = detect_boundary(dims, {"x": 5.0}, threshold=0.05)
+        s = report.dims[0]
+        assert s.position_pct == 0.5
+        assert s.edge == "none"
+        assert s.expanded is False
+
+    def test_zero_span_log_returns_center(self) -> None:
+        """Degenerate log dim with low==high → position 0.5."""
+        dims = [FloatDim("x", low=1.0, high=1.0, log=True)]
+        report = detect_boundary(dims, {"x": 1.0}, threshold=0.05)
+        s = report.dims[0]
+        assert s.position_pct == 0.5
+        assert s.edge == "none"
+
+    def test_expand_range_edge_none_passthrough(self) -> None:
+        """expand_dims with no expansion returns same dims."""
+        dims = [
+            FloatDim("a", low=0.0, high=1.0),
+            IntDim("b", low=1, high=100),
+        ]
+        # Best in center → no expansion
+        report = detect_boundary(dims, {"a": 0.5, "b": 50}, threshold=0.05)
+        assert report.expanded_names == ()
+        new = expand_dims(dims, report)
+        assert new[0] is dims[0]
+        assert new[1] is dims[1]
+
+    def test_expand_dims_unrecognized_dim_passthrough(self) -> None:
+        """Dim in expand_map but not matching FloatDim/IntDim falls through."""
+        # This tests the else branch at L373 — a dim in expansion_map
+        # that is somehow neither FloatDim nor IntDim (defensive code).
+        # We can trigger it by creating a boundary report with CategoricalDim
+        # manually marked as expanded (which shouldn't happen in practice).
+        dims = [CategoricalDim("cat", choices=("a", "b"))]
+        fake_status = BoundaryDimStatus(
+            name="cat",
+            best_value="a",
+            low=None,
+            high=None,
+            position_pct=None,
+            edge="none",
+            expanded=True,  # Force expansion flag on categorical
+            new_low=None,
+            new_high=None,
+        )
+        fake_report = BoundaryReport(dims=(fake_status,), expanded_names=("cat",))
+        new = expand_dims(dims, fake_report)
+        # CategoricalDim should pass through unchanged
+        assert new[0] is dims[0]
+
+    def test_int_dim_log_upper_expansion(self) -> None:
+        """IntDim with log scale expands upper bound correctly."""
+        dims = [IntDim("x", low=1, high=100, log=True)]
+        report = detect_boundary(dims, {"x": 99}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "upper"
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], IntDim)
+        assert new[0].high == 300  # 100 * 3.0, ceiled to int
+
+    def test_float_linear_upper_expansion(self) -> None:
+        """FloatDim linear upper expansion adds range."""
+        dims = [FloatDim("x", low=0.0, high=1.0)]
+        report = detect_boundary(dims, {"x": 0.98}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "upper"
+        assert s.new_high is not None
+        assert s.new_high == pytest.approx(2.0)  # 1.0 + (1.0 - 0.0)
+        assert s.new_low == pytest.approx(0.0)  # lower bound unchanged
+
+    def test_multiple_rounds_three_rounds(self) -> None:
+        """Three sequential resume rounds build up correctly."""
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        r1 = model.tune(df)
+        assert len(r1.rounds) == 1
+
+        r2 = model.tune(df, resume=True, n_trials=2)
+        assert len(r2.rounds) == 2
+        assert r2.rounds[0].round == 1
+        assert r2.rounds[1].round == 2
+
+        r3 = model.tune(df, resume=True, n_trials=2)
+        assert len(r3.rounds) == 3
+        assert r3.rounds[2].round == 3
+        # All trials should have round numbers 1, 2, or 3
+        round_nums = {t.round for t in r3.trials}
+        assert round_nums == {1, 2, 3}
+
+    def test_round_summary_best_score_before(self) -> None:
+        """Round 2 should record round 1's best as best_score_before."""
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        r1 = model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=2)
+
+        assert r2.rounds[0].best_score_before is None  # round 1 has no prior
+        assert r2.rounds[1].best_score_before == r1.best_score
+
+
+# ---------------------------------------------------------------------------
+# Plot tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlotTuningHistoryRounds:
+    """Test plot_tuning_history with round separators."""
+
+    def test_single_round_no_vlines(self) -> None:
+        """Single round should not add vertical lines."""
+        from lizyml.plots.tuning import plot_tuning_history
+
+        result = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.5,
+            trials=[
+                TrialResult(number=0, params={"x": 1}, score=0.6, state="complete"),
+                TrialResult(number=1, params={"x": 2}, score=0.5, state="complete"),
+            ],
+            metric_name="rmse",
+            direction="minimize",
+            rounds=(
+                RoundSummary(
+                    round=1,
+                    n_trials=2,
+                    best_score_before=None,
+                    best_score_after=0.5,
+                    expanded_dims=(),
+                    space_snapshot=(),
+                ),
+            ),
+        )
+        fig = plot_tuning_history(result)
+        # Should have traces but no vertical lines (shapes)
+        assert len(fig.data) >= 1
+        # No vline shapes for single round
+        shapes = fig.layout.shapes or ()
+        assert len(shapes) == 0
+
+    def test_two_rounds_has_vline(self) -> None:
+        """Two rounds should add a vertical dashed line at the boundary."""
+        from lizyml.plots.tuning import plot_tuning_history
+
+        result = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.4,
+            trials=[
+                TrialResult(
+                    number=0, params={"x": 1}, score=0.6, state="complete", round=1
+                ),
+                TrialResult(
+                    number=1, params={"x": 2}, score=0.5, state="complete", round=1
+                ),
+                TrialResult(
+                    number=2, params={"x": 3}, score=0.4, state="complete", round=2
+                ),
+            ],
+            metric_name="rmse",
+            direction="minimize",
+            rounds=(
+                RoundSummary(
+                    round=1,
+                    n_trials=2,
+                    best_score_before=None,
+                    best_score_after=0.5,
+                    expanded_dims=(),
+                    space_snapshot=(),
+                ),
+                RoundSummary(
+                    round=2,
+                    n_trials=1,
+                    best_score_before=0.5,
+                    best_score_after=0.4,
+                    expanded_dims=("lr",),
+                    space_snapshot=(),
+                ),
+            ),
+        )
+        fig = plot_tuning_history(result)
+        # Should have at least one vline shape
+        shapes = fig.layout.shapes or ()
+        assert len(shapes) >= 1
+        # Should have round annotations
+        annotations = fig.layout.annotations or ()
+        assert len(annotations) >= 2  # one per round
+        # Check annotation text
+        texts = [a.text for a in annotations]
+        assert any("Round 1" in t for t in texts)
+        assert any("Round 2" in t and "lr" in t for t in texts)
+
+    def test_plot_with_failed_trials(self) -> None:
+        """Plot handles mix of complete and failed trials."""
+        from lizyml.plots.tuning import plot_tuning_history
+
+        result = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.5,
+            trials=[
+                TrialResult(number=0, params={"x": 1}, score=0.5, state="complete"),
+                TrialResult(
+                    number=1, params={"x": 2}, score=float("nan"), state="fail"
+                ),
+            ],
+            metric_name="rmse",
+            direction="minimize",
+        )
+        fig = plot_tuning_history(result)
+        assert len(fig.data) >= 2  # complete + fail traces
+
+    def test_plot_maximize_direction(self) -> None:
+        """Best score line works for maximize direction."""
+        from lizyml.plots.tuning import plot_tuning_history
+
+        result = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.9,
+            trials=[
+                TrialResult(number=0, params={"x": 1}, score=0.7, state="complete"),
+                TrialResult(number=1, params={"x": 2}, score=0.9, state="complete"),
+            ],
+            metric_name="auc",
+            direction="maximize",
+        )
+        fig = plot_tuning_history(result)
+        # Find the "Best Score" trace
+        best_trace = [t for t in fig.data if t.name == "Best Score"]
+        assert len(best_trace) == 1
+        # Best line should be monotonically increasing
+        ys = list(best_trace[0].y)
+        assert ys[1] >= ys[0]

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -1,0 +1,462 @@
+"""Tests for H-0068: Re-tune (Study Resume + Boundary Expansion).
+
+Covers:
+- Boundary detection: linear, log, categorical, edge cases
+- Dimension expansion: asymmetric expansion, IntDim guards
+- Model.tune(resume=True): study resume, trial accumulation, round tracking
+- Model.tune(resume=True) without prior tune() → error
+- TuningResult.rounds populated correctly
+- TuneProgressInfo.round / cumulative_trials / expanded_dims
+- TrialResult.round field
+- tuning_table() with round/state columns
+- boundary_table() output
+- expand_boundary=None defaults (default space vs user space)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lizyml import Model
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.search_dim import CategoricalDim, FloatDim, IntDim
+from lizyml.core.types.tuning_result import (
+    BoundaryReport,
+    RoundSummary,
+    TrialResult,
+    TuneProgressInfo,
+    TuningResult,
+)
+from lizyml.tuning.search_space import detect_boundary, expand_dims
+from tests._helpers import make_config, make_regression_df
+
+# ---------------------------------------------------------------------------
+# Boundary detection unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBoundary:
+    """Test detect_boundary() for various dimension types."""
+
+    def test_float_dim_lower_edge(self) -> None:
+        dims = [FloatDim("lr", low=0.001, high=0.1, log=False)]
+        report = detect_boundary(dims, {"lr": 0.002}, threshold=0.05)
+        assert len(report.dims) == 1
+        s = report.dims[0]
+        assert s.name == "lr"
+        assert s.edge == "lower"
+        assert s.expanded is True
+        assert "lr" in report.expanded_names
+
+    def test_float_dim_upper_edge(self) -> None:
+        dims = [FloatDim("ff", low=0.5, high=1.0)]
+        report = detect_boundary(dims, {"ff": 0.98}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "upper"
+        assert s.expanded is True
+
+    def test_float_dim_center_no_expand(self) -> None:
+        dims = [FloatDim("lr", low=0.001, high=0.1)]
+        report = detect_boundary(dims, {"lr": 0.05}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "none"
+        assert s.expanded is False
+        assert report.expanded_names == ()
+
+    def test_log_dim_lower_edge(self) -> None:
+        dims = [FloatDim("lr", low=0.0001, high=0.1, log=True)]
+        # log(0.0001)=-9.21, log(0.1)=-2.30, span=6.91
+        # log(0.00012)=-9.03, position=(9.21-9.03)/6.91=0.026 < 0.05
+        report = detect_boundary(dims, {"lr": 0.00012}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "lower"
+        assert s.expanded is True
+
+    def test_log_dim_center_no_expand(self) -> None:
+        dims = [FloatDim("lr", low=0.0001, high=0.1, log=True)]
+        report = detect_boundary(dims, {"lr": 0.003}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "none"
+        assert s.expanded is False
+
+    def test_int_dim_upper_edge(self) -> None:
+        dims = [IntDim("leaves", low=16, high=256)]
+        report = detect_boundary(dims, {"leaves": 254}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "upper"
+        assert s.expanded is True
+        assert isinstance(s.new_high, int)
+        assert s.new_high > 256
+
+    def test_int_dim_lower_guard(self) -> None:
+        """IntDim lower bound cannot go below 1."""
+        dims = [IntDim("x", low=1, high=10)]
+        report = detect_boundary(dims, {"x": 1}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "lower"
+        assert s.expanded is True
+        assert s.new_low is not None
+        assert s.new_low >= 1  # Guard: min(1, ...)
+
+    def test_categorical_no_expand(self) -> None:
+        dims = [CategoricalDim("obj", choices=("huber", "fair"))]
+        report = detect_boundary(dims, {"obj": "huber"}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "none"
+        assert s.expanded is False
+        assert s.position_pct is None
+
+    def test_multiple_dims_partial_expand(self) -> None:
+        dims = [
+            FloatDim("lr", low=0.001, high=0.1),  # will be near lower
+            IntDim("leaves", low=16, high=256),  # will be in center
+            CategoricalDim("obj", choices=("a", "b")),  # categorical
+        ]
+        report = detect_boundary(
+            dims, {"lr": 0.002, "leaves": 128, "obj": "a"}, threshold=0.05
+        )
+        assert report.expanded_names == ("lr",)
+        assert len(report.dims) == 3
+
+    def test_missing_param_uses_center(self) -> None:
+        """Missing param key defaults to center → no expansion."""
+        dims = [FloatDim("lr", low=0.001, high=0.1)]
+        report = detect_boundary(dims, {}, threshold=0.05)
+        s = report.dims[0]
+        assert s.edge == "none"
+        assert s.expanded is False
+
+
+# ---------------------------------------------------------------------------
+# Expand dims unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpandDims:
+    def test_expand_lower_linear(self) -> None:
+        dims = [FloatDim("lr", low=0.001, high=0.1)]
+        report = detect_boundary(dims, {"lr": 0.002}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert len(new) == 1
+        assert isinstance(new[0], FloatDim)
+        assert new[0].low < 0.001  # expanded downward
+        assert new[0].high == 0.1  # upper unchanged
+
+    def test_expand_upper_linear(self) -> None:
+        dims = [IntDim("leaves", low=16, high=256)]
+        report = detect_boundary(dims, {"leaves": 254}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], IntDim)
+        assert new[0].low == 16  # lower unchanged
+        assert new[0].high > 256  # expanded upward
+
+    def test_expand_log_lower(self) -> None:
+        dims = [FloatDim("lr", low=0.0001, high=0.1, log=True)]
+        report = detect_boundary(dims, {"lr": 0.00012}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].low < 0.0001
+        assert new[0].log is True  # log flag preserved
+        assert new[0].category == "model"  # category preserved
+
+    def test_no_expand_center(self) -> None:
+        dims = [FloatDim("lr", low=0.001, high=0.1)]
+        report = detect_boundary(dims, {"lr": 0.05}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].low == 0.001
+        assert new[0].high == 0.1
+
+    def test_categorical_unchanged(self) -> None:
+        dims = [CategoricalDim("obj", choices=("a", "b"))]
+        report = detect_boundary(dims, {"obj": "a"}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0] is dims[0]  # same object, untouched
+
+
+# ---------------------------------------------------------------------------
+# Type extension tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrialResultRound:
+    def test_default_round_is_1(self) -> None:
+        t = TrialResult(number=0, params={"x": 1}, score=0.5, state="complete")
+        assert t.round == 1
+
+    def test_explicit_round(self) -> None:
+        t = TrialResult(number=5, params={}, score=0.3, state="complete", round=2)
+        assert t.round == 2
+
+
+class TestTuningResultExtensions:
+    def test_rounds_default_empty(self) -> None:
+        r = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.5,
+            trials=[],
+            metric_name="rmse",
+            direction="minimize",
+        )
+        assert r.rounds == ()
+        assert r.boundary_report is None
+
+    def test_rounds_populated(self) -> None:
+        rs = RoundSummary(
+            round=1,
+            n_trials=10,
+            best_score_before=None,
+            best_score_after=0.5,
+            expanded_dims=(),
+            space_snapshot=(),
+        )
+        r = TuningResult(
+            best_model_params={},
+            best_smart_params={},
+            best_training_params={},
+            best_score=0.5,
+            trials=[],
+            metric_name="rmse",
+            direction="minimize",
+            rounds=(rs,),
+        )
+        assert len(r.rounds) == 1
+        assert r.rounds[0].round == 1
+
+    def test_backward_compat_best_params(self) -> None:
+        r = TuningResult(
+            best_model_params={"a": 1},
+            best_smart_params={"b": 2},
+            best_training_params={"c": 3},
+            best_score=0.5,
+            trials=[],
+            metric_name="rmse",
+            direction="minimize",
+        )
+        assert r.best_params == {"a": 1, "b": 2, "c": 3}
+
+
+class TestTuneProgressInfoExtensions:
+    def test_default_values(self) -> None:
+        info = TuneProgressInfo(
+            current_trial=1,
+            total_trials=10,
+            elapsed_seconds=0.5,
+            best_score=None,
+            latest_score=None,
+            latest_state="complete",
+        )
+        assert info.round == 1
+        assert info.cumulative_trials == 0
+        assert info.expanded_dims == ()
+
+    def test_h0068_fields(self) -> None:
+        info = TuneProgressInfo(
+            current_trial=5,
+            total_trials=30,
+            elapsed_seconds=10.0,
+            best_score=0.3,
+            latest_score=0.31,
+            latest_state="complete",
+            round=2,
+            cumulative_trials=55,
+            expanded_dims=("lr", "leaves"),
+        )
+        assert info.round == 2
+        assert info.cumulative_trials == 55
+        assert info.expanded_dims == ("lr", "leaves")
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _reg_config_with_tuning(n_trials: int = 3) -> dict[str, Any]:
+    cfg = make_config("regression")
+    cfg["tuning"] = {
+        "optuna": {
+            "params": {"n_trials": n_trials, "direction": "minimize"},
+            "space": {
+                "num_leaves": {"type": "int", "low": 8, "high": 32},
+                "learning_rate": {
+                    "type": "float",
+                    "low": 0.01,
+                    "high": 0.3,
+                    "log": True,
+                },
+            },
+        }
+    }
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Model.tune(resume=True) integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelRetuneResume:
+    """Integration tests for tune(resume=True)."""
+
+    def test_resume_without_prior_tune_raises(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        model = Model(cfg)
+        with pytest.raises(LizyMLError) as exc_info:
+            model.tune(make_regression_df(), resume=True)
+        assert exc_info.value.code == ErrorCode.TUNING_FAILED
+        assert "resume" in str(exc_info.value.user_message).lower()
+
+    def test_resume_accumulates_trials(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=3)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        r1 = model.tune(df)
+        assert len(r1.trials) == 3
+        assert len(r1.rounds) == 1
+        assert r1.rounds[0].round == 1
+
+        r2 = model.tune(df, resume=True, n_trials=2)
+        # 3 original + 1 enqueued + 2 new = 6 total,
+        # but enqueued counts as a trial in study
+        assert len(r2.trials) >= 5
+        assert len(r2.rounds) == 2
+        assert r2.rounds[1].round == 2
+
+    def test_resume_best_score_monotonic(self) -> None:
+        """Best score should not get worse across rounds."""
+        cfg = _reg_config_with_tuning(n_trials=3)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        r1 = model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=3)
+        # minimize → lower or equal
+        assert r2.best_score <= r1.best_score + 1e-10
+
+    def test_resume_trial_round_numbers(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=2)
+
+        round_1_trials = [t for t in r2.trials if t.round == 1]
+        round_2_trials = [t for t in r2.trials if t.round == 2]
+        assert len(round_1_trials) >= 2
+        assert len(round_2_trials) >= 2
+
+    def test_resume_progress_callback(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+
+        infos: list[TuneProgressInfo] = []
+        model.tune(
+            df,
+            resume=True,
+            n_trials=2,
+            progress_callback=lambda i: infos.append(i),
+        )
+        assert len(infos) >= 2
+        for info in infos:
+            assert info.round == 2
+            assert info.cumulative_trials > 0
+
+    def test_n_trials_override(self) -> None:
+        """n_trials parameter overrides config value."""
+        cfg = _reg_config_with_tuning(n_trials=10)  # config says 10
+        df = make_regression_df()
+        model = Model(cfg)
+
+        r1 = model.tune(df, n_trials=2)  # override to 2
+        assert r1.rounds[0].n_trials == 2
+
+
+# ---------------------------------------------------------------------------
+# Boundary expansion integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelRetuneBoundaryExpansion:
+    """Integration tests for boundary detection + expansion during resume."""
+
+    def test_expand_boundary_none_user_space_no_expand(self) -> None:
+        """User-specified space + expand_boundary=None → no expansion."""
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=2)
+        # expand_boundary defaults to False for user space
+        assert r2.boundary_report is None
+
+    def test_expand_boundary_explicit_true_user_space(self) -> None:
+        """User-specified space + expand_boundary=True → expansion happens."""
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=2, expand_boundary=True)
+        assert r2.boundary_report is not None
+        assert isinstance(r2.boundary_report, BoundaryReport)
+
+    def test_expand_boundary_false_no_report(self) -> None:
+        """expand_boundary=False → no boundary detection."""
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+        r2 = model.tune(df, resume=True, n_trials=2, expand_boundary=False)
+        assert r2.boundary_report is None
+
+
+# ---------------------------------------------------------------------------
+# Table tests
+# ---------------------------------------------------------------------------
+
+
+class TestTuningTableRetune:
+    def test_tuning_table_has_round_and_state(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+
+        model.tune(df)
+        model.tune(df, resume=True, n_trials=2)
+        table = model.tuning_table()
+        assert "round" in table.columns
+        assert "state" in table.columns
+        assert set(table["round"].unique()) == {1, 2}
+
+
+class TestBoundaryTable:
+    def test_boundary_table_no_report_raises(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        with pytest.raises(LizyMLError) as exc_info:
+            model.boundary_table()
+        assert exc_info.value.code == ErrorCode.MODEL_NOT_FIT
+
+    def test_boundary_table_with_report(self) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        model.tune(df, resume=True, n_trials=2, expand_boundary=True)
+        table = model.boundary_table()
+        assert "dim" in table.columns
+        assert "edge" in table.columns
+        assert "expanded" in table.columns
+        assert len(table) == 2  # 2 dims in space

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -309,6 +309,14 @@ class TestModelRetuneResume:
         assert exc_info.value.code == ErrorCode.TUNING_FAILED
         assert "resume" in str(exc_info.value.user_message).lower()
 
+    @pytest.mark.parametrize("threshold", [0.0, 0.5, 1.0, -0.1])
+    def test_invalid_boundary_threshold_raises(self, threshold: float) -> None:
+        cfg = _reg_config_with_tuning(n_trials=2)
+        model = Model(cfg)
+        with pytest.raises(LizyMLError) as exc_info:
+            model.tune(make_regression_df(), boundary_threshold=threshold)
+        assert exc_info.value.code == ErrorCode.CONFIG_INVALID
+
     def test_resume_accumulates_trials(self) -> None:
         cfg = _reg_config_with_tuning(n_trials=3)
         df = make_regression_df()
@@ -320,9 +328,9 @@ class TestModelRetuneResume:
         assert r1.rounds[0].round == 1
 
         r2 = model.tune(df, resume=True, n_trials=2)
-        # 3 original + 1 enqueued + 2 new = 6 total,
-        # but enqueued counts as a trial in study
-        assert len(r2.trials) >= 5
+        # Round 1: 3 trials. Round 2: optimize(n_trials=2) — enqueue counts
+        # as 1 of the 2 trials. Total: 3 + 2 = 5 trials.
+        assert len(r2.trials) == 5
         assert len(r2.rounds) == 2
         assert r2.rounds[1].round == 2
 

--- a/tests/test_tuning/test_tuning_reproducibility.py
+++ b/tests/test_tuning/test_tuning_reproducibility.py
@@ -44,7 +44,7 @@ class TestTuningReproducibility:
             # Deterministic objective based only on params
             return (lr - 0.1) ** 2 + (nl - 31) ** 2 / 1000.0
 
-        result = tuner.tune(objective, metric_name="synthetic")
+        result, _ = tuner.tune(objective, metric_name="synthetic")
         return result
 
     def test_same_seed_same_best_params(self) -> None:
@@ -86,7 +86,7 @@ class TestAllTrialFailure:
             raise ValueError(msg)
 
         with pytest.raises(LizyMLError) as exc_info:
-            tuner.tune(failing_objective)
+            tuner.tune(failing_objective)  # raises before returning tuple
         assert exc_info.value.code == ErrorCode.TUNING_FAILED
         assert exc_info.value.context["n_trials"] == 3
 
@@ -100,7 +100,7 @@ class TestAllTrialFailure:
             raise RuntimeError(msg)
 
         with pytest.raises(LizyMLError) as exc_info:
-            tuner.tune(failing_objective)
+            tuner.tune(failing_objective)  # raises before returning tuple
         assert "failed" in exc_info.value.user_message.lower()
 
 
@@ -123,7 +123,7 @@ class TestPartialTrialFailure:
                 raise ValueError(msg)
             return lr  # lower is better
 
-        result = tuner.tune(partial_objective)
+        result, _ = tuner.tune(partial_objective)
         # Should have some completed trials
         completed = [t for t in result.trials if t.state == "complete"]
         failed = [t for t in result.trials if t.state != "complete"]


### PR DESCRIPTION
## Release v0.9.0

### Added

- **Re-tune: Study Resume + Boundary Expansion** (H-0068)
  - `Model.tune(resume=True)` resumes from the previous Optuna Study with additional trials
  - Automatic boundary detection identifies dimensions where best params are near search space edges
  - Asymmetric space expansion extends promising directions only (linear: 2x, log: 3x)
  - `TuningResult.rounds` tracks per-round history (`RoundSummary`)
  - `TuningResult.boundary_report` provides dimension-by-dimension analysis (`BoundaryReport` / `BoundaryDimStatus`)
  - `Model.boundary_table()` returns boundary detection results as DataFrame
  - `TuneProgressInfo` gains `round`, `cumulative_trials`, `expanded_dims`
  - `TrialResult.round` indicates which re-tune round each trial belongs to
  - `tuning_table()` includes `round` and `state` columns
  - `plot_tuning_history()` shows round boundary separators with annotations
  - New public types: `BoundaryReport`, `BoundaryDimStatus`, `RoundSummary`
  - Fully backward compatible

### Documentation

- docs/api.md updated with all new types and parameters
- CHANGELOG.md v0.9.0 entry
- Tuning tutorial notebook with §7 Re-tune section

### Test

- 50 new tests for re-tune (1545 total, all passing)
- Coverage: tuning_result 100%, search_space 99%, tuner 98%, plots/tuning 96%

### Merge instructions

**Create a merge commit** (Squash merge prohibited — see CLAUDE.md §5)