### PR TITLE
fix(types): tighten storage to str | BaseStorage | None (#113)

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -30,11 +30,14 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+
+if TYPE_CHECKING:
+    from optuna.storages import BaseStorage
 
 from lizyml import __version__
 from lizyml.config.loader import load_config
@@ -394,7 +397,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         expand_boundary: bool | None = None,
         boundary_threshold: float = 0.05,
         progress_callback: TuneProgressCallback | None = None,
-        storage: str | Any | None = None,
+        storage: str | BaseStorage | None = None,
         study_name: str | None = None,
     ) -> TuningResult:
         """Run hyperparameter search with optuna (H-0068: resume + expand,

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from optuna.storages import BaseStorage
 from lizyml.core.types.tuning_result import (
     TrialResult,
     TuneProgressCallback,
@@ -68,7 +71,7 @@ class Tuner:
         seed: int = 42,
         *,
         progress_callback: TuneProgressCallback | None = None,
-        storage: str | Any | None = None,
+        storage: str | BaseStorage | None = None,
         study_name: str | None = None,
     ) -> None:
         if storage is not None and study_name is None:


### PR DESCRIPTION
## Summary
Closes #113.

The ``storage`` parameter was annotated ``str | Any | None``. ``Any`` swallows the entire union, so mypy effectively skipped type checking on this parameter — passing an ``int`` produced no static error. Replace ``Any`` with ``BaseStorage`` from ``optuna.storages``, imported under ``TYPE_CHECKING`` because optuna is an optional dependency.

```python
# Before
storage: str | Any | None = None

# After
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from optuna.storages import BaseStorage

storage: str | BaseStorage | None = None
```

Sites:
- ``lizyml/tuning/tuner.py:71`` — ``Tuner.__init__``
- ``lizyml/core/model.py:397`` — ``Model.tune()``

## Skill / DoD
- Skill: `skills/optional-dependencies` + `skills/tuning` — typed surface for an optional-dep type.
- DoD:
  - Both call sites use ``str | BaseStorage | None``.
  - ``optuna.storages.BaseStorage`` imported under ``TYPE_CHECKING`` (no runtime import → optuna remains optional).
  - mypy succeeds on both files.
  - ``int`` passed to ``storage=`` would now trigger a mypy error at user code (verified manually — not encoded as a test since mypy-in-pytest is awkward).

## Test plan
- [x] `uv run pytest tests/test_tuning/` — 153 passed.
- [x] `uv run mypy lizyml/tuning/tuner.py lizyml/core/model.py` — Success: no issues found.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] Persistence tests (`test_tuner_persistence.py`, 11 tests) — all pass with real `storage="sqlite:///..."` URLs unchanged.

## Notes
- No public API change; no runtime behavior change.
- Doc string at the call site already mentioned `BaseStorage` — the type now matches the documentation.
- The previous `# type: ignore[import-untyped]` was unnecessary (optuna ships type info), and was dropped after mypy flagged it.