### PR TITLE
fix(tuning): clamp FloatDim linear lower expansion at zero (#110)

### DIFF
--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -221,9 +221,19 @@ def _expand_range(
     *,
     log: bool,
 ) -> tuple[float, float]:
-    """Expand *low*/*high* asymmetrically toward *edge*."""
+    """Expand *low*/*high* asymmetrically toward *edge*.
+
+    Linear lower-edge expansion is clamped at 0.0 (#110): negative bounds are
+    physically meaningless for hyperparameters such as ``learning_rate`` and
+    crash downstream samplers. Log-scale expansion is already safe because
+    division by ``_LOG_EXPANSION_FACTOR`` cannot make a positive value cross
+    zero. ``IntDim`` retains its own ``max(1, ...)`` clamp at the call site.
+    """
     if edge == "lower":
-        new_low = low / _LOG_EXPANSION_FACTOR if log and low > 0 else low - (high - low)
+        if log and low > 0:
+            new_low = low / _LOG_EXPANSION_FACTOR
+        else:
+            new_low = max(0.0, low - (high - low))
         return new_low, high
     if edge == "upper":
         new_high = (

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -174,6 +174,32 @@ class TestExpandDims:
         new = expand_dims(dims, report)
         assert new[0] is dims[0]  # same object, untouched
 
+    def test_float_dim_linear_lower_clamped_to_zero(self) -> None:
+        """Regression for #110: linear FloatDim expansion must not produce
+        negative lower bounds, otherwise downstream samplers (e.g. LightGBM
+        learning_rate) crash on physically-impossible negative values.
+        """
+        dims = [FloatDim("learning_rate", low=0.001, high=0.1, log=False)]
+        report = detect_boundary(dims, {"learning_rate": 0.001}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], FloatDim)
+        assert new[0].low >= 0.0, (
+            f"FloatDim.low must not be negative after expansion, got {new[0].low}"
+        )
+        assert new[0].high == 0.1  # upper unchanged
+
+    def test_float_dim_linear_lower_clamp_preserves_already_safe_values(
+        self,
+    ) -> None:
+        """Linear expansion that produces a non-negative low must not be
+        clamped (no over-correction)."""
+        dims = [FloatDim("ratio", low=0.5, high=1.0, log=False)]
+        report = detect_boundary(dims, {"ratio": 0.51}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.5 - (1.0 - 0.5) = 0.0, exactly the floor — should pass through
+        assert new[0].low == 0.0
+        assert new[0].high == 1.0
+
 
 # ---------------------------------------------------------------------------
 # Type extension tests


### PR DESCRIPTION
## Summary
Closes #110.

`_expand_range()` for non-log `FloatDim` produced negative `new_low` values when the best param sat near the lower edge:

```python
FloatDim("learning_rate", low=0.001, high=0.1)
best = 0.001
new_low = 0.001 - (0.1 - 0.001) = -0.098   # crashes LightGBM
```

`IntDim` already had a `max(1, ...)` clamp; `FloatDim` had none. The fix applies `max(0.0, low - (high - low))` to the linear lower-edge expansion. Log expansion is untouched (positive divided by a factor stays positive).

## Skill / DoD
- Skill: `skills/tuning` — boundary expansion safety guard.
- DoD:
  - Regression test reproduces the bug pre-fix and passes post-fix (`test_float_dim_linear_lower_clamped_to_zero`).
  - Already-safe expansions are not over-corrected (`test_float_dim_linear_lower_clamp_preserves_already_safe_values`).

## Test plan
- [x] `uv run pytest tests/test_tuning/test_retune.py` — 52 passed.
- [x] `uv run pytest tests/test_tuning/` — 152 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/tuning/search_space.py`

## Notes
- No public API change.
- No new dependency.
- Issue suggested an explicit `min_val` field on `FloatDim` as an alternative — that would require a HISTORY.md Proposal (public schema change) and is intentionally not part of this PR.