### PR TITLE
fix(tuning): surface exception details in progress_callback warning (#117)

### DIFF
--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -183,9 +183,10 @@ class Tuner:
                 )
                 try:
                     user_cb(info)
-                except Exception:
+                except Exception as exc:
                     warnings.warn(
-                        "progress_callback raised an exception; ignoring.",
+                        f"progress_callback raised an exception; ignoring. "
+                        f"{type(exc).__name__}: {exc}",
                         RuntimeWarning,
                         stacklevel=1,
                     )

--- a/tests/test_tuning/test_tuning_progress.py
+++ b/tests/test_tuning/test_tuning_progress.py
@@ -206,3 +206,28 @@ class TestProgressCallbackIntegration:
 
         assert call_count == 3
         assert result.best_params is not None
+
+    def test_callback_exception_warning_includes_details(self) -> None:
+        """Warning emitted from a failing callback must surface exception
+        type and message so users can debug their own callback (#117).
+        """
+
+        def bad_callback(info: TuneProgressInfo) -> None:
+            raise ValueError("intentional error in callback")
+
+        df = make_regression_df(n=200)
+        cfg = _reg_config_with_tuning(n_trials=2)
+        model = Model(cfg, data=df)
+
+        with pytest.warns(RuntimeWarning) as records:
+            model.tune(progress_callback=bad_callback)
+
+        callback_warnings = [
+            str(rec.message)
+            for rec in records
+            if "progress_callback" in str(rec.message)
+        ]
+        assert callback_warnings, "expected at least one progress_callback warning"
+        for msg in callback_warnings:
+            assert "ValueError" in msg
+            assert "intentional error in callback" in msg


### PR DESCRIPTION
## Summary
Closes #117.

`Tuner` previously swallowed user-supplied `progress_callback` exceptions with a generic `"progress_callback raised an exception; ignoring."` warning that gave the user **no signal about what actually went wrong**. This violates the global rule *"Never swallow errors silently"* and made callbacks hard to debug.

The warning now includes the exception type and message:

```
progress_callback raised an exception; ignoring. ValueError: intentional error in callback
```

## Why not the existing forhim007 PR (#127)
PR #127 covers the same surface but was authored externally; per the user's instruction it is being ignored and replaced with this in-tree fix.

## Skill / DoD
- Skill: `skills/exceptions-and-logging` — surface diagnostic context instead of swallowing.
- DoD: warning now carries `type(exc).__name__` + `str(exc)`; existing tuning tests still pass; new test asserts the contract.

## Test plan
- [x] `uv run pytest tests/test_tuning/test_tuning_progress.py` — 14 passed (1 new test added).
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/tuning/tuner.py`
- [x] New test `test_callback_exception_warning_includes_details` asserts the warning string contains `ValueError` and the original message — fails before this fix, passes after.

## Notes
- No public API change.
- No new dependency.
- `stacklevel=1` preserved (matches surrounding callbacks).