### PR TITLE
fix(config): emit DeprecationWarning for legacy validation_ratio (#111)

### DIFF
--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -373,6 +373,13 @@ class EarlyStoppingConfig(BaseModel):
                 iv_value = data.get("inner_valid")
                 if iv_value is None:
                     if legacy_ratio is not None:
+                        warnings.warn(
+                            "`validation_ratio` is deprecated; use "
+                            "`inner_valid.ratio` instead. "
+                            "Will be removed in v1.0.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
                         data["inner_valid"] = {
                             "method": "holdout",
                             "ratio": legacy_ratio,

--- a/tests/test_config/test_early_stopping_roundtrip.py
+++ b/tests/test_config/test_early_stopping_roundtrip.py
@@ -101,9 +101,10 @@ class TestExplicitFlagTracking:
     """
 
     def test_legacy_validation_ratio_keeps_auto_resolve(self) -> None:
-        cfg = EarlyStoppingConfig.model_validate(
-            {"enabled": True, "rounds": 50, "validation_ratio": 0.2}
-        )
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = EarlyStoppingConfig.model_validate(
+                {"enabled": True, "rounds": 50, "validation_ratio": 0.2}
+            )
         assert cfg.inner_valid is not None
         assert cfg.inner_valid.method == "holdout"
         assert cfg.inner_valid.ratio == 0.2

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -337,11 +337,87 @@ class TestValidationRatio:
                 }
             },
         }
-        cfg = load_config(raw)
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = load_config(raw)
         es = cfg.training.early_stopping
         assert es.inner_valid is not None
         assert es.inner_valid.ratio == pytest.approx(0.2)
         assert es.inner_valid.method == "holdout"
+
+    def test_validation_ratio_emits_deprecation_warning(self) -> None:
+        """Pure legacy ``validation_ratio`` input must emit a
+        ``DeprecationWarning`` so users have a signal to migrate (#111).
+
+        The warning must mention the field name and the replacement
+        ``inner_valid.ratio``.
+        """
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 50,
+                    "validation_ratio": 0.15,
+                }
+            },
+        }
+        with pytest.warns(DeprecationWarning) as records:
+            load_config(raw)
+        msgs = [str(rec.message) for rec in records]
+        relevant = [m for m in msgs if "validation_ratio" in m]
+        assert relevant, f"expected validation_ratio deprecation, got: {msgs}"
+        assert any("inner_valid" in m for m in relevant)
+
+    def test_inner_valid_only_emits_no_deprecation(self) -> None:
+        """Configs using the new ``inner_valid`` form must not emit any
+        deprecation warning (round-trip safety, #111)."""
+        import warnings
+
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 30,
+                    "inner_valid": {"method": "holdout", "ratio": 0.15},
+                }
+            },
+        }
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            load_config(raw)
+        vr_warnings = [r for r in records if "validation_ratio" in str(r.message)]
+        assert not vr_warnings, (
+            f"unexpected validation_ratio warning(s): "
+            f"{[str(r.message) for r in vr_warnings]}"
+        )
+
+    def test_validation_ratio_roundtrip_emits_no_deprecation(self) -> None:
+        """A round-trip dump (``inner_valid`` + ``validation_ratio`` both
+        present and consistent) must not emit a deprecation warning — the
+        ``validation_ratio`` value is the dump artifact of the computed field,
+        not user-authored legacy input (#111)."""
+        import warnings
+
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 30,
+                    "inner_valid": {"method": "holdout", "ratio": 0.15},
+                    "validation_ratio": 0.15,
+                }
+            },
+        }
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            load_config(raw)
+        vr_warnings = [r for r in records if "validation_ratio" in str(r.message)]
+        assert not vr_warnings, (
+            f"unexpected validation_ratio warning on roundtrip: "
+            f"{[str(r.message) for r in vr_warnings]}"
+        )
 
     def test_validation_ratio_and_inner_valid_conflict_raises(self) -> None:
         """Both validation_ratio and inner_valid specified → CONFIG_INVALID."""

--- a/tests/test_training/test_inner_valid_extensions.py
+++ b/tests/test_training/test_inner_valid_extensions.py
@@ -218,7 +218,8 @@ class TestExplicitOverride:
                 }
             },
         }
-        cfg = load_config(raw)
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = load_config(raw)
         iv = build_inner_valid(cfg)
         assert isinstance(iv, HoldoutInnerValid)
         assert iv.ratio == 0.2


### PR DESCRIPTION
## Summary
Closes #111.

Pure legacy input `{ training: { early_stopping: { validation_ratio: 0.15 } } }` silently migrated to `inner_valid.ratio` without any warning, breaking the consistency with other deprecated config fields (`calibration.n_splits`, `purge_window`, `embargo_pct`).

The warning is emitted only on **pure legacy input** (`validation_ratio` present, `inner_valid` absent). Round-trip dumps (which always carry both keys, since `validation_ratio` is a `computed_field`) remain warning-free.

```
DeprecationWarning: `validation_ratio` is deprecated; use `inner_valid.ratio` instead. Will be removed in v1.0.
```

## Skill / DoD
- Skill: `skills/config-and-specs` + `skills/learned/pydantic-deprecated-field-roundtrip-warning.md`.
- DoD:
  - Pure legacy input emits `DeprecationWarning` mentioning `inner_valid.ratio`.
  - `inner_valid`-only configs emit **no** deprecation warning (round-trip safety).
  - Both-keys round-trip dumps emit **no** deprecation warning.
  - Existing legacy tests updated to `pytest.warns(DeprecationWarning)`.
  - All 1674 tests pass.

## Test plan
- [x] `uv run pytest tests/test_config/ tests/test_training/ tests/test_persistence/` — 225 passed.
- [x] `uv run pytest` (full suite) — 1674 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/config/schema.py`
- [x] 3 new tests cover: warning fired on legacy, silent on `inner_valid`-only, silent on round-trip.

## Notes
- No public API change.
- Deprecation removal target (`v1.0`) tracked centrally as part of #121 (planned in Sprint 4).