### PR TITLE
fix(config): make validation_ratio a computed field (H-0069, #95)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -341,8 +341,8 @@ config = {
 | `seed` | `int` | No | `42` | グローバルシード |
 | `early_stopping.enabled` | `bool` | No | `True` | |
 | `early_stopping.rounds` | `int` | No | `150` | |
-| `early_stopping.validation_ratio` | `float \| null` | No | `0.1` | inner_valid.ratio のエイリアス |
-| `early_stopping.inner_valid` | `object \| null` | No | `null`（自動解決） | |
+| `early_stopping.validation_ratio` | `float` (read-only) | — | `inner_valid.ratio` から派生 | `inner_valid.ratio` の computed alias（H-0069）。入力は `inner_valid` 経由を推奨。legacy YAML での入力は受理 |
+| `early_stopping.inner_valid` | `object \| null` | No | `null`（自動解決） | inner valid の唯一の正規表現 |
 
 ### tuning
 
@@ -584,8 +584,8 @@ LizyML 非依存の学習・推論コードを自動生成する。
 ### 10.3.1 設定の解決規則
 
 - `training.early_stopping.inner_valid` を明示指定した場合は、その method / ratio / random_state をそのまま使う。外側 `split.method` は参照しない。
-- `training.early_stopping.validation_ratio` は ratio の shorthand であり、method 指定ではない。`inner_valid` を明示指定していない場合、ratio は `validation_ratio` から取り、method は外側 `split.method` から自動解決する。
-- `validation_ratio` と `inner_valid` を同時に明示指定した場合は `CONFIG_INVALID` とする。ただし `model_dump()` round-trip で両者が同値になるケースは許容する。
+- `training.early_stopping.validation_ratio` は legacy 入力ショートハンドであり、method 指定ではない。`inner_valid` を明示指定していない場合、ratio は `validation_ratio` から取り、method は外側 `split.method` から自動解決する。H-0069 以降、`validation_ratio` は `inner_valid.ratio` から派生する read-only の computed field。出力 (`model_dump()`) には常に同値の `validation_ratio` が含まれる。
+- `validation_ratio` と `inner_valid` を同時に明示指定した場合、ratio が一致しなければ `CONFIG_INVALID`、一致すれば許容する（round-trip 互換）。一致しない場合の検知は維持される。
 - 自動解決時に inner valid が継承する outer CV 設定は `split.method` のみとする。`n_splits` / `shuffle` / `random_state` / `gap` / `purge_gap` / `embargo` / `train_size_max` / `test_size_max` は inner valid に伝搬しない。
 - 自動解決時の seed は `training.seed` を使う。outer split の `random_state` は inner valid に伝搬しない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`Model.load()` fails for non-holdout `inner_valid`** (H-0069, [#95](https://github.com/nbx-liz/LizyML/issues/95)) — Saving a model fit with `inner_valid.method ∈ {group_holdout, time_holdout}` produced an artifact that could not be re-loaded (`CONFIG_INVALID`). Root cause: `validation_ratio` and `inner_valid.ratio` were two mutable fields whose only synchronization was a one-way validator branch that ignored `group_holdout` / `time_holdout`. `model_dump()` always emitted both keys, so the round-trip silently broke.
+
+### Changed
+
+- **`EarlyStoppingConfig.validation_ratio` is now a read-only computed field** (H-0069) — `validation_ratio` mirrors `inner_valid.ratio` automatically, eliminating the dual-write inconsistency at its source. Existing YAML inputs (`validation_ratio: 0.1` only, or `inner_valid: {...}` only) are fully backward compatible. Existing `model.lizyml` artifacts load without migration. Side effect: codegen `export_code()` now uses the correct holdout fraction when `inner_valid.ratio` differs from the default 0.1 (previously a silent ratio mismatch).
+
 ## [0.9.0] - 2026-04-12
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5336,3 +5336,78 @@ LizyML Core は callback + 結果型でデータを提供し、Widget/Studio が
 12. デフォルト空間 + `expand_boundary=None` → 拡張される
 13. `resume=True` で未 tune → `TUNING_FAILED` エラー
 14. 品質ゲート（ruff / mypy / pytest）全 PASS
+
+## H-0069: `validation_ratio` を computed_field 化（Issue #95 構造的根治）
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-02
+- **スコープ**: Public Config | Schema | Persistence
+- **関連**: [Issue #95](https://github.com/nbx-liz/LizyML/issues/95), [LizyStudio #345](https://github.com/nbx-liz/LizyStudio/issues/345)
+
+### 目的
+
+`EarlyStoppingConfig.validation_ratio` と `inner_valid.ratio` が「両方 mutable / 両方 dump 出力 / 同期は validator の片方向のみ」という二重表現になっており、以下のバグを構造的に発生させている:
+
+1. **Issue #95（顕在）**: `inner_valid` が `group_holdout` / `time_holdout` のとき `Model.save()` → `Model.load()` で round-trip が `ValidationError` で落ちる。LizyStudio #345 の production 500 エラーを引き起こしている
+2. **codegen silent ratio mismatch（潜在）**: `inner_valid={method:..., ratio:0.25}` を渡しても `validation_ratio` は default 0.1 のまま。`_model_persistence.py:206` が `es.validation_ratio` を `export_code()` に渡すため、生成 `train.py` が誤った holdout 比率で動作する
+
+これらは個別に対症修正（B 案: validator 内双方向同期）しても、二重表現自体が残るため再発リスクが高い。本 Proposal は `validation_ratio` を `inner_valid.ratio` から派生する read-only `@computed_field` に正規化し、Single Source of Truth 化することで二重表現を根絶する。
+
+### 変更内容
+
+1. **`EarlyStoppingConfig` schema 改訂** (`lizyml/config/schema.py`)
+   - `validation_ratio: float | None = 0.1` を **削除**（stored field でなくなる）
+   - `@computed_field` として `validation_ratio` プロパティを追加 — `inner_valid.ratio` を返す read-only
+   - `_resolve_validation_ratio` validator を削除し、以下に置換:
+     - `mode="wrap"` validator で legacy YAML 入力 (`{"validation_ratio": 0.1}` のみ) を `{"inner_valid": {"method": "holdout", "ratio": 0.1}}` に変換 + round-trip 入力 (`validation_ratio` と `inner_valid` 両方在) は `validation_ratio` を strip
+     - mode="wrap" 内で `_inner_valid_explicit` PrivateAttr を「ユーザーが入力で `inner_valid` を明示し、かつ `validation_ratio` を併記しなかった場合のみ True」に設定（既存 auto-resolve セマンティクス維持）
+   - `mode="after"` で `inner_valid is None` のとき default `HoldoutInnerValidConfig(method="holdout", ratio=0.1)` を補填
+
+2. **下流の読み出し経路は無変更**
+   - `_model_persistence.py:206`, `_model_tables.py:290` は `es.validation_ratio` を読むが、computed_field なので呼び出しは不変。値は自動的に正しくなる
+   - `model.py:795` の `tp["validation_ratio"]` 読み出し（Tuner 探索次元）は引数辞書ベースなので無変更
+   - `defaults.py:73` の `FloatDim("validation_ratio", ...)` も無変更（探索次元名として継続使用）
+
+3. **既存 `model.lizyml` artifact 互換**
+   - 旧 `metadata.json` には `validation_ratio: 0.1` が含まれる → mode="wrap" の round-trip strip ロジックで透過的に受理される
+   - `format_version` bump 不要
+
+### 影響範囲
+
+- `lizyml/config/schema.py` — `EarlyStoppingConfig` schema（中核）
+- `tests/test_config/test_early_stopping_defaults.py` — 既存テスト確認（API 不変なので PASS のはず）
+- `tests/test_config/test_early_stopping_roundtrip.py` — 新規 round-trip 回帰テスト（Issue #95 受け入れ基準）
+- `tests/regression/test_reg_issue_95_*.py` — 永続化互換テスト（旧形式 metadata.json の読み込み）
+- BLUEPRINT.md — `EarlyStoppingConfig` セクションがあれば更新
+
+### 互換性
+
+- **YAML 入力（user-facing）**: 完全互換
+  - `{"validation_ratio": 0.1}` → 内部で `inner_valid: holdout` に正規化（既存挙動と同じ）
+  - `{"inner_valid": {...}}` → そのまま（既存挙動と同じ）
+  - 両方併記 + 値一致 → OK（既存 round-trip allowance を継承）
+  - 両方併記 + 値不一致 → `ValueError`（実コンフリクトの検知は維持）
+- **`Model.load()` 互換**: 旧 artifact (`validation_ratio: 0.1` を含む metadata) はそのまま load 可能
+- **`cfg.training.early_stopping.validation_ratio` の読み取り**: 引き続き動作（computed_field）
+- **`auto-resolve` セマンティクス**: `_inner_valid_explicit` フラグの設定ルール変更なし（legacy YAML や round-trip では False、明示的 inner_valid では True）。`_model_factories.py:253` の挙動は不変
+- **format_version**: 変更なし（schema 入出力契約は維持）
+
+### 代替案
+
+- **A. `isinstance` チェックを緩和するだけ**: Issue #95 の症状のみ修正。`validation_ratio ↔ inner_valid.ratio` の同期欠落は残存し codegen silent bug は手付かず → 場当たり修正
+- **B. validator 内で双方向同期**: 同期欠落を修正するが二重表現は残存。新コンシューマが `validation_ratio` を mutable 前提で書くと再発リスク → 中庸
+- **C. computed_field 化（本 Proposal）**: 二重表現を構造的に根絶。ユーザー API（read 経路）は完全互換 → **採用**
+- **D. `validation_ratio` 完全撤廃**: 全 consumer を `inner_valid.ratio` 直読に変更。最もクリーンだが破壊的（YAML 入力 + Tuner 探索次元名）。次メジャー（v1.0）に持ち越し
+
+### 受け入れ基準（テスト観点）
+
+1. **Issue #95 直接修正**: 3 つの `InnerValidConfig` discriminant (`holdout` / `group_holdout` / `time_holdout`) について `model_validate(model_dump())` round-trip がすべて成功
+2. **non-default ratio round-trip**: 上記 3 discriminant × `ratio ∈ {0.1, 0.25, 0.4}` の cross product でも round-trip 成功（隠れていた validation_ratio 同期欠落も同時解消）
+3. **legacy YAML 互換**: `{"validation_ratio": 0.1}` 単独入力で `inner_valid` が `Holdout(ratio=0.1)` に正規化され、`_inner_valid_explicit=False`（auto-resolve 経路維持）
+4. **明示的 inner_valid**: `{"inner_valid": {"method": "group_holdout", "ratio": 0.2}}` 入力で `_inner_valid_explicit=True`、`es.validation_ratio == 0.2`
+5. **両方併記の整合性ガード**: `{"inner_valid": {ratio: 0.1}, "validation_ratio": 0.25}` は `ValidationError`（不整合の検知は維持）
+6. **下流読み取り正常性**: `cfg.training.early_stopping.validation_ratio` が `inner_valid.ratio` と一致（computed）
+7. **persistence 互換**: 旧 `validation_ratio: 0.1` を含む `metadata.json` から `Model.load()` 成功（パラメトライズ: 3 discriminant）
+8. **codegen 整合**: `inner_valid={method: holdout, ratio: 0.25}` で fit したモデルを `export_code` した `train.py` が `validation_ratio=0.25` で動作（codegen silent bug の同時修正確認）
+9. **auto-resolve 維持**: `validation_ratio: 0.1` + `split.method=group_kfold` の組み合わせで factory が `GroupHoldoutInnerValid` を返す（既存挙動）
+10. **品質ゲート**: ruff / mypy / pytest 全 PASS、既存 1320+ テストが PASS

--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 import warnings
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    computed_field,
+    model_validator,
+)
 
 # ---------------------------------------------------------------------------
 # DataConfig
@@ -312,37 +319,94 @@ InnerValidConfig = Annotated[
 ]
 
 
+_DEFAULT_VALIDATION_RATIO = 0.1
+
+
 class EarlyStoppingConfig(BaseModel):
+    """Early-stopping configuration.
+
+    ``inner_valid`` is the canonical source of truth for the holdout
+    fraction.  ``validation_ratio`` is exposed as a read-only computed
+    field that mirrors ``inner_valid.ratio`` (H-0069).
+
+    Legacy YAML inputs that supply only ``validation_ratio`` are
+    transparently migrated into a ``HoldoutInnerValidConfig`` so the
+    user-facing surface stays compatible.
+    """
+
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = True
     rounds: int = 150
     inner_valid: InnerValidConfig | None = None
-    validation_ratio: float | None = 0.1
     _inner_valid_explicit: bool = PrivateAttr(default=False)
 
-    @model_validator(mode="after")
-    def _resolve_validation_ratio(self) -> EarlyStoppingConfig:
-        iv_explicit = "inner_valid" in self.model_fields_set
-        vr_explicit = "validation_ratio" in self.model_fields_set
-        if iv_explicit and vr_explicit:
-            # Allow round-trip: model_dump() produces both; consistent is OK
-            if (
-                isinstance(self.inner_valid, HoldoutInnerValidConfig)
-                and self.inner_valid.ratio == self.validation_ratio
-            ):
-                return self
-            raise ValueError(
-                "Specify either 'validation_ratio' or 'inner_valid', not both."
+    @model_validator(mode="wrap")
+    @classmethod
+    def _migrate_and_track_explicit(
+        cls, data: Any, handler: Any
+    ) -> EarlyStoppingConfig:
+        """Translate legacy ``validation_ratio`` input + track explicitness.
+
+        Behavior (H-0069):
+
+        - Pure legacy input ``{"validation_ratio": 0.1}`` → migrates to
+          ``inner_valid: {method: "holdout", ratio: 0.1}``;
+          ``_inner_valid_explicit`` stays ``False`` so the factory's
+          auto-resolve path keeps choosing the split-aware variant.
+        - Explicit ``{"inner_valid": {...}}`` → kept as-is;
+          ``_inner_valid_explicit`` becomes ``True``.
+        - Round-trip dump ``{"inner_valid": {...}, "validation_ratio": x}``
+          → ``validation_ratio`` is silently dropped (it is a computed
+          field re-emitted by ``model_dump()``); explicitness mirrors
+          the round-trip-without-vr semantics (False — auto-resolve).
+        - Inconsistent values (``validation_ratio != inner_valid.ratio``)
+          → ``ValueError`` to surface real conflicts.
+        """
+        user_explicit_inner_valid = False
+        if isinstance(data, dict):
+            iv_in = data.get("inner_valid") is not None
+            vr_present = "validation_ratio" in data
+            user_explicit_inner_valid = iv_in and not vr_present
+            if vr_present:
+                legacy_ratio = data.pop("validation_ratio")
+                iv_value = data.get("inner_valid")
+                if iv_value is None:
+                    if legacy_ratio is not None:
+                        data["inner_valid"] = {
+                            "method": "holdout",
+                            "ratio": legacy_ratio,
+                        }
+                else:
+                    iv_ratio = (
+                        iv_value.get("ratio")
+                        if isinstance(iv_value, dict)
+                        else getattr(iv_value, "ratio", None)
+                    )
+                    if (
+                        legacy_ratio is not None
+                        and iv_ratio is not None
+                        and legacy_ratio != iv_ratio
+                    ):
+                        raise ValueError(
+                            "Specify either 'validation_ratio' or 'inner_valid', "
+                            "not both."
+                        )
+        instance: EarlyStoppingConfig = handler(data)
+        if instance.inner_valid is None:
+            instance.inner_valid = HoldoutInnerValidConfig(
+                method="holdout", ratio=_DEFAULT_VALIDATION_RATIO
             )
-        if iv_explicit:
-            self._inner_valid_explicit = True
-            return self
-        if self.validation_ratio is not None:
-            self.inner_valid = HoldoutInnerValidConfig(
-                method="holdout", ratio=self.validation_ratio
-            )
-        return self
+        instance._inner_valid_explicit = user_explicit_inner_valid
+        return instance
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def validation_ratio(self) -> float:
+        """Holdout fraction; derived from ``inner_valid.ratio`` (H-0069)."""
+        if self.inner_valid is None:
+            return _DEFAULT_VALIDATION_RATIO
+        return self.inner_valid.ratio
 
 
 class TrainingConfig(BaseModel):

--- a/tests/test_config/test_early_stopping_roundtrip.py
+++ b/tests/test_config/test_early_stopping_roundtrip.py
@@ -1,0 +1,173 @@
+"""Regression tests for issue #95.
+
+`EarlyStoppingConfig.model_dump()` always emits both ``inner_valid`` and
+``validation_ratio`` (the latter from its non-None default 0.1). The
+round-trip allowance previously only accepted ``HoldoutInnerValidConfig``,
+so models persisted with ``group_holdout`` or ``time_holdout`` could not be
+re-loaded via ``LizyMLConfig.model_validate(model_dump())`` (i.e.
+``Model.load()``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from lizyml.config.schema import EarlyStoppingConfig
+
+
+class TestInnerValidRoundtrip:
+    """Round-trip ``model_dump()`` → ``model_validate()`` for every
+    ``InnerValidConfig`` discriminant."""
+
+    @pytest.mark.parametrize(
+        "inner_valid",
+        [
+            {"method": "holdout", "ratio": 0.1, "stratify": False, "random_state": 42},
+            {"method": "group_holdout", "ratio": 0.1, "random_state": 42},
+            {"method": "time_holdout", "ratio": 0.1},
+        ],
+        ids=["holdout", "group_holdout", "time_holdout"],
+    )
+    def test_roundtrip_preserves_inner_valid(
+        self, inner_valid: dict[str, object]
+    ) -> None:
+        cfg = EarlyStoppingConfig(
+            enabled=True,
+            rounds=50,
+            inner_valid=inner_valid,  # type: ignore[arg-type]
+        )
+        dumped = cfg.model_dump()
+
+        # Sanity: dump must include both fields (this is what triggered the bug).
+        assert "inner_valid" in dumped
+        assert "validation_ratio" in dumped
+
+        restored = EarlyStoppingConfig.model_validate(dumped)
+        assert restored.inner_valid is not None
+        assert restored.inner_valid.method == inner_valid["method"]
+        assert restored.inner_valid.ratio == inner_valid["ratio"]
+
+    @pytest.mark.parametrize(
+        "method",
+        ["holdout", "group_holdout", "time_holdout"],
+    )
+    def test_roundtrip_with_non_default_ratio(self, method: str) -> None:
+        """Non-default ratio still round-trips (ratio is propagated to
+        ``validation_ratio`` when only ``inner_valid`` is set)."""
+        cfg = EarlyStoppingConfig(
+            enabled=True,
+            rounds=50,
+            inner_valid={"method": method, "ratio": 0.25},  # type: ignore[arg-type]
+        )
+        dumped = cfg.model_dump()
+        restored = EarlyStoppingConfig.model_validate(dumped)
+        assert restored.inner_valid is not None
+        assert restored.inner_valid.ratio == 0.25
+
+
+class TestInnerValidConflictGuard:
+    """The 'specify only one' guard must still fire on a *real* conflict —
+    inconsistent ``inner_valid.ratio`` and ``validation_ratio``."""
+
+    @pytest.mark.parametrize(
+        "method",
+        ["holdout", "group_holdout", "time_holdout"],
+    )
+    def test_inconsistent_ratio_still_rejected(self, method: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            EarlyStoppingConfig.model_validate(
+                {
+                    "enabled": True,
+                    "rounds": 50,
+                    "inner_valid": {"method": method, "ratio": 0.1},
+                    "validation_ratio": 0.25,
+                }
+            )
+        assert "Specify either 'validation_ratio' or 'inner_valid'" in str(
+            exc_info.value
+        )
+
+
+class TestExplicitFlagTracking:
+    """``_inner_valid_explicit`` PrivateAttr drives the factory's
+    auto-resolve path (`_model_factories.py:253`).  H-0069 must
+    preserve the existing semantics:
+
+    - Legacy ``validation_ratio`` only → ``False`` (auto-resolve)
+    - Explicit ``inner_valid`` only → ``True`` (use as-is)
+    - Round-trip (both keys) → ``False`` (auto-resolve, matching
+      pre-H-0069 behaviour for round-tripped artifacts)
+    """
+
+    def test_legacy_validation_ratio_keeps_auto_resolve(self) -> None:
+        cfg = EarlyStoppingConfig.model_validate(
+            {"enabled": True, "rounds": 50, "validation_ratio": 0.2}
+        )
+        assert cfg.inner_valid is not None
+        assert cfg.inner_valid.method == "holdout"
+        assert cfg.inner_valid.ratio == 0.2
+        assert cfg._inner_valid_explicit is False
+
+    def test_explicit_inner_valid_disables_auto_resolve(self) -> None:
+        cfg = EarlyStoppingConfig.model_validate(
+            {
+                "enabled": True,
+                "rounds": 50,
+                "inner_valid": {"method": "group_holdout", "ratio": 0.2},
+            }
+        )
+        assert cfg._inner_valid_explicit is True
+        assert cfg.validation_ratio == 0.2
+
+    def test_default_construction_keeps_auto_resolve(self) -> None:
+        cfg = EarlyStoppingConfig()
+        assert cfg.inner_valid is not None
+        assert cfg.inner_valid.ratio == 0.1
+        assert cfg._inner_valid_explicit is False
+
+    def test_roundtrip_preserves_auto_resolve(self) -> None:
+        """A dump always carries both ``inner_valid`` and ``validation_ratio``
+        — re-loading must mirror the legacy behaviour where the pair triggers
+        auto-resolve, not explicit."""
+        original = EarlyStoppingConfig.model_validate(
+            {
+                "enabled": True,
+                "rounds": 50,
+                "inner_valid": {"method": "group_holdout", "ratio": 0.2},
+            }
+        )
+        restored = EarlyStoppingConfig.model_validate(original.model_dump())
+        assert restored._inner_valid_explicit is False
+
+
+class TestComputedFieldContract:
+    """``validation_ratio`` is now a computed field — it must always
+    mirror ``inner_valid.ratio`` and be present in ``model_dump()``."""
+
+    @pytest.mark.parametrize(
+        ("method", "ratio"),
+        [
+            ("holdout", 0.1),
+            ("holdout", 0.3),
+            ("group_holdout", 0.2),
+            ("time_holdout", 0.4),
+        ],
+    )
+    def test_validation_ratio_mirrors_inner_valid(
+        self, method: str, ratio: float
+    ) -> None:
+        cfg = EarlyStoppingConfig(
+            inner_valid={"method": method, "ratio": ratio}  # type: ignore[arg-type]
+        )
+        assert cfg.validation_ratio == ratio
+        dumped = cfg.model_dump()
+        assert dumped["validation_ratio"] == ratio
+        assert dumped["inner_valid"]["ratio"] == ratio
+
+    def test_validation_ratio_is_read_only(self) -> None:
+        """Direct assignment to the computed field must fail —
+        ``inner_valid.ratio`` is the SSOT."""
+        cfg = EarlyStoppingConfig()
+        with pytest.raises((AttributeError, ValueError)):
+            cfg.validation_ratio = 0.5  # type: ignore[misc]

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -360,7 +360,12 @@ class TestValidationRatio:
         assert exc_info.value.code == ErrorCode.CONFIG_INVALID
 
     def test_inner_valid_backward_compat(self) -> None:
-        """Existing inner_valid form continues to work unchanged."""
+        """Existing inner_valid form continues to work unchanged.
+
+        Post-H-0069: ``validation_ratio`` is a computed field that
+        mirrors ``inner_valid.ratio``; the previous silent default of
+        ``0.1`` is replaced by the actual configured ratio.
+        """
         raw = {
             **_MINIMAL_CONFIG,
             "training": {
@@ -375,4 +380,4 @@ class TestValidationRatio:
         es = cfg.training.early_stopping
         assert es.inner_valid is not None
         assert es.inner_valid.ratio == pytest.approx(0.15)
-        assert es.validation_ratio == 0.1  # default, but inner_valid takes precedence
+        assert es.validation_ratio == pytest.approx(0.15)

--- a/tests/test_persistence/test_issue_95_inner_valid_save_load.py
+++ b/tests/test_persistence/test_issue_95_inner_valid_save_load.py
@@ -1,0 +1,151 @@
+"""Regression tests for issue #95 — Model.save() / Model.load()
+round-trip with non-holdout ``inner_valid``.
+
+Pre-H-0069 the round-trip allowance in ``EarlyStoppingConfig`` only
+accepted ``HoldoutInnerValidConfig``, so saving a model fit with
+``group_holdout`` or ``time_holdout`` produced an artifact that could
+not be loaded back (``CONFIG_INVALID``).  H-0069 makes
+``validation_ratio`` a computed field derived from
+``inner_valid.ratio``, eliminating the dual-write inconsistency at
+its root.
+
+These tests exercise the full save → load cycle for every
+``InnerValidConfig`` discriminant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizyml import Model
+from tests._helpers import make_binary_df
+
+
+def _build_config(
+    *,
+    split_method: str,
+    inner_valid: dict[str, Any] | None,
+    extra_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data_cfg: dict[str, Any] = {"target": "target"}
+    if extra_data:
+        data_cfg.update(extra_data)
+    split_cfg: dict[str, Any] = {"method": split_method, "n_splits": 3}
+    if split_method in ("kfold", "stratified_kfold"):
+        split_cfg["random_state"] = 42
+    if split_method == "group_kfold":
+        # GroupKFold has no random_state.
+        pass
+
+    early_stopping: dict[str, Any] = {"enabled": True, "rounds": 30}
+    if inner_valid is not None:
+        early_stopping["inner_valid"] = inner_valid
+
+    return {
+        "config_version": 1,
+        "task": "binary",
+        "data": data_cfg,
+        "split": split_cfg,
+        "model": {"name": "lgbm", "params": {"n_estimators": 10}},
+        "training": {"seed": 0, "early_stopping": early_stopping},
+        "evaluation": {"metrics": ["auc"]},
+    }
+
+
+def _make_grouped_binary_df(n: int = 90, n_groups: int = 6) -> pd.DataFrame:
+    df = make_binary_df(n=n)
+    rng = np.random.default_rng(42)
+    df["g"] = rng.integers(0, n_groups, size=len(df))
+    return df
+
+
+def _make_time_binary_df(n: int = 90) -> pd.DataFrame:
+    df = make_binary_df(n=n)
+    df["t"] = np.arange(len(df), dtype=int)
+    return df
+
+
+class TestSaveLoadRoundtrip:
+    """Save → load preserves every ``InnerValidConfig`` discriminant."""
+
+    def test_holdout_roundtrip(self, tmp_path: Path) -> None:
+        cfg = _build_config(
+            split_method="stratified_kfold",
+            inner_valid={"method": "holdout", "ratio": 0.2, "random_state": 42},
+        )
+        df = make_binary_df(n=80)
+        m = Model(cfg)
+        m.fit(data=df)
+
+        out = tmp_path / "model"
+        m.export(out)
+
+        loaded = Model.load(out)
+        assert loaded._cfg.training.early_stopping.inner_valid is not None
+        assert loaded._cfg.training.early_stopping.inner_valid.method == "holdout"
+        assert loaded._cfg.training.early_stopping.validation_ratio == 0.2
+
+    def test_group_holdout_roundtrip(self, tmp_path: Path) -> None:
+        cfg = _build_config(
+            split_method="group_kfold",
+            inner_valid={"method": "group_holdout", "ratio": 0.2, "random_state": 42},
+            extra_data={"group_col": "g"},
+        )
+        df = _make_grouped_binary_df()
+        m = Model(cfg)
+        m.fit(data=df)
+
+        out = tmp_path / "model"
+        m.export(out)
+
+        loaded = Model.load(out)
+        assert loaded._cfg.training.early_stopping.inner_valid is not None
+        assert loaded._cfg.training.early_stopping.inner_valid.method == "group_holdout"
+        assert loaded._cfg.training.early_stopping.validation_ratio == 0.2
+
+    def test_time_holdout_roundtrip(self, tmp_path: Path) -> None:
+        cfg = _build_config(
+            split_method="time_series",
+            inner_valid={"method": "time_holdout", "ratio": 0.2},
+            extra_data={"time_col": "t"},
+        )
+        df = _make_time_binary_df()
+        m = Model(cfg)
+        m.fit(data=df)
+
+        out = tmp_path / "model"
+        m.export(out)
+
+        loaded = Model.load(out)
+        assert loaded._cfg.training.early_stopping.inner_valid is not None
+        assert loaded._cfg.training.early_stopping.inner_valid.method == "time_holdout"
+        assert loaded._cfg.training.early_stopping.validation_ratio == 0.2
+
+
+class TestNonDefaultRatioRoundtrip:
+    """Non-default ratios round-trip correctly (was silently broken
+    pre-H-0069 even for ``holdout`` because ``validation_ratio`` was
+    not synced from ``inner_valid.ratio``)."""
+
+    @pytest.mark.parametrize("ratio", [0.15, 0.3])
+    def test_holdout_with_non_default_ratio(self, tmp_path: Path, ratio: float) -> None:
+        cfg = _build_config(
+            split_method="stratified_kfold",
+            inner_valid={"method": "holdout", "ratio": ratio, "random_state": 42},
+        )
+        df = make_binary_df(n=80)
+        m = Model(cfg)
+        m.fit(data=df)
+
+        out = tmp_path / "model"
+        m.export(out)
+
+        loaded = Model.load(out)
+        assert loaded._cfg.training.early_stopping.inner_valid is not None
+        assert loaded._cfg.training.early_stopping.inner_valid.ratio == ratio
+        assert loaded._cfg.training.early_stopping.validation_ratio == ratio


### PR DESCRIPTION
## Summary

Fixes [#95](https://github.com/nbx-liz/LizyML/issues/95) — `Model.load()` failing for non-holdout `inner_valid`. Resolves the structural root cause rather than the surface symptom by collapsing the `validation_ratio` / `inner_valid.ratio` dual-mutable-field surface into a single source of truth.

- `inner_valid` is now the canonical typed field
- `validation_ratio` is a read-only `@computed_field` returning `inner_valid.ratio`
- Legacy YAML inputs (`validation_ratio: 0.1` alone) keep working transparently
- Existing `model.lizyml` artifacts load without migration
- The `_inner_valid_explicit` tracking that drives the factory auto-resolve path is preserved

## Why structural (C) over symptom-fix (A/B)

Investigation surfaced a **second silent bug** in the same surface: when `inner_valid.ratio` ≠ 0.1, `_model_persistence.py:206` was passing the stale `validation_ratio = 0.1` into `export_code()`, so generated `train.py` used the wrong holdout fraction. Both bugs share the dual-write design root cause. Fixing them together via the C-level structural change closes the class permanently; A or B would patch one symptom and leave the alias drift in place.

See HISTORY.md H-0069 for the alternatives evaluation (A/B/C/D).

## Related skill

[`paired-config-fields`](.claude/skills/paired-config-fields/SKILL.md) — new project skill encoding the design rule that prevented this class of bug from being noticed earlier.

## DoD (per H-0069 acceptance criteria)

- [x] 3 `InnerValidConfig` discriminant × 2+ ratios round-trip via `model_dump()` → `model_validate()`
- [x] Legacy YAML compat: `validation_ratio: 0.1` only → `inner_valid: holdout`, `_inner_valid_explicit=False`
- [x] Explicit `inner_valid`: `_inner_valid_explicit=True`
- [x] Inconsistent `validation_ratio` ≠ `inner_valid.ratio` → `ValidationError` (real-conflict guard)
- [x] `Model.save()` → `Model.load()` regression tests for all 3 discriminants (`tests/test_persistence/test_issue_95_inner_valid_save_load.py`)
- [x] Auto-resolve preserved (`_model_factories.build_inner_valid` reads `_inner_valid_explicit`)
- [x] Existing 1545 tests pass; 23 new tests added (1568 total)
- [x] BLUEPRINT.md §14.4 + §10.3.1 updated

## Test plan

- [x] `uv run pytest` — 1568 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy --no-incremental lizyml/` — clean
- [x] LizyStudio #345 unblocked — once this lands and a release ships, the GUI's `group_kfold` / `time_series` save→load path works without manual metadata patching