### PR TITLE
refactor(training): inline tail-holdout fallback in StratifiedTimeHoldoutInnerValid (#124)

### DIFF
--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -215,7 +215,17 @@ class StratifiedTimeHoldoutInnerValid(BaseInnerValidStrategy):
         groups: npt.NDArray[Any] | None = None,
     ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
         if y is None:
-            return TimeHoldoutInnerValid(self.ratio).split(n_samples)
+            # Inline tail holdout (#124): avoids per-call construction of
+            # TimeHoldoutInnerValid, which is hot in tuning workloads.
+            n_valid = max(1, int(n_samples * self.ratio))
+            if n_valid >= n_samples:
+                raise ValueError(
+                    f"Inner validation would consume all {n_samples} sample(s) "
+                    f"(n_valid={n_valid}, ratio={self.ratio}). "
+                    "Increase training data or decrease validation_ratio."
+                )
+            all_idx = np.arange(n_samples, dtype=np.intp)
+            return all_idx[:-n_valid], all_idx[-n_valid:]
 
         valid_indices: list[int] = []
         for cls in np.unique(y):


### PR DESCRIPTION
## Summary
Closes #124.

`StratifiedTimeHoldoutInnerValid.split()` previously fell back to a freshly-constructed `TimeHoldoutInnerValid` per call:

```python
if y is None:
    return TimeHoldoutInnerValid(self.ratio).split(n_samples)
```

In tuning workloads (`split()` invoked many times per trial × many trials per study) this allocates a new strategy object per call. The fallback's logic is just two lines — inline directly.

## Skill / DoD
- Skill: `skills/training-cv-and-inner-valid` — internal performance refactor, no behavioral change.
- DoD:
  - No per-call instantiation of `TimeHoldoutInnerValid` in the fallback path.
  - Existing `test_regression_fallback` and 14 other inner-valid tests pass without modification (behavioral safety net).
  - Same `ValueError` raised when `n_valid >= n_samples` (preserves contract).

## Test plan
- [x] `uv run pytest tests/test_training/test_blocked_group_inner_valid.py` — 15 passed.
- [x] `uv run pytest tests/test_training/` — 73 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/training/inner_valid.py`

## Notes
- Internal change, no public API impact.
- Issue suggested two options; chose Option 2 (inline) as recommended.
- Mild duplication of 5 lines vs `TimeHoldoutInnerValid.split()` is acceptable — fallback path documented inline.