### PR TITLE
refactor(core): extract _sort_and_rebuild_components helper (#115)

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -895,23 +895,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             tc = components.time_col
             assert tc is not None  # noqa: S101
             sort_order = tc.argsort()
-            X = X.iloc[sort_order].reset_index(drop=True)
-            y = y.iloc[sort_order].reset_index(drop=True)
+            components = self._sort_and_rebuild_components(sort_order, components)
+            X, y = components.X, components.y
             if groups is not None:
                 groups = groups[sort_order]
-            sorted_time = tc.iloc[sort_order].reset_index(drop=True)
-            sorted_group = (
-                components.group_col.iloc[sort_order].reset_index(drop=True)
-                if components.group_col is not None
-                else None
-            )
-            components = DataFrameComponents(
-                X=X,
-                y=y,
-                time_col=sorted_time,
-                group_col=sorted_group,
-                target_encoder=components.target_encoder,
-            )
 
         if cfg.split.method in _BLOCK_METHODS:
             if not isinstance(cfg.split, BlockedGroupKFoldConfig):
@@ -948,35 +935,53 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             block_series = df[blocks_col_name]
             group_series = df[groups_col_name]
 
-            # Sort by blocks.col
+            # Sort by blocks.col, then rebuild via shared helper.
             sort_order = block_series.argsort()
-            X = X.iloc[sort_order].reset_index(drop=True)
-            y = y.iloc[sort_order].reset_index(drop=True)
+            components = self._sort_and_rebuild_components(sort_order, components)
+            X, y = components.X, components.y
 
             # Override groups with groups.col (not data.group_col)
             groups = group_series.iloc[sort_order].to_numpy()
             self._block_values = block_series.iloc[sort_order].to_numpy()
 
-            # Update components
-            block_sorted_time: pd.Series | None = (
-                components.time_col.iloc[sort_order].reset_index(drop=True)
-                if components.time_col is not None
-                else None
-            )
-            block_sorted_group: pd.Series | None = (
-                components.group_col.iloc[sort_order].reset_index(drop=True)
-                if components.group_col is not None
-                else None
-            )
-            components = DataFrameComponents(
-                X=X,
-                y=y,
-                time_col=block_sorted_time,
-                group_col=block_sorted_group,
-                target_encoder=components.target_encoder,
-            )
-
         return X, y, groups, components
+
+    @staticmethod
+    def _sort_and_rebuild_components(
+        sort_order: npt.NDArray[np.intp] | pd.Series,
+        components: DataFrameComponents,
+    ) -> DataFrameComponents:
+        """Apply *sort_order* to every Series in *components* and return a
+        new :class:`DataFrameComponents` (#115).
+
+        Shared by the time-series and blocked-group branches of
+        :meth:`_prepare_training_data`. The two callers previously contained
+        nearly-identical sort-and-reset blocks; the only difference is the
+        sort key, which the caller computes.
+
+        ``groups`` (``np.ndarray`` outside ``components``) is *not* touched
+        here — each branch handles it differently (TS reuses, Block
+        replaces). The ``target_encoder`` is propagated unchanged.
+        """
+        X = components.X.iloc[sort_order].reset_index(drop=True)
+        y = components.y.iloc[sort_order].reset_index(drop=True)
+        sorted_time = (
+            components.time_col.iloc[sort_order].reset_index(drop=True)
+            if components.time_col is not None
+            else None
+        )
+        sorted_group = (
+            components.group_col.iloc[sort_order].reset_index(drop=True)
+            if components.group_col is not None
+            else None
+        )
+        return DataFrameComponents(
+            X=X,
+            y=y,
+            time_col=sorted_time,
+            group_col=sorted_group,
+            target_encoder=components.target_encoder,
+        )
 
     def _build_run_meta(self, run_id: str) -> RunMeta:
         def _ver(pkg: str) -> str:


### PR DESCRIPTION
## Summary
Closes #115.

`Model._prepare_training_data()` had two near-identical \"sort_order → iloc → reset_index → DataFrameComponents reconstruction\" blocks — one for time-series methods, one for blocked-group methods. The two blocks differed only in the *sort key*; everything else (X, y, time_col, group_col, target_encoder propagation) was duplicated.

Extract a shared static helper:

```python
@staticmethod
def _sort_and_rebuild_components(sort_order, components) -> DataFrameComponents:
    ...
```

Both branches now call:
```python
sort_order = ...  # tc.argsort()  or  block_series.argsort()
components = self._sort_and_rebuild_components(sort_order, components)
X, y = components.X, components.y
# branch-specific groups handling
```

`groups` (the numpy array outside `components`) is left to each branch, since the TS branch reuses it (`groups[sort_order]`) while the Block branch replaces it (`group_series.iloc[sort_order].to_numpy()`).

## Skill / DoD
- Skill: `skills/feature-pipeline-and-leakage` — single source of truth for sort-and-rebuild.
- DoD:
  - TS branch and Block branch share the rebuild logic via the new helper.
  - `_prepare_training_data` length reduced (the duplicated block ~22 lines → 1-line call).
  - Existing E2E tests (`test_e2e/`, `test_core/`, `test_splitters/test_blocked_group_kfold.py`) pass without modification — 413 tests green.

## Test plan
- [x] `uv run pytest tests/test_e2e/ tests/test_core/ tests/test_splitters/test_blocked_group_kfold.py` — 413 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/core/model.py`

## Notes
- No public API change.
- `target_encoder` propagation is preserved (passed through unchanged in the helper).
- Behaviour is identical: existing tests cover the TS/Block code paths so any regression would surface.