### PR TITLE
feat(metrics): add sMAPE and WAPE — zero-tolerant percentage-style regression metrics (H-0071, #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **sMAPE / WAPE — zero-tolerant percentage-style regression metrics** (H-0071, [#101](https://github.com/nbx-liz/LizyML/issues/101)) — `lizyml.metrics.SMAPE` and `lizyml.metrics.WAPE` are now available for `task=regression` and registered in `MetricRegistry` under `"smape"` / `"wape"`. Both close the gap left by MAPE on datasets where `y_true` may be `0` (sales / demand / count regressions). Wired into the LightGBM metric bridge so `params={"metric": ["smape", "wape"]}` produces feval-driven entries in `eval_history` / learning curves, and into the codegen exporter so `Model.export_code()` reproduces the same values offline. Authoritative formulas and edge-case conventions are documented in [`docs/config-reference.md` § Metric formula reference](docs/config-reference.md#metric-formula-reference).
+
 ## [0.10.0] - 2026-05-04
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5513,3 +5513,149 @@ LizyML Core は callback + 結果型でデータを提供し、Widget/Studio が
 8. **persistence 互換**: format_version=1 artifact (旧 fixture) を load して数値 y 用 predict 経路が等価動作（INV-5）
 9. **codegen E2E**: 非数値 classification で `export_code` → 別プロセスで `predict.py` 実行 → 元ラベルが復元される
 10. **品質ゲート**: ruff / mypy / pytest 全 PASS、既存 1320+ テスト全 PASS
+
+## H-0071: sMAPE / WAPE — zero-tolerant percentage-style 回帰メトリクスの追加
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-05
+- **決定日**: 2026-05-05
+- **スコープ**: Public API (Metrics) | LGBM metric bridge | Codegen feval | Docs
+- **関連**: [Issue #101](https://github.com/nbx-liz/LizyML/issues/101), LizyStudio v0.4.0 GUI 検証で発覚（target に 0 を含む sales/demand 系 regression で MAPE が `UNSUPPORTED_METRIC`）
+
+### 目的
+
+回帰メトリクス集合（`rmse`, `mae`, `r2`, `rmsle`, `mape`, `huber`）には **zero-tolerant な percentage-style 指標が無い**。`MAPE` は `y_true` に 0 を含むと `LizyMLError(UNSUPPORTED_METRIC)` を raise する仕様（[regression.py:152-157](lizyml/metrics/regression.py#L152-L157)）であり、これは数学的には正しいが、0 が valid 値となる sales / demand / count 回帰では percentage 系の代替が存在しない。
+
+本 Proposal は **sMAPE**（symmetric MAPE）と **WAPE**（weighted absolute percentage error）の 2 指標を追加し、既存契約を破壊せずにギャップを埋める。LizyStudio 側でも「計算不能 metric の auto-disable warning」を companion Issue で別途対処予定だが、上流で tolerant な代替を提供するのが本質的な解。
+
+### 変更内容
+
+1. **新規 metric クラス 2 件** (`lizyml/metrics/regression.py`)
+   - `@MetricRegistry.register("smape")` → `class SMAPE(BaseMetric)`
+     - 式: `mean(2 * |y_true - y_pred| / (|y_true| + |y_pred|)) * 100`、range `[0, 200]`（doubled 形）
+     - `y_true == y_pred == 0` の行は `0/0` を 0 として扱う（perfect prediction 規約）
+     - `greater_is_better=False`, `needs_proba=False`
+   - `@MetricRegistry.register("wape")` → `class WAPE(BaseMetric)`
+     - 式: `sum(|y_true - y_pred|) / sum(|y_true|) * 100`（= `MAE / mean(|y_true|) * 100`）
+     - `sum(|y_true|) == 0` のときのみ `LizyMLError(UNSUPPORTED_METRIC, "WAPE is undefined when sum(|y_true|) is zero.")`
+     - `greater_is_better=False`, `needs_proba=False`
+
+2. **Registry 拡張** (`lizyml/metrics/registry.py:26`)
+   - `_TASK_METRICS["regression"]` の frozenset に `"smape"`, `"wape"` を追加
+
+3. **LGBM feval Bridge 連携** (`lizyml/estimators/lgbm/metric_bridge.py`)
+   - LightGBM ネイティブに sMAPE / WAPE は無いため、`_FEVAL_METRICS["regression"]` 既存の `frozenset(["rmsle", "r2"])` に `"smape"`, `"wape"` を追加
+   - `_build_feval()` は `BaseMetric` インスタンスを受けて feval callable を生成する汎用機構なので追加実装不要（H-0064 の設計を継承）
+   - これにより `params={"metric": "smape"}` で early stopping / learning curve への接続が自動的に有効化される
+
+4. **Re-export** (`lizyml/metrics/__init__.py`)
+   - `from .regression import SMAPE, WAPE` 追加（既存パターン踏襲）
+
+5. **Codegen 対応** (`lizyml/codegen/templates.py`)
+   - Codegen の `_FEVAL_REGISTRY` は metric_bridge と独立した手書き dict のため、`_feval_smape` / `_feval_wape` 関数と registry エントリを追記
+   - 関数定義は metric 本体と同一の数式を再現（`np.errstate` で 0/0 を 0 扱い、`sum(|y|)==0` で `ValueError`）
+   - `tests/test_codegen/test_feval_codegen.py` にて lizyml 実装との数値等価性を rtol=1e-10 で検証
+
+### 影響範囲
+
+- **新規シンボル**: `lizyml.metrics.SMAPE`, `lizyml.metrics.WAPE`
+- **変更ファイル**:
+  - `lizyml/metrics/regression.py`（クラス 2 件追加）
+  - `lizyml/metrics/registry.py`（task frozenset 拡張）
+  - `lizyml/metrics/__init__.py`（re-export）
+  - `lizyml/estimators/lgbm/metric_bridge.py`（feval 名 frozenset 拡張）
+- **無変更**: BaseMetric IF / Evaluator / FeaturePipeline / Calibration / Persistence
+- **Config 互換**: 既存の `eval_metrics: ["rmse", "mae"]` 等は完全互換、`smape`/`wape` を新規に列挙可能
+
+### 不変条件 (Invariants-First)
+
+| ID | Invariant |
+|---|---|
+| INV-1 | `SMAPE(y, y) == 0.0`（恒等予測でゼロ） |
+| INV-2 | `SMAPE` 出力範囲 `[0, 200]`、`y_true == y_pred == 0` の行は寄与 0 |
+| INV-3 | `WAPE(y, y) == 0.0`、`sum(|y_true|) == 0` でのみ `UNSUPPORTED_METRIC` raise（per-row 0 では raise しない） |
+| INV-4 | `MetricRegistry.get("smape", "regression")` と `("wape", "regression")` が成功、binary / multiclass では `LizyMLError(METRIC_NOT_FOUND)` |
+| INV-5 | `params={"metric": "smape"}` で `lgb.train` の `eval_results` に `smape` キーが現れる（feval 経由）|
+| INV-6 | `greater_is_better=False`、`needs_proba=False`（両 metric 共通） |
+
+### 互換性
+
+- **後方互換**: 完全互換。既存 metric / Config / FitResult / Persistence に変更なし
+- **format_version**: bump 不要（artifact 構造に変更なし）
+- **LightGBM 依存**: feval 経由で実装するため LightGBM のバージョン要件に変更なし
+
+### 代替案
+
+- **A. 何もしない（status quo）** — 0 を含む regression データで percentage 系評価が不可能。問題本体の放置
+- **B. MAPE の挙動緩和（`y_true == 0` を skip）** — 数学的に MAPE の定義を歪める。既存ユーザーへの silent な挙動変化、リグレッションリスク高 → 不採用
+- **C. sMAPE のみ追加** — sMAPE は per-row 平均、WAPE は sum 比であり用途が異なる（imbalanced magnitude regression では WAPE の方が頑健）。Issue 起案者も両方要請 → 不採用
+- **D. sMAPE + WAPE 同時追加（本 Proposal）** — 既存 metric IF に乗るだけ、追加コスト最小、用途分離明確 → **採用**
+
+### 受け入れ基準（テスト観点）
+
+1. **基本正解性** (`tests/test_metrics/test_regression.py`):
+   - sMAPE: hand-computed example（例: y=[1,2,3], y_pred=[1,2,4] → 期待値を手計算で固定）
+   - WAPE: hand-computed example、`MAE / mean(|y_true|) * 100` との一致
+2. **エッジケース**:
+   - sMAPE: `y_true = [0, 1]`, `y_pred = [0, 1]` で 0.0（INV-2）
+   - sMAPE: `y_true = [0, 5]`, `y_pred = [0, 4]` で raise しない（MAPE 対比）
+   - WAPE: `y_true = [0, 0, 0]`, `y_pred = [0, 1, 2]` で `UNSUPPORTED_METRIC` raise（INV-3）
+   - WAPE: `y_true = [0, 1, 2]`（部分的 0）で raise しない
+3. **属性契約**: `name`, `greater_is_better`, `needs_proba` の golden test（INV-6）
+4. **Registry 統合**: `MetricRegistry.get("smape", "regression")` / `("wape", "regression")` 成功、binary 等では失敗（INV-4）
+5. **LGBM feval E2E** (`tests/test_estimators/test_lgbm_feval.py` 拡張):
+   - regression × `params={"metric": "smape"}` で fit 成功、`fit_result.history` に `smape` キーが現れる（INV-5）
+   - 同上 `wape` パターン
+   - `params={"metric": ["rmse", "smape", "wape"]}` の native + feval 混在
+6. **Codegen E2E** (`tests/test_codegen/`):
+   - regression + smape + wape を `eval_metrics` に含む config で `export_code` → 別プロセスで `predict.py` 実行 → equivalence 確認（feval bridge 継承の確認）
+7. **CHANGELOG**: `Added` セクションに sMAPE / WAPE 追加を記載
+8. **Docstring**: 各クラスに式・range・edge case 規約・MAPE との使い分け方針を明記
+9. **品質ゲート**: ruff / mypy / pytest 全 PASS、既存 1320+ テスト全 PASS
+
+### 参考実装方針（informational）
+
+```python
+# lizyml/metrics/regression.py（追加）
+
+@MetricRegistry.register("smape")
+class SMAPE(BaseMetric):
+    """Symmetric Mean Absolute Percentage Error (range [0, 200])."""
+
+    @property
+    def name(self) -> str: return "smape"
+    @property
+    def needs_proba(self) -> bool: return False
+    @property
+    def greater_is_better(self) -> bool: return False
+
+    def __call__(self, y_true, y_pred) -> float:
+        _validate_shapes(y_true, y_pred, self.name)
+        denom = np.abs(y_true) + np.abs(y_pred)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            terms = np.where(denom == 0, 0.0, 2 * np.abs(y_true - y_pred) / denom)
+        return float(np.mean(terms) * 100)
+
+
+@MetricRegistry.register("wape")
+class WAPE(BaseMetric):
+    """Weighted Absolute Percentage Error (= MAE / mean(|y_true|) * 100)."""
+
+    @property
+    def name(self) -> str: return "wape"
+    @property
+    def needs_proba(self) -> bool: return False
+    @property
+    def greater_is_better(self) -> bool: return False
+
+    def __call__(self, y_true, y_pred) -> float:
+        _validate_shapes(y_true, y_pred, self.name)
+        denom = float(np.sum(np.abs(y_true)))
+        if denom == 0.0:
+            raise LizyMLError(
+                code=ErrorCode.UNSUPPORTED_METRIC,
+                user_message="WAPE is undefined when sum(|y_true|) is zero.",
+                context={"metric": self.name},
+            )
+        return float(np.sum(np.abs(y_true - y_pred)) / denom * 100)
+```

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -264,6 +264,8 @@ Supported values for `model.params.metric` by task:
 |---|:---:|:---:|:---:|
 | `rmsle` | ✅ | | |
 | `r2` | ✅ | | |
+| `smape` | ✅ | | |
+| `wape` | ✅ | | |
 | `f1` | | ✅ | ✅ |
 | `brier` | | ✅ | ✅ |
 | `ece` | | ✅ | |
@@ -438,7 +440,7 @@ Supported metric names by task:
 
 | task | metrics |
 |---|---|
-| `regression` | `rmse`, `mae`, `r2`, `rmsle`, `mape`, `huber` |
+| `regression` | `rmse`, `mae`, `r2`, `rmsle`, `mape`, `huber`, `smape`, `wape` |
 | `binary` | `logloss`, `auc`, `auc_pr`, `f1`, `accuracy`, `brier`, `ece`, `precision_at_k` |
 | `multiclass` | `logloss`, `f1`, `accuracy`, `auc`, `auc_pr`, `brier` |
 
@@ -452,6 +454,8 @@ Metric details:
 | `rmsle` | Root Mean Squared Logarithmic Error (requires non-negative values) | No | No |
 | `mape` | Mean Absolute Percentage Error (undefined when y_true contains zeros) | No | No |
 | `huber` | Huber Loss (delta=1.0) | No | No |
+| `smape` | Symmetric MAPE — tolerates per-row zeros (range [0, 200]) | No | No |
+| `wape` | Weighted Absolute Percentage Error — defined whenever sum(\|y_true\|) > 0 | No | No |
 | `logloss` | Log Loss (binary cross-entropy / multi-class cross-entropy) | Yes | No |
 | `auc` | Area Under the ROC Curve (binary or multiclass OvR macro) | Yes | Yes |
 | `auc_pr` | Area Under the Precision-Recall Curve (macro average for multiclass) | Yes | Yes |
@@ -460,6 +464,54 @@ Metric details:
 | `brier` | Brier Score (mean squared probability error, macro average for multiclass) | Yes | No |
 | `ece` | Expected Calibration Error (equal-width bins, M=10). Per-bin accuracy = fraction of positives `mean(y_true)`, confidence = `mean(y_pred)`. | Yes | No |
 | `precision_at_k` | Precision at top-K% (default K=10). K is configurable via dict form: `{precision_at_k: {k: 20}}` | Yes | Yes |
+
+### Metric formula reference
+
+Authoritative formulas for each evaluation metric. `n` denotes the number
+of rows; `y` is `y_true` and `ŷ` is `y_pred`. For probabilistic
+classification metrics, `p` denotes the predicted probability.
+
+#### Regression
+
+| metric | formula | range | notes |
+|---|---|---|---|
+| `rmse` | $\sqrt{\frac{1}{n}\sum_i (y_i - \hat y_i)^2}$ | $[0, \infty)$ | — |
+| `mae` | $\frac{1}{n}\sum_i \lvert y_i - \hat y_i \rvert$ | $[0, \infty)$ | — |
+| `r2` | $1 - \frac{\sum_i (y_i - \hat y_i)^2}{\sum_i (y_i - \bar y)^2}$ | $(-\infty, 1]$ | $\bar y$ = mean of `y_true` |
+| `rmsle` | $\sqrt{\frac{1}{n}\sum_i (\log(1+y_i) - \log(1+\hat y_i))^2}$ | $[0, \infty)$ | requires $y_i, \hat y_i \ge 0$ |
+| `mape` | $\frac{100}{n}\sum_i \left\lvert \frac{y_i - \hat y_i}{y_i} \right\rvert$ | $[0, \infty)$ | undefined if any $y_i = 0$ |
+| `huber` | $\frac{1}{n}\sum_i L_\delta(y_i - \hat y_i)$ where $L_\delta(e) = \begin{cases} \tfrac{1}{2}e^2 & \lvert e \rvert \le \delta \\ \delta (\lvert e \rvert - \tfrac{1}{2}\delta) & \text{otherwise} \end{cases}$ | $[0, \infty)$ | $\delta = 1.0$ default |
+| `smape` (H-0071) | $\frac{100}{n}\sum_i \frac{2 \lvert y_i - \hat y_i \rvert}{\lvert y_i \rvert + \lvert \hat y_i \rvert}$ | $[0, 200]$ | row with $\lvert y_i \rvert + \lvert \hat y_i \rvert = 0$ contributes 0 |
+| `wape` (H-0071) | $\frac{\sum_i \lvert y_i - \hat y_i \rvert}{\sum_i \lvert y_i \rvert} \times 100$ | $[0, \infty)$ | undefined only when $\sum_i \lvert y_i \rvert = 0$ |
+
+**MAPE vs sMAPE vs WAPE.**
+- **MAPE** is the classical per-row percentage error — fails on any $y_i = 0$.
+- **sMAPE** averages a *symmetric* percentage error per row, so a single $y_i = 0$ no longer breaks it; it only breaks when both $y_i = 0$ and $\hat y_i = 0$ (which we treat as 0 contribution by convention).
+- **WAPE** is a *sum-ratio*, equivalent to $\text{MAE}/\overline{\lvert y \rvert} \times 100$. It tolerates per-row zeros and is the most robust choice for imbalanced-magnitude regressions where a few large-volume series would otherwise dominate.
+
+#### Classification — probability-based
+
+| metric | formula | range | notes |
+|---|---|---|---|
+| `logloss` (binary) | $-\frac{1}{n}\sum_i \big[y_i \log p_i + (1-y_i) \log (1-p_i)\big]$ | $[0, \infty)$ | $p_i$ = predicted prob. of class 1 |
+| `logloss` (multiclass) | $-\frac{1}{n}\sum_i \sum_{k} \mathbf{1}\{y_i = k\} \log p_{i,k}$ | $[0, \infty)$ | $p_{i,k}$ = predicted prob. of class $k$ |
+| `auc` (binary) | Area under the ROC curve (TPR vs FPR over all thresholds) | $[0, 1]$ | computed via sklearn `roc_auc_score` |
+| `auc` (multiclass) | OvR macro average of per-class AUC | $[0, 1]$ | one-vs-rest, equal-weight average |
+| `auc_pr` (binary) | Area under the precision–recall curve (= average precision) | $[0, 1]$ | sklearn `average_precision_score` |
+| `auc_pr` (multiclass) | macro average of per-class AP | $[0, 1]$ | — |
+| `brier` (binary) | $\frac{1}{n}\sum_i (p_i - y_i)^2$ | $[0, 1]$ | mean squared probability error |
+| `brier` (multiclass) | $\frac{1}{K}\sum_{k=1}^{K} \mathrm{Brier}(\mathbf{1}\{y = k\}, p_{:,k})$ | $[0, 1]$ | macro average over classes |
+| `ece` (binary) | $\sum_{m=1}^{M} \frac{\lvert B_m \rvert}{n} \big\lvert \mathrm{acc}(B_m) - \mathrm{conf}(B_m) \big\rvert$ | $[0, 1]$ | $M = 10$ equal-width bins; $\mathrm{acc}(B_m) = \mathrm{mean}(y_{B_m})$, $\mathrm{conf}(B_m) = \mathrm{mean}(p_{B_m})$ |
+
+#### Classification — label-based
+
+| metric | formula | range | notes |
+|---|---|---|---|
+| `f1` (binary) | $\frac{2 \cdot \mathrm{precision} \cdot \mathrm{recall}}{\mathrm{precision} + \mathrm{recall}}$ at threshold 0.5 | $[0, 1]$ | uses `(p \ge 0.5)` cut |
+| `f1` (multiclass) | macro average of per-class F1 | $[0, 1]$ | argmax over class probs |
+| `accuracy` (binary) | $\frac{1}{n}\sum_i \mathbf{1}\{\hat y_i = y_i\}$ at threshold 0.5 | $[0, 1]$ | — |
+| `accuracy` (multiclass) | $\frac{1}{n}\sum_i \mathbf{1}\{\arg\max_k p_{i,k} = y_i\}$ | $[0, 1]$ | — |
+| `precision_at_k` | $\mathrm{mean}\big(y_{\text{top-K\%}}\big)$ where rows are sorted desc by $p$ and top-K% kept | $[0, 1]$ | default $K = 10\%$; configurable: `{precision_at_k: {k: 20}}` |
 
 ## `calibration`
 

--- a/lizyml/codegen/templates.py
+++ b/lizyml/codegen/templates.py
@@ -201,6 +201,18 @@ def _feval_accuracy(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     pred = (y_pred >= 0.5).astype(int) if y_pred.dtype.kind == "f" else y_pred
     return float(accuracy_score(y_true, pred))
 
+def _feval_smape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = np.abs(y_true) + np.abs(y_pred)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        terms = np.where(denom == 0, 0.0, 2.0 * np.abs(y_true - y_pred) / denom)
+    return float(np.mean(terms) * 100.0)
+
+def _feval_wape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = float(np.sum(np.abs(y_true)))
+    if denom == 0.0:
+        raise ValueError("WAPE is undefined when sum(|y_true|) is zero.")
+    return float(np.sum(np.abs(y_true - y_pred)) / denom * 100.0)
+
 
 _FEVAL_REGISTRY: dict = {
     "rmsle": _feval_rmsle,
@@ -210,6 +222,8 @@ _FEVAL_REGISTRY: dict = {
     "ece": _feval_ece,
     "precision_at_k": _feval_precision_at_k,
     "accuracy": _feval_accuracy,
+    "smape": _feval_smape,
+    "wape": _feval_wape,
 }
 
 

--- a/lizyml/estimators/lgbm/metric_bridge.py
+++ b/lizyml/estimators/lgbm/metric_bridge.py
@@ -116,7 +116,7 @@ _LGBM_NATIVE_METRICS: dict[str, frozenset[str]] = {
 # NOTE: r2 is documented in LightGBM master but not shipped in 4.6.0 binary.
 # Kept here until the upstream release is confirmed and minimum version bumped.
 _FEVAL_METRICS: dict[str, frozenset[str]] = {
-    "regression": frozenset(["rmsle", "r2"]),
+    "regression": frozenset(["rmsle", "r2", "smape", "wape"]),
     "binary": frozenset(["f1", "brier", "ece", "precision_at_k", "accuracy"]),
     "multiclass": frozenset(["f1", "brier", "accuracy"]),
 }

--- a/lizyml/metrics/__init__.py
+++ b/lizyml/metrics/__init__.py
@@ -21,7 +21,7 @@ from lizyml.metrics.registry import (
     parse_metric_entries,
     parse_metric_entry,
 )
-from lizyml.metrics.regression import MAE, MAPE, R2, RMSE, RMSLE, HuberLoss
+from lizyml.metrics.regression import MAE, MAPE, R2, RMSE, RMSLE, SMAPE, WAPE, HuberLoss
 
 __all__ = [
     "BaseMetric",
@@ -32,6 +32,8 @@ __all__ = [
     "RMSLE",
     "MAPE",
     "HuberLoss",
+    "SMAPE",
+    "WAPE",
     # classification
     "LogLoss",
     "AUC",

--- a/lizyml/metrics/registry.py
+++ b/lizyml/metrics/registry.py
@@ -23,7 +23,9 @@ MetricEntry = str | dict[str, dict[str, Any]]
 
 # Metrics that are valid per task type
 _TASK_METRICS: dict[TaskType, frozenset[str]] = {
-    "regression": frozenset(["rmse", "mae", "r2", "rmsle", "mape", "huber"]),
+    "regression": frozenset(
+        ["rmse", "mae", "r2", "rmsle", "mape", "huber", "smape", "wape"]
+    ),
     "binary": frozenset(
         ["logloss", "auc", "auc_pr", "f1", "accuracy", "brier", "ece", "precision_at_k"]
     ),

--- a/lizyml/metrics/regression.py
+++ b/lizyml/metrics/regression.py
@@ -1,4 +1,4 @@
-"""Regression metrics: RMSE, MAE, R2, RMSLE, MAPE, HuberLoss."""
+"""Regression metrics: RMSE, MAE, R2, RMSLE, MAPE, HuberLoss, SMAPE, WAPE."""
 
 from __future__ import annotations
 
@@ -194,3 +194,85 @@ class HuberLoss(BaseMetric):
             self.delta * (abs_e - 0.5 * self.delta),
         )
         return float(np.mean(loss))
+
+
+@MetricRegistry.register("smape")
+class SMAPE(BaseMetric):
+    """Symmetric Mean Absolute Percentage Error (range [0, 200]).
+
+    Formula::
+
+        sMAPE = mean( 2 * |y_true - y_pred| / (|y_true| + |y_pred|) ) * 100
+
+    Tolerates ``y_true == 0`` (unlike :class:`MAPE`). Convention: when
+    ``|y_true| + |y_pred| == 0`` for a row (i.e. both are zero), the
+    row's contribution is 0 (perfect prediction).
+
+    Use sMAPE instead of MAPE when the target may take the value 0
+    on a per-row basis (e.g. demand / count regressions).
+    """
+
+    @property
+    def name(self) -> str:
+        return "smape"
+
+    @property
+    def needs_proba(self) -> bool:
+        return False
+
+    @property
+    def greater_is_better(self) -> bool:
+        return False
+
+    def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
+        _validate_shapes(y_true, y_pred, self.name)
+        denom = np.abs(y_true) + np.abs(y_pred)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            terms = np.where(
+                denom == 0,
+                0.0,
+                2.0 * np.abs(y_true - y_pred) / denom,
+            )
+        return float(np.mean(terms) * 100.0)
+
+
+@MetricRegistry.register("wape")
+class WAPE(BaseMetric):
+    """Weighted Absolute Percentage Error.
+
+    Formula::
+
+        WAPE = sum(|y_true - y_pred|) / sum(|y_true|) * 100
+             = MAE / mean(|y_true|) * 100
+
+    Defined whenever ``sum(|y_true|) > 0`` — much weaker than MAPE's
+    per-row guard. Particularly useful for imbalanced-magnitude
+    regressions where one large-volume series would otherwise dominate
+    MAE noise.
+
+    Raises :class:`~lizyml.core.exceptions.LizyMLError` with
+    ``UNSUPPORTED_METRIC`` only when ``sum(|y_true|) == 0``.
+    """
+
+    @property
+    def name(self) -> str:
+        return "wape"
+
+    @property
+    def needs_proba(self) -> bool:
+        return False
+
+    @property
+    def greater_is_better(self) -> bool:
+        return False
+
+    def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
+        _validate_shapes(y_true, y_pred, self.name)
+        denom = float(np.sum(np.abs(y_true)))
+        if denom == 0.0:
+            raise LizyMLError(
+                code=ErrorCode.UNSUPPORTED_METRIC,
+                user_message="WAPE is undefined when sum(|y_true|) is zero.",
+                context={"metric": self.name},
+            )
+        return float(np.sum(np.abs(y_true - y_pred)) / denom * 100.0)

--- a/tests/test_codegen/test_feval_codegen.py
+++ b/tests/test_codegen/test_feval_codegen.py
@@ -249,6 +249,46 @@ class TestFevalNumericalEquivalence:
             rtol=1e-10,
         )
 
+    def test_smape(self, regression_data: tuple[np.ndarray, np.ndarray]) -> None:
+        """H-0071: codegen sMAPE numerically matches lizyml.metrics.SMAPE."""
+        y_true, y_pred = regression_data
+        codegen_fn = self._get_codegen_fn("smape")
+        lizyml_metric = self._get_lizyml_metric("smape")
+        np.testing.assert_allclose(
+            codegen_fn(y_true, y_pred),
+            lizyml_metric(y_true, y_pred),
+            rtol=1e-10,
+        )
+
+    def test_smape_with_zero_zero_row(self) -> None:
+        """H-0071: codegen sMAPE handles |y_true|+|y_pred|==0 row."""
+        codegen_fn = self._get_codegen_fn("smape")
+        lizyml_metric = self._get_lizyml_metric("smape")
+        y_true = np.array([0.0, 5.0, 4.0])
+        y_pred = np.array([0.0, 6.0, 6.0])
+        np.testing.assert_allclose(
+            codegen_fn(y_true, y_pred),
+            lizyml_metric(y_true, y_pred),
+            rtol=1e-10,
+        )
+
+    def test_wape(self, regression_data: tuple[np.ndarray, np.ndarray]) -> None:
+        """H-0071: codegen WAPE numerically matches lizyml.metrics.WAPE."""
+        y_true, y_pred = regression_data
+        codegen_fn = self._get_codegen_fn("wape")
+        lizyml_metric = self._get_lizyml_metric("wape")
+        np.testing.assert_allclose(
+            codegen_fn(y_true, y_pred),
+            lizyml_metric(y_true, y_pred),
+            rtol=1e-10,
+        )
+
+    def test_wape_all_zero_y_true_raises(self) -> None:
+        """H-0071: codegen WAPE raises on sum(|y_true|)==0."""
+        codegen_fn = self._get_codegen_fn("wape")
+        with pytest.raises(ValueError, match="WAPE is undefined"):
+            codegen_fn(np.array([0.0, 0.0]), np.array([1.0, 2.0]))
+
     def test_f1_binary(self, binary_data: tuple[np.ndarray, np.ndarray]) -> None:
         y_true, y_pred = binary_data
         codegen_fn = self._get_codegen_fn("f1")
@@ -382,6 +422,9 @@ class TestTemplateFevalContent:
             "_feval_ece",
             "_feval_precision_at_k",
             "_feval_accuracy",
+            # H-0071: zero-tolerant percentage-style regression metrics
+            "_feval_smape",
+            "_feval_wape",
         ]
         for name in expected:
             assert name in src, f"{name} not found in train.py template"

--- a/tests/test_estimators/test_lgbm_feval_behavioral.py
+++ b/tests/test_estimators/test_lgbm_feval_behavioral.py
@@ -195,6 +195,54 @@ class TestFevalRegressionTraining:
         assert "rmse" in valid_keys
         assert "rmsle" in valid_keys
 
+    def test_smape_in_eval_results(self) -> None:
+        """H-0071: sMAPE feval works during regression training."""
+        rng = np.random.default_rng(42)
+        X_train, y_train, X_valid, y_valid = _make_regression_data(rng)
+
+        adapter = LGBMAdapter(
+            task="regression",
+            params={"metric": ["smape"], "n_estimators": 10},
+            early_stopping_rounds=5,
+        )
+        adapter.fit(X_train, y_train, X_valid, y_valid)
+
+        history = adapter.eval_results
+        valid_keys = set(history.get("valid_0", {}).keys())
+        assert "smape" in valid_keys
+
+    def test_wape_in_eval_results(self) -> None:
+        """H-0071: WAPE feval works during regression training."""
+        rng = np.random.default_rng(42)
+        X_train, y_train, X_valid, y_valid = _make_regression_data(rng)
+
+        adapter = LGBMAdapter(
+            task="regression",
+            params={"metric": ["wape"], "n_estimators": 10},
+            early_stopping_rounds=5,
+        )
+        adapter.fit(X_train, y_train, X_valid, y_valid)
+
+        history = adapter.eval_results
+        valid_keys = set(history.get("valid_0", {}).keys())
+        assert "wape" in valid_keys
+
+    def test_mixed_native_and_smape_wape(self) -> None:
+        """H-0071: native + smape + wape mixed."""
+        rng = np.random.default_rng(42)
+        X_train, y_train, X_valid, y_valid = _make_regression_data(rng)
+
+        adapter = LGBMAdapter(
+            task="regression",
+            params={"metric": ["rmse", "smape", "wape"], "n_estimators": 10},
+            early_stopping_rounds=5,
+        )
+        adapter.fit(X_train, y_train, X_valid, y_valid)
+
+        history = adapter.eval_results
+        valid_keys = set(history.get("valid_0", {}).keys())
+        assert {"rmse", "smape", "wape"}.issubset(valid_keys)
+
 
 class TestFevalMulticlassTraining:
     """feval metrics in multiclass training."""

--- a/tests/test_estimators/test_lgbm_metric_bridge.py
+++ b/tests/test_estimators/test_lgbm_metric_bridge.py
@@ -441,6 +441,64 @@ class TestFevalNumericalCorrectness:
         assert is_higher is False
         assert feval_val == pytest.approx(expected, abs=1e-10)
 
+    # -- SMAPE / WAPE (regression, H-0071) --
+
+    def test_smape_regression_numerical(self) -> None:
+        """sMAPE feval: regression, no logit transform, tolerates per-row 0."""
+        _, fevals, _ = resolve_metrics(["smape"], "regression")
+        import lightgbm as lgb
+
+        y_true = np.array([0.0, 5.0, 4.0])
+        y_pred = np.array([1.0, 6.0, 6.0])
+        ds = lgb.Dataset(np.zeros((3, 1)), label=y_true, free_raw_data=False)
+        ds.construct()
+
+        name, feval_val, is_higher = fevals[0](y_pred, ds)
+
+        ds_label = np.asarray(ds.get_label())
+        denom = np.abs(ds_label) + np.abs(y_pred)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            terms = np.where(
+                denom == 0,
+                0.0,
+                2.0 * np.abs(ds_label - y_pred) / denom,
+            )
+        expected = float(np.mean(terms) * 100.0)
+
+        assert name == "smape"
+        assert is_higher is False
+        assert feval_val == pytest.approx(expected, abs=1e-6)
+
+    def test_wape_regression_numerical(self) -> None:
+        """WAPE feval: regression, sum-ratio form."""
+        _, fevals, _ = resolve_metrics(["wape"], "regression")
+        import lightgbm as lgb
+
+        y_true = np.array([10.0, 20.0, 30.0])
+        y_pred = np.array([11.0, 18.0, 33.0])
+        ds = lgb.Dataset(np.zeros((3, 1)), label=y_true, free_raw_data=False)
+        ds.construct()
+
+        name, feval_val, is_higher = fevals[0](y_pred, ds)
+
+        ds_label = np.asarray(ds.get_label())
+        expected = float(
+            np.sum(np.abs(ds_label - y_pred)) / np.sum(np.abs(ds_label)) * 100.0
+        )
+
+        assert name == "wape"
+        assert is_higher is False
+        assert feval_val == pytest.approx(expected, abs=1e-6)
+
+    def test_smape_invalid_for_binary(self) -> None:
+        """smape is registered as a regression-only feval metric."""
+        with pytest.raises(LizyMLError):
+            resolve_metrics(["smape"], "binary")
+
+    def test_wape_invalid_for_multiclass(self) -> None:
+        with pytest.raises(LizyMLError):
+            resolve_metrics(["wape"], "multiclass")
+
     # -- F1 (multiclass) --
 
     def test_f1_multiclass_numerical(self) -> None:

--- a/tests/test_metrics/test_regression_metrics.py
+++ b/tests/test_metrics/test_regression_metrics.py
@@ -1,4 +1,8 @@
-"""Tests for MAPE and HuberLoss regression metrics (H-0004)."""
+"""Tests for MAPE / HuberLoss / SMAPE / WAPE regression metrics.
+
+H-0004: MAPE / HuberLoss
+H-0071: SMAPE / WAPE (zero-tolerant percentage-style alternatives to MAPE)
+"""
 
 from __future__ import annotations
 
@@ -6,7 +10,14 @@ import numpy as np
 import pytest
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
-from lizyml.metrics import MAPE, HuberLoss, get_metric, get_metrics_for_task
+from lizyml.metrics import (
+    MAPE,
+    SMAPE,
+    WAPE,
+    HuberLoss,
+    get_metric,
+    get_metrics_for_task,
+)
 
 # ---------------------------------------------------------------------------
 # MAPE
@@ -112,4 +123,172 @@ class TestHuberLoss:
     def test_task_compat_multiclass_raises(self) -> None:
         with pytest.raises(LizyMLError) as exc:
             get_metrics_for_task(["huber"], "multiclass")
+        assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+
+# ---------------------------------------------------------------------------
+# SMAPE (H-0071) — symmetric MAPE, range [0, 200], tolerates per-row zeros
+# ---------------------------------------------------------------------------
+
+
+class TestSMAPE:
+    """Symmetric Mean Absolute Percentage Error.
+
+    Formula::
+
+        sMAPE = mean( 2 * |y_true - y_pred| / (|y_true| + |y_pred|) ) * 100
+
+    Convention: when ``|y_true| + |y_pred| == 0`` for a row, that row's
+    contribution is 0 (perfect prediction).
+    """
+
+    def test_correctness_handcomputed(self) -> None:
+        # |yt - yp|         = [0,    1,   2]
+        # |yt| + |yp|       = [200, 11,  10]
+        # 2 * |yt-yp| / d   = [0,   2/11, 0.4]
+        y_true = np.array([100.0, 5.0, 4.0])
+        y_pred = np.array([100.0, 6.0, 6.0])
+        expected = float(np.mean([0.0, 2 / 11, 0.4]) * 100)
+        assert SMAPE()(y_true, y_pred) == pytest.approx(expected)
+
+    def test_perfect_prediction_is_zero(self) -> None:
+        y = np.array([1.0, 2.0, 3.0])
+        assert SMAPE()(y, y) == pytest.approx(0.0)
+
+    def test_zero_zero_row_treated_as_zero(self) -> None:
+        # INV-2: |y_true| + |y_pred| == 0 → row contributes 0
+        y_true = np.array([0.0, 1.0])
+        y_pred = np.array([0.0, 1.0])
+        assert SMAPE()(y_true, y_pred) == pytest.approx(0.0)
+
+    def test_tolerates_zero_in_y_true(self) -> None:
+        # MAPE would raise here; SMAPE must not.
+        y_true = np.array([0.0, 5.0])
+        y_pred = np.array([1.0, 4.0])
+        # row 0: 2 * 1 / 1   = 2.0
+        # row 1: 2 * 1 / 9   = 2/9
+        expected = float(np.mean([2.0, 2 / 9]) * 100)
+        assert SMAPE()(y_true, y_pred) == pytest.approx(expected)
+
+    def test_tolerates_zero_in_y_pred(self) -> None:
+        y_true = np.array([5.0, 4.0])
+        y_pred = np.array([0.0, 4.0])
+        # row 0: 2 * 5 / 5   = 2.0
+        # row 1: 2 * 0 / 8   = 0.0
+        expected = float(np.mean([2.0, 0.0]) * 100)
+        assert SMAPE()(y_true, y_pred) == pytest.approx(expected)
+
+    def test_upper_bound_200(self) -> None:
+        # Opposite signs maximise sMAPE per row at 200.
+        y_true = np.array([1.0, 1.0, 1.0])
+        y_pred = np.array([-1.0, -1.0, -1.0])
+        # 2 * |1 - (-1)| / (1 + 1) = 2.0 → 200%
+        assert SMAPE()(y_true, y_pred) == pytest.approx(200.0)
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(LizyMLError) as exc:
+            SMAPE()(np.array([1.0, 2.0]), np.array([1.0]))
+        assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+    def test_contracts(self) -> None:
+        m = SMAPE()
+        assert m.name == "smape"
+        assert m.needs_proba is False
+        assert m.greater_is_better is False
+
+    def test_registry_lookup(self) -> None:
+        m = get_metric("smape")
+        assert isinstance(m, SMAPE)
+
+    def test_task_compat_regression(self) -> None:
+        metrics = get_metrics_for_task(["smape"], "regression")
+        assert len(metrics) == 1
+
+    def test_task_compat_binary_raises(self) -> None:
+        with pytest.raises(LizyMLError) as exc:
+            get_metrics_for_task(["smape"], "binary")
+        assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+
+# ---------------------------------------------------------------------------
+# WAPE (H-0071) — Weighted Absolute Percentage Error
+# ---------------------------------------------------------------------------
+
+
+class TestWAPE:
+    """Weighted Absolute Percentage Error.
+
+    Formula::
+
+        WAPE = sum(|y_true - y_pred|) / sum(|y_true|) * 100
+             = MAE / mean(|y_true|) * 100
+
+    Defined whenever ``sum(|y_true|) > 0`` (much weaker than MAPE's
+    per-row guard).
+    """
+
+    def test_correctness_handcomputed(self) -> None:
+        y_true = np.array([10.0, 20.0, 30.0])
+        y_pred = np.array([11.0, 18.0, 33.0])
+        # sum(|err|)   = 1 + 2 + 3 = 6
+        # sum(|y_true|) = 60
+        assert WAPE()(y_true, y_pred) == pytest.approx(10.0)
+
+    def test_equivalent_to_mae_over_mean_abs_y_true(self) -> None:
+        y_true = np.array([1.0, 2.0, 3.0, 4.0])
+        y_pred = np.array([1.5, 1.5, 3.5, 3.5])
+        mae = float(np.mean(np.abs(y_true - y_pred)))
+        mean_abs_yt = float(np.mean(np.abs(y_true)))
+        expected = mae / mean_abs_yt * 100
+        assert WAPE()(y_true, y_pred) == pytest.approx(expected)
+
+    def test_perfect_prediction_is_zero(self) -> None:
+        y = np.array([1.0, 2.0, 3.0])
+        assert WAPE()(y, y) == pytest.approx(0.0)
+
+    def test_partial_zero_in_y_true_does_not_raise(self) -> None:
+        # Unlike MAPE, partial zeros are fine for WAPE.
+        y_true = np.array([0.0, 1.0, 2.0])
+        y_pred = np.array([0.5, 1.0, 2.0])
+        # sum(|err|) = 0.5, sum(|y_true|) = 3.0 → 0.5 / 3.0 * 100
+        expected = 0.5 / 3.0 * 100
+        assert WAPE()(y_true, y_pred) == pytest.approx(expected)
+
+    def test_all_zero_y_true_raises(self) -> None:
+        # INV-3: only sum(|y_true|) == 0 raises.
+        y_true = np.array([0.0, 0.0, 0.0])
+        y_pred = np.array([0.0, 1.0, 2.0])
+        with pytest.raises(LizyMLError) as exc:
+            WAPE()(y_true, y_pred)
+        assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+    def test_negative_y_true_uses_abs(self) -> None:
+        # |y_true| in denominator means signs do not cancel.
+        y_true = np.array([-10.0, 10.0])
+        y_pred = np.array([-9.0, 9.0])
+        # sum(|err|) = 1 + 1 = 2, sum(|y_true|) = 20 → 10%
+        assert WAPE()(y_true, y_pred) == pytest.approx(10.0)
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(LizyMLError) as exc:
+            WAPE()(np.array([1.0, 2.0]), np.array([1.0]))
+        assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC
+
+    def test_contracts(self) -> None:
+        m = WAPE()
+        assert m.name == "wape"
+        assert m.needs_proba is False
+        assert m.greater_is_better is False
+
+    def test_registry_lookup(self) -> None:
+        m = get_metric("wape")
+        assert isinstance(m, WAPE)
+
+    def test_task_compat_regression(self) -> None:
+        metrics = get_metrics_for_task(["wape"], "regression")
+        assert len(metrics) == 1
+
+    def test_task_compat_binary_raises(self) -> None:
+        with pytest.raises(LizyMLError) as exc:
+            get_metrics_for_task(["wape"], "binary")
         assert exc.value.code == ErrorCode.UNSUPPORTED_METRIC


### PR DESCRIPTION
## Summary

Closes #101. Implements [H-0071](HISTORY.md) — adds **sMAPE** and **WAPE**, two zero-tolerant percentage-style regression metrics, plus authoritative formula documentation for every metric LizyML ships.

- **sMAPE** — `mean(2*|y - y_hat| / (|y| + |y_hat|)) * 100`, range `[0, 200]`. Tolerates per-row zeros; the `y_true == y_pred == 0` row contributes `0` by convention.
- **WAPE** — `sum(|y - y_hat|) / sum(|y|) * 100` (= `MAE / mean(|y|) * 100`). Defined whenever `sum(|y|) > 0`; only that single global case raises `UNSUPPORTED_METRIC`.

Both close the gap left by MAPE for sales / demand / count regressions where `y_true == 0` is a valid value.

## Why

Discovered by LizyStudio v0.4.0 GUI verification on 2026-05-05: regression datasets with zero-valued targets had no percentage-style option (MAPE bails with `UNSUPPORTED_METRIC`).

## Wiring

| Layer | Change |
|---|---|
| `lizyml/metrics/regression.py` | New `SMAPE`, `WAPE` classes |
| `lizyml/metrics/registry.py` | `_TASK_METRICS["regression"]` extended with `"smape"`, `"wape"` |
| `lizyml/metrics/__init__.py` | Re-export `SMAPE`, `WAPE` |
| `lizyml/estimators/lgbm/metric_bridge.py` | Added to `_FEVAL_METRICS["regression"]` so `params={"metric": "smape"}` works |
| `lizyml/codegen/templates.py` | `_feval_smape` / `_feval_wape` mirror metric bridge so `Model.export_code()` reproduces values offline |
| `docs/config-reference.md` | New **Metric formula reference** section — formulas + ranges + edge-case conventions for **every** LizyML metric, regression and classification |
| `CHANGELOG.md` | `[Unreleased]` entry under **Added** |
| `HISTORY.md` | H-0071 status flipped from **Proposed** to **Accepted** |

## Invariants verified

- INV-1/2: `SMAPE(y, y) == 0`, range `[0, 200]`, zero/zero row contributes `0` ([test_regression_metrics.py](tests/test_metrics/test_regression_metrics.py))
- INV-3: `WAPE` raises `UNSUPPORTED_METRIC` only when `sum(|y_true|) == 0`, not on per-row zeros
- INV-4: `MetricRegistry.get("smape", "regression")` succeeds, binary / multiclass raises `LizyMLError`
- INV-5: `params={"metric": "smape"}` produces `eval_history["valid_0"]["smape"]` entries during real LightGBM training
- INV-6: `greater_is_better=False`, `needs_proba=False`

## Test plan

- [x] `tests/test_metrics/test_regression_metrics.py` — 22 new unit tests (correctness, edge cases, registry, task routing)
- [x] `tests/test_estimators/test_lgbm_metric_bridge.py` — 4 new bridge tests (numerical equivalence + task-incompat raises)
- [x] `tests/test_estimators/test_lgbm_feval_behavioral.py` — 3 new behavioral tests with real `lgb.train` (eval history coverage)
- [x] `tests/test_codegen/test_feval_codegen.py` — 4 new codegen tests + extended `test_contains_all_feval_functions`
- [x] `uv run ruff check .` ✅
- [x] `uv run ruff format --check .` ✅
- [x] `uv run mypy lizyml/` ✅
- [x] `uv run pytest` — **1660 passed** (was 1320 baseline + new H-0071 + downstream additions since)

## Backwards compatibility

Fully additive. No format_version bump, no Config schema change, no behavior change for any existing metric. Default `_TASK_METRIC` (`["huber", "mae", "mape"]`) is unchanged — opt-in only.
