### PR TITLE
docs: update CHANGELOG for v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.12.0] - 2026-05-06
 
 ### Added
 


### PR DESCRIPTION
Promote the Unreleased block to [0.12.0] - 2026-05-06 ahead of the release PR. Contains H-0072 (Optuna persistent storage for resumable tuning, #105). No code changes.