### PR TITLE
docs: update CHANGELOG for v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.11.0] - 2026-05-05
 
 ### Added
 
 - **sMAPE / WAPE — zero-tolerant percentage-style regression metrics** (H-0071, [#101](https://github.com/nbx-liz/LizyML/issues/101)) — `lizyml.metrics.SMAPE` and `lizyml.metrics.WAPE` are now available for `task=regression` and registered in `MetricRegistry` under `"smape"` / `"wape"`. Both close the gap left by MAPE on datasets where `y_true` may be `0` (sales / demand / count regressions). Wired into the LightGBM metric bridge so `params={"metric": ["smape", "wape"]}` produces feval-driven entries in `eval_history` / learning curves, and into the codegen exporter so `Model.export_code()` reproduces the same values offline. Authoritative formulas and edge-case conventions are documented in [`docs/config-reference.md` § Metric formula reference](docs/config-reference.md#metric-formula-reference).
+- **Metric formula reference** — `docs/config-reference.md` now documents authoritative formulas, ranges, and edge-case conventions for every regression and classification metric LizyML ships, plus a MAPE / sMAPE / WAPE selection guide.
 
 ## [0.10.0] - 2026-05-04
 


### PR DESCRIPTION
## Summary

CHANGELOG-only feature PR that precedes the v0.11.0 release.

- Promote `[Unreleased]` → `[0.11.0] - 2026-05-05`
- Adds a separate **Metric formula reference** entry covering the new docs section in `docs/config-reference.md`

## Release composition

v0.11.0 contains the following work since v0.10.0:

| H-id | PR | Topic |
|---|---|---|
| H-0071 | [#102](https://github.com/nbx-liz/LizyML/pull/102) | sMAPE / WAPE — zero-tolerant percentage-style regression metrics |
| (docs) | this PR | Metric formula reference section in `docs/config-reference.md` |

## Test plan

- [x] CHANGELOG entry uses correct date (2026-05-05) and version
- [x] No source code changes — pure docs PR
- [x] After this PR is squash-merged to develop, run `uv run python scripts/release.py v0.11.0` to open the develop → main release PR

## Next step (after squash-merge)

```bash
uv run python scripts/release.py v0.11.0
```

This opens the develop → main release PR with title `release: v0.11.0`. Merge that PR with **Create a merge commit** (NOT squash). The `auto-release.yml` workflow then creates the tag and GitHub Release, which triggers PyPI publish.
