### PR TITLE
fix(errors): enrich LizyMLError(context) at 23 sites + regression guard (#118)

### DIFF
--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -86,7 +86,10 @@ def _build_splitter_for_method(
                     "blocked_group_kfold requires block_values "
                     "(extracted from blocks.col by Facade)."
                 ),
-                context={},
+                context={
+                    "split_method": "blocked_group_kfold",
+                    "blocks_col": split_cfg.blocks.col,
+                },
             )
         stratify_bool = _resolve_stratify(
             split_cfg.groups.stratify, task or "regression"

--- a/lizyml/core/_model_plots.py
+++ b/lizyml/core/_model_plots.py
@@ -82,7 +82,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task == "regression":
             raise LizyMLError(
@@ -117,7 +117,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task != "binary":
             raise LizyMLError(
@@ -152,7 +152,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task != "binary":
             raise LizyMLError(
@@ -245,7 +245,7 @@ class ModelPlotsMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="tune() has not been called yet.",
-                context={},
+                context={"plot": "tuning_history", "task": self._cfg.task},
             )
         from lizyml.plots.tuning import plot_tuning_history
 

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -81,7 +81,11 @@ class ModelTablesMixin:
                     "Re-export the model with the latest version to enable "
                     "diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={
+                    "task": self._cfg.task,
+                    "loaded_from_artifact": True,
+                    "method": "residuals",
+                },
             )
         result: npt.NDArray[np.float64] = np.asarray(self._y) - fit_result.oof_pred
         return result
@@ -109,7 +113,7 @@ class ModelTablesMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task == "regression":
             raise LizyMLError(
@@ -157,7 +161,11 @@ class ModelTablesMixin:
                         "Re-export the model with the latest version to enable "
                         "diagnostic APIs after Model.load()."
                     ),
-                    context={},
+                    context={
+                        "task": self._cfg.task,
+                        "kind": kind,
+                        "method": "importance",
+                    },
                 )
             from lizyml.explain.shap_explainer import compute_shap_importance
 
@@ -201,7 +209,7 @@ class ModelTablesMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="tune() has not been called yet.",
-                context={},
+                context={"method": "tuning_table", "task": self._cfg.task},
             )
         tr = self._tuning_result
         rows = []
@@ -236,7 +244,10 @@ class ModelTablesMixin:
                     "No boundary report available. "
                     "Run tune(resume=True) to generate a boundary report."
                 ),
-                context={},
+                context={
+                    "method": "boundary_table",
+                    "tune_called": self._tuning_result is not None,
+                },
             )
         report = self._tuning_result.boundary_report
         rows = []
@@ -274,7 +285,7 @@ class ModelTablesMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="No trained models available.",
-                context={},
+                context={"method": "params_table", "task": self._cfg.task},
             )
 
         rows: list[dict[str, Any]] = []

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -287,7 +287,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Metrics not computed. Call fit() first.",
-                context={},
+                context={"task": self._cfg.task, "fit_called": False},
             )
 
         if metrics is None:
@@ -444,7 +444,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                     "No tuning configuration found. "
                     "Add a 'tuning' section to the config to enable tuning."
                 ),
-                context={},
+                context={"task": cfg.task, "model": getattr(cfg.model, "name", None)},
             )
 
         if resume and self._study is None:
@@ -454,7 +454,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                     "Cannot resume tuning: no previous tune() call. "
                     "Run tune() first, then tune(resume=True)."
                 ),
-                context={},
+                context={"resume": True, "round_number": self._round_number},
             )
 
         if not 0.0 < boundary_threshold < 0.5:
@@ -850,7 +850,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 "No data provided. Pass a DataFrame to fit(data=df) or "
                 "set data.path in the config."
             ),
-            context={},
+            context={
+                "cfg_data_path": self._cfg.data.path,
+                "constructor_data": self._data is not None,
+            },
         )
 
     def _prepare_training_data(
@@ -1072,7 +1075,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Model has not been fitted. Call fit() first.",
-                context={},
+                context={"task": self._cfg.task, "method": "fit"},
             )
         return self._fit_result
 
@@ -1081,6 +1084,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Model has not been fitted. Call fit() first.",
-                context={},
+                context={
+                    "task": self._cfg.task,
+                    "method": "refit",
+                    "fit_done": self._fit_result is not None,
+                },
             )
         return self._refit_result

--- a/lizyml/plots/calibration.py
+++ b/lizyml/plots/calibration.py
@@ -48,7 +48,7 @@ def _require_calibrator(fit_result: FitResult) -> Any:
                 "Calibration plots require calibration to be enabled. "
                 "Set calibration.method in the config."
             ),
-            context={},
+            context={"calibrator_type": type(fit_result.calibrator).__name__},
         )
     return fit_result.calibrator
 

--- a/lizyml/plots/importance.py
+++ b/lizyml/plots/importance.py
@@ -87,7 +87,7 @@ def plot_importance(
         raise LizyMLError(
             code=ErrorCode.MODEL_NOT_FIT,
             user_message="No trained models found in FitResult.",
-            context={},
+            context={"plot": "importance", "kind": kind},
         )
 
     # Average importance across folds

--- a/lizyml/plots/learning_curve.py
+++ b/lizyml/plots/learning_curve.py
@@ -61,7 +61,7 @@ def plot_learning_curve(
         raise LizyMLError(
             code=ErrorCode.MODEL_NOT_FIT,
             user_message="No training history found in FitResult.",
-            context={},
+            context={"plot": "learning_curve", "n_history": 0},
         )
 
     # Gather eval_history entries; skip folds with empty history
@@ -86,7 +86,10 @@ def plot_learning_curve(
                 "No evaluation history found. "
                 "Enable early stopping to record validation metrics per fold."
             ),
-            context={},
+            context={
+                "plot": "learning_curve",
+                "n_folds": len(fit_result.history),
+            },
         )
 
     # Use first fold's keys as reference

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -143,7 +143,10 @@ class GroupHoldoutInnerValid(BaseInnerValidStrategy):
                     "GroupHoldoutInnerValid requires groups to be provided. "
                     "Set data.group_col in the config."
                 ),
-                context={},
+                context={
+                    "n_samples": n_samples,
+                    "strategy": "GroupHoldoutInnerValid",
+                },
             )
         # Preserve input order of groups (np.unique sorts, so use dict.fromkeys)
         seen: dict[Any, None] = dict.fromkeys(groups.tolist())
@@ -286,7 +289,11 @@ class BlockedGroupInnerValid(BaseInnerValidStrategy):
                     "BlockedGroupInnerValid requires groups. "
                     "Set groups.col in the split config."
                 ),
-                context={},
+                context={
+                    "n_samples": n_samples,
+                    "strategy": "BlockedGroupInnerValid",
+                    "task": self.task,
+                },
             )
 
         # Preserve input order (= time order)

--- a/tests/test_core/test_no_empty_context.py
+++ b/tests/test_core/test_no_empty_context.py
@@ -1,0 +1,47 @@
+"""Lint-style regression test: forbid bare ``context={}`` in production code (#118).
+
+The rule:
+    Every ``LizyMLError(...)`` must include at least one diagnostic key in
+    ``context``. Empty dicts strip the user of useful debugging info — see
+    the project rule \"Never swallow errors silently\".
+
+This test scans ``lizyml/`` for the literal ``context={}`` and fails if any
+sites are found. Tests and SKILL.md examples are exempt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE_ROOT = Path(__file__).parent.parent.parent / "lizyml"
+_PATTERN = re.compile(r"context\s*=\s*\{\s*\}")
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SOURCE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+class TestNoEmptyContext:
+    def test_source_root_exists(self) -> None:
+        """Sanity: the scan target must exist."""
+        assert _SOURCE_ROOT.is_dir(), f"missing source root: {_SOURCE_ROOT}"
+
+    def test_no_empty_context_in_production(self) -> None:
+        """Every ``LizyMLError`` must carry a non-empty ``context``."""
+        offenders: list[str] = []
+        for path in _iter_python_files():
+            text = path.read_text(encoding="utf-8")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if _PATTERN.search(line):
+                    rel = path.relative_to(_SOURCE_ROOT.parent)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+        if offenders:
+            pytest.fail(
+                "Empty context={} found in production code (#118 rule). "
+                "Every LizyMLError must include at least one diagnostic key:\n"
+                + "\n".join(offenders)
+            )


### PR DESCRIPTION
## Summary
Closes #118.

`LizyMLError` is designed to carry a ``context: dict`` for downstream debugging, but 23 call sites passed ``context={}``. When one of these errors fires in production, the user had no information beyond the generic ``user_message``. This violated the project rule *"Never swallow errors silently"*.

This PR:
1. Enriches every site with at least one diagnostic key (typically: ``method``, ``task``, ``loaded_from_artifact``, ``split_method``, ``strategy``, ``plot``, ``kind``, etc.).
2. Adds a lint-style regression test (`tests/test_core/test_no_empty_context.py`) that fails CI if any new ``context={}`` is introduced in ``lizyml/``.

Files touched:
- ``lizyml/core/model.py`` (6 sites)
- ``lizyml/core/_model_plots.py`` (4 sites)
- ``lizyml/core/_model_tables.py`` (6 sites)
- ``lizyml/core/_model_factories.py`` (1 site)
- ``lizyml/training/inner_valid.py`` (2 sites)
- ``lizyml/plots/calibration.py`` (1 site)
- ``lizyml/plots/importance.py`` (1 site)
- ``lizyml/plots/learning_curve.py`` (2 sites)

Total: **23 sites enriched, 0 ``context={}`` remain in production**.

## Skill / DoD
- Skill: `skills/exceptions-and-logging` — every error must carry diagnostic context.
- DoD:
  - ``grep -rn 'context={}' lizyml/`` returns zero matches.
  - Each enriched context contains at least one key relevant to the failure site (audited per-site).
  - New regression test prevents regression.
  - All 1693 tests pass.

## Test plan
- [x] `uv run pytest tests/test_core/test_no_empty_context.py` — 2 passed (new lint test).
- [x] `uv run pytest` (full suite) — 1693 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/`
- [x] `grep -rn 'context={}' lizyml/` — 0 matches.

## Notes
- No public API change.
- Context keys chosen are small, low-PII, and useful for triage (``task``, ``method``, ``split_method``, etc.). No raw user data is leaked into context.