### PR TITLE
fix(core): loud fail on unhandled SplitConfig in splitter dispatch (#119)

### DIFF
--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -139,15 +139,25 @@ def _build_splitter_for_method(
             max_train_size=split_cfg.train_size_max,
             max_test_size=split_cfg.test_size_max,
         )
-    # Default: KFoldConfig (or any unmatched variant)
     if isinstance(split_cfg, KFoldConfig):
         return KFoldSplitter(
             n_splits=n_splits,
             shuffle=split_cfg.shuffle,
             random_state=split_cfg.random_state,
         )
-    # Fallback — should not be reachable with the current union
-    return KFoldSplitter(n_splits=n_splits, shuffle=True, random_state=42)
+    # Loud fail — adding a new SplitConfig variant without updating this
+    # dispatch must not silently produce KFold splits (#119).
+    from lizyml.core.exceptions import ErrorCode, LizyMLError
+
+    type_name = type(split_cfg).__name__
+    raise LizyMLError(
+        code=ErrorCode.CONFIG_INVALID,
+        user_message=(
+            f"Unhandled SplitConfig type: {type_name}. "
+            "Update _build_splitter_for_method dispatch when adding a new variant."
+        ),
+        context={"split_config_type": type_name},
+    )
 
 
 def build_splitter(

--- a/tests/test_core/test_splitter_dispatch.py
+++ b/tests/test_core/test_splitter_dispatch.py
@@ -1,0 +1,37 @@
+"""Regression tests for splitter dispatch fallback (#119).
+
+The dispatch in ``_build_splitter_for_method`` previously ended with a silent
+``KFoldSplitter`` fallback for unmatched ``SplitConfig`` variants. Adding a
+new variant without updating the dispatch would have silently produced KFold
+splits instead of failing loudly. The fallback now raises ``LizyMLError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizyml.core._model_factories import _build_splitter_for_method
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+
+
+class _UnknownSplitConfig:
+    """Sentinel object that does not match any recognised ``SplitConfig``
+    isinstance check, simulating a future variant added without updating
+    the dispatch."""
+
+
+class TestUnhandledSplitConfigRaises:
+    def test_unknown_split_config_raises_lizyml_error(self) -> None:
+        unknown = _UnknownSplitConfig()
+        with pytest.raises(LizyMLError) as exc_info:
+            _build_splitter_for_method(unknown, n_splits=5)  # type: ignore[arg-type]
+        assert exc_info.value.code == ErrorCode.CONFIG_INVALID
+
+    def test_error_message_names_the_unhandled_type(self) -> None:
+        unknown = _UnknownSplitConfig()
+        with pytest.raises(LizyMLError) as exc_info:
+            _build_splitter_for_method(unknown, n_splits=5)  # type: ignore[arg-type]
+        # The message and context must surface the unhandled config type
+        # so contributors get a clear signal.
+        assert "_UnknownSplitConfig" in exc_info.value.user_message
+        assert exc_info.value.context.get("split_config_type") == "_UnknownSplitConfig"


### PR DESCRIPTION
## Summary
Closes #119.

`_build_splitter_for_method` previously ended with:

```python
# Fallback — should not be reachable with the current union
return KFoldSplitter(n_splits=n_splits, shuffle=True, random_state=42)
```

If a future `SplitConfig` variant were added without updating the dispatch, this fallback would silently produce KFold splits — the user would *not* see an error, just wrong CV behaviour. The fallback is now an explicit `LizyMLError` carrying the unhandled type name in both `user_message` and `context`.

## Skill / DoD
- Skill: `skills/exceptions-and-logging` — never silently swallow unrecognized types.
- DoD:
  - Unrecognized `SplitConfig` raises `LizyMLError(code=CONFIG_INVALID)`.
  - Error message names the unhandled class (`type(split_cfg).__name__`).
  - All known splitter dispatch paths still resolve correctly (existing 79 splitter tests pass).

## Test plan
- [x] `uv run pytest tests/test_core/test_splitter_dispatch.py` — 2 passed (new).
- [x] `uv run pytest tests/test_splitters/ tests/test_core/test_blocked_group_factory.py tests/test_config/test_stratified_default.py` — 79 passed.
- [x] `uv run pytest` (full suite) — 1673 passed, 0 failed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/core/_model_factories.py`

## Notes
- No public API change.
- `KFoldConfig` branch retained as the "default" KFold path — only the unconditional bottom-of-function fallback is replaced.
- Local `LizyMLError` import preserves the original module's lazy import style.