### PR TITLE
docs(target-encoder): document lexicographic class ordering (#125)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -475,7 +475,8 @@ LizyML 非依存の学習・推論コードを自動生成する。
 - `target_encoder`（H-0070, format_version=2）
   - `TargetEncoder(classes_: tuple[Any, ...], needs_encoding: bool, original_dtype: str)`
   - 数値 y / regression では `needs_encoding=False` の no-op
-  - 非数値 classification y では `classes_` に sorted 元ラベルを保持
+  - 非数値 classification y では `classes_` に **lexicographically** sorted な元ラベルを保持
+    （`sorted(unique, key=str)`、numeric-string では自然順とは一致しない: `["1","10","2"]` → `("1","10","2")`）
   - `predict()` / codegen / persistence migration で利用
 
 ## 7.2 TuningResult（固定スキーマ）

--- a/lizyml/core/types/target_encoder.py
+++ b/lizyml/core/types/target_encoder.py
@@ -29,9 +29,27 @@ class TargetEncoder:
     can map predicted codes back to the original labels via
     :meth:`inverse_transform`.
 
+    Class ordering:
+        Class labels are sorted **lexicographically** by their string form
+        (``sorted(unique, key=str)``). This is deterministic and works for
+        heterogeneous label types (e.g. mixed ``str``/``int``) but does
+        **not** match natural numeric order for numeric-string labels::
+
+            input y:   ["1", "10", "2"]
+            classes_:  ("1", "10", "2")     # NOT ("1", "2", "10")
+            codes:      0     1     2
+
+        Downstream metric tables (``f1_score`` per class, etc.) inherit
+        this order. If natural numeric ordering is required, cast the
+        target to a numeric dtype before fitting (then the encoder becomes
+        a no-op and the model uses the numeric values directly). This
+        ordering rule is part of the public contract — see
+        BLUEPRINT.md §7.1.
+
     Attributes:
-        classes_: Sorted original labels. Empty tuple when ``needs_encoding``
-            is False. ``classes_[i]`` corresponds to int code ``i``.
+        classes_: Lexicographically sorted original labels (see *Class
+            ordering* above). Empty tuple when ``needs_encoding`` is False.
+            ``classes_[i]`` corresponds to int code ``i``.
         needs_encoding: Whether ``transform`` / ``inverse_transform`` perform
             actual mapping. False for regression and numeric classification.
         original_dtype: String form of the original y dtype (e.g. ``"object"``,


### PR DESCRIPTION
## Summary
Closes #125.

`TargetEncoder.classes_` uses `sorted(unique, key=str)`, producing lexicographic order on the string form of each label. For numeric-string labels this surprises users:

```
input y:   ["1", "10", "2"]
classes_:  ("1", "10", "2")     # NOT ("1", "2", "10")
codes:      0     1     2
```

Downstream metric tables (`f1_score` per class, etc.) inherit this order. Determinism is preserved (same input → same output) so this is **not a correctness bug** — but the docstring did not mention it, leaving users to infer the rule from code.

This PR:
1. Expands the `TargetEncoder` class docstring with an explicit *Class ordering* section and concrete example.
2. Updates BLUEPRINT.md §7.1 to note the lexicographic key (`sorted(unique, key=str)`) and the numeric-string caveat.

## Skill / DoD
- Skill: `skills/config-and-specs` + `skills/spec-update` — public-contract documentation.
- DoD: docstring documents the ordering behavior with an explicit example; BLUEPRINT.md cross-reference is verified and updated.

## Test plan
- [x] No code change; pure documentation.
- [x] `uv run pytest tests/test_core/test_target_encoder.py` — 33 passed (no behavior change).
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/core/types/target_encoder.py`

## Notes
- No public API change.
- A future Proposal could add `class_order: Literal["lexicographic", "natural"]` to expose alternative ordering — intentionally out of scope here (Change Gate would apply).