### PR TITLE
refactor(core): split Model.tune() into 5 testable helpers (#114)

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -437,6 +437,120 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 prior tune().
         """
         cfg = self._cfg
+        self._validate_tune_inputs(resume=resume, boundary_threshold=boundary_threshold)
+
+        optuna_cfg = cfg.tuning.optuna.params  # type: ignore[union-attr]
+        actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
+
+        _log.info(
+            "event='tune.start' task=%s resume=%s n_trials=%d",
+            cfg.task,
+            resume,
+            actual_n_trials,
+        )
+
+        self._ensure_run_dir(generate_run_id())
+        X, y, groups, _ = self._prepare_training_data(data)
+        self._X, self._y = X, y
+
+        provider = get_provider(cfg.model)
+        self._provider = provider
+        n_classes = int(y.nunique()) if cfg.task == "multiclass" else None
+        splitter = build_splitter(
+            cfg,
+            block_values=self._block_values,
+            task=cfg.task,
+            seed=cfg.training.seed,
+        )
+        base_model_params, base_smart_params = self._merge_params(provider)
+
+        space, used_default, fixed = self._resolve_search_space(
+            resume=resume, provider=provider
+        )
+        space, boundary_report, expanded_names = self._maybe_expand_boundary(
+            space,
+            resume=resume,
+            used_default=used_default,
+            expand_boundary=expand_boundary,
+            boundary_threshold=boundary_threshold,
+        )
+
+        # --- Metric & evaluator setup --------------------------------------------
+        metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
+        from lizyml.metrics.registry import parse_metric_entry
+
+        first_entry = metric_entries[0]
+        metric_name, _ = parse_metric_entry(first_entry)
+
+        evaluator = Evaluator(task=cfg.task)
+        fingerprint = fp_compute(X, file_path=None)
+        run_meta = self._build_run_meta(generate_run_id())
+
+        objective = self._build_tune_objective(
+            space=space,
+            base_model_params=base_model_params,
+            base_smart_params=base_smart_params,
+            fixed=fixed,
+            provider=provider,
+            splitter=splitter,
+            X=X,
+            y=y,
+            groups=groups,
+            n_classes=n_classes,
+            fingerprint=fingerprint,
+            run_meta=run_meta,
+            evaluator=evaluator,
+            first_entry=first_entry,
+            metric_name=metric_name,
+        )
+
+        round_number = self._round_number + 1
+        result, study, prior_trials, best_score_before = self._run_tune_round(
+            objective,
+            space=space,
+            actual_n_trials=actual_n_trials,
+            optuna_cfg=optuna_cfg,
+            metric_name=metric_name,
+            progress_callback=progress_callback,
+            storage=storage,
+            study_name=study_name,
+            resume=resume,
+            round_number=round_number,
+            expanded_names=expanded_names,
+        )
+
+        final_result, all_rounds = self._assemble_tuning_result(
+            result,
+            round_number=round_number,
+            actual_n_trials=actual_n_trials,
+            best_score_before=best_score_before,
+            expanded_names=expanded_names,
+            space=space,
+            boundary_report=boundary_report,
+            prior_trials=prior_trials,
+        )
+
+        # --- Update internal state -----------------------------------------------
+        self._tuning_result = final_result
+        self._study = study
+        self._round_number = round_number
+        self._rounds = list(all_rounds)
+        self._space = space
+        self._used_default_space = used_default
+
+        _log.info(
+            "event='tune.done' round=%d best_params=%s",
+            round_number,
+            final_result.best_params,
+        )
+        return final_result
+
+    # --- tune() helpers (#114 — split god method) -------------------------------
+
+    def _validate_tune_inputs(self, *, resume: bool, boundary_threshold: float) -> None:
+        """Validate cfg + tune-call invariants. Raises ``LizyMLError`` on
+        violation."""
+        cfg = self._cfg
         if cfg.tuning is None:
             raise LizyMLError(
                 code=ErrorCode.CONFIG_INVALID,
@@ -467,32 +581,20 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 context={"boundary_threshold": boundary_threshold},
             )
 
-        optuna_cfg = cfg.tuning.optuna.params
-        actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
+    def _resolve_search_space(
+        self,
+        *,
+        resume: bool,
+        provider: EstimatorProvider,
+    ) -> tuple[list[Any], bool, dict[str, Any]]:
+        """Return the search space for this tune call.
 
-        _log.info(
-            "event='tune.start' task=%s resume=%s n_trials=%d",
-            cfg.task,
-            resume,
-            actual_n_trials,
-        )
-
-        self._ensure_run_dir(generate_run_id())
-        X, y, groups, _ = self._prepare_training_data(data)
-        self._X, self._y = X, y
-
-        provider = get_provider(cfg.model)
-        self._provider = provider
-        n_classes = int(y.nunique()) if cfg.task == "multiclass" else None
-        splitter = build_splitter(
-            cfg,
-            block_values=self._block_values,
-            task=cfg.task,
-            seed=cfg.training.seed,
-        )
-        base_model_params, base_smart_params = self._merge_params(provider)
-
-        # --- Resolve search space ------------------------------------------------
+        Returns a tuple ``(space, used_default, fixed_params)`` where
+        ``used_default`` signals that no user-supplied space was provided
+        (drives the H-0068 expand-boundary default).
+        """
+        cfg = self._cfg
+        assert cfg.tuning is not None  # noqa: S101 — validated upstream
         if resume and self._space is not None:
             space = list(self._space)
             used_default = self._used_default_space
@@ -508,52 +610,86 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         fixed: dict[str, Any] = (
             provider.default_fixed_params(cfg.task) if used_default else {}
         )
+        return space, used_default, fixed
 
-        # --- H-0068: boundary detection + expansion ------------------------------
-        boundary_report: BoundaryReport | None = None
-        expanded_names: tuple[str, ...] = ()
-        if resume and self._tuning_result is not None:
-            should_expand = expand_boundary
-            if should_expand is None:
-                should_expand = used_default
+    def _maybe_expand_boundary(
+        self,
+        space: list[Any],
+        *,
+        resume: bool,
+        used_default: bool,
+        expand_boundary: bool | None,
+        boundary_threshold: float,
+    ) -> tuple[list[Any], BoundaryReport | None, tuple[str, ...]]:
+        """Apply H-0068 boundary detection + expansion when applicable.
 
-            if should_expand:
-                boundary_report = detect_boundary(
-                    space, self._tuning_result.best_params, boundary_threshold
-                )
-                expanded_names = boundary_report.expanded_names
-                if expanded_names:
-                    space = expand_dims(space, boundary_report)
-                    for name in expanded_names:
-                        status = next(s for s in boundary_report.dims if s.name == name)
-                        _log.info(
-                            "event='tune.expand' dim=%s edge=%s "
-                            "old=[%s, %s] new=[%s, %s] best=%s",
-                            name,
-                            status.edge,
-                            status.low,
-                            status.high,
-                            status.new_low,
-                            status.new_high,
-                            status.best_value,
-                        )
-                else:
-                    _log.info("event='tune.resume' no dims near boundary")
-            else:
-                _log.info("event='tune.resume' expand_boundary=False")
+        Returns ``(new_space, boundary_report, expanded_names)``. Without
+        a prior tune() or when ``expand_boundary`` is False, the input
+        ``space`` is returned unchanged with ``(None, ())``.
+        """
+        if not (resume and self._tuning_result is not None):
+            return space, None, ()
 
-        # --- Metric & evaluator setup --------------------------------------------
-        metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
-        from lizyml.metrics.registry import parse_metric_entry
+        should_expand = expand_boundary
+        if should_expand is None:
+            should_expand = used_default
 
-        first_entry = metric_entries[0]
-        metric_name, _ = parse_metric_entry(first_entry)
+        if not should_expand:
+            _log.info("event='tune.resume' expand_boundary=False")
+            return space, None, ()
 
-        evaluator = Evaluator(task=cfg.task)
-        fingerprint = fp_compute(X, file_path=None)
-        run_meta = self._build_run_meta(generate_run_id())
+        boundary_report = detect_boundary(
+            space, self._tuning_result.best_params, boundary_threshold
+        )
+        expanded_names = boundary_report.expanded_names
+        if not expanded_names:
+            _log.info("event='tune.resume' no dims near boundary")
+            return space, boundary_report, expanded_names
 
-        # --- Build objective closure (H-0050: uses _build_train_components) -------
+        new_space = expand_dims(space, boundary_report)
+        for name in expanded_names:
+            status = next(s for s in boundary_report.dims if s.name == name)
+            _log.info(
+                "event='tune.expand' dim=%s edge=%s old=[%s, %s] new=[%s, %s] best=%s",
+                name,
+                status.edge,
+                status.low,
+                status.high,
+                status.new_low,
+                status.new_high,
+                status.best_value,
+            )
+        return new_space, boundary_report, expanded_names
+
+    def _build_tune_objective(
+        self,
+        *,
+        space: list[Any],
+        base_model_params: dict[str, Any],
+        base_smart_params: dict[str, Any],
+        fixed: dict[str, Any],
+        provider: EstimatorProvider,
+        splitter: Any,
+        X: pd.DataFrame,
+        y: pd.Series,
+        groups: npt.NDArray[Any] | None,
+        n_classes: int | None,
+        fingerprint: Any,
+        run_meta: RunMeta,
+        evaluator: Evaluator,
+        first_entry: Any,
+        metric_name: str,
+    ) -> Any:
+        """Return the optuna objective closure used by ``Tuner``.
+
+        Captures all parameters needed by a single trial: the provider,
+        splitter, training data, fingerprint/run-meta and the metric to
+        optimise. The closure rebuilds ``TrainComponents`` and ``CVTrainer``
+        per trial because trial-level params (``smart``, ``training``)
+        change per call.
+        """
+        cfg = self._cfg
+
         def objective(trial: Any) -> float:
             trial_params = suggest_params(trial, space)
             model_p, smart_p, training_p = split_by_category(trial_params, space)
@@ -591,15 +727,35 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             score: float = metrics["raw"]["oof"][metric_name]
             return score
 
-        # --- Run tuner ------------------------------------------------------------
-        round_number = self._round_number + 1
+        return objective
+
+    def _run_tune_round(
+        self,
+        objective: Any,
+        *,
+        space: list[Any],
+        actual_n_trials: int,
+        optuna_cfg: Any,
+        metric_name: str,
+        progress_callback: TuneProgressCallback | None,
+        storage: str | BaseStorage | None,
+        study_name: str | None,
+        resume: bool,
+        round_number: int,
+        expanded_names: tuple[str, ...],
+    ) -> tuple[TuningResult, Any, int, float | None]:
+        """Construct the ``Tuner`` and execute one round of optuna search.
+
+        Returns ``(raw_result, study, prior_trials, best_score_before)``.
+        ``prior_trials`` and ``best_score_before`` are populated only when
+        ``resume`` is True (validated upstream by ``_validate_tune_inputs``).
+        """
         prior_trials = 0
         best_score_before: float | None = None
         enqueue: dict[str, Any] | None = None
         if resume:
-            # Guaranteed non-None: validated at the top of tune()
-            assert self._study is not None
-            assert self._tuning_result is not None
+            assert self._study is not None  # noqa: S101 — validated upstream
+            assert self._tuning_result is not None  # noqa: S101
             prior_trials = len(self._study.trials)
             best_score_before = self._tuning_result.best_score
             enqueue = dict(self._tuning_result.best_params)
@@ -609,12 +765,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             n_trials=actual_n_trials,
             direction=optuna_cfg.direction,
             timeout=optuna_cfg.timeout,
-            seed=cfg.training.seed,
+            seed=self._cfg.training.seed,
             progress_callback=progress_callback,
             storage=storage,
             study_name=study_name,
         )
-
         result, study = tuner.tune(
             objective,
             metric_name=metric_name,
@@ -624,26 +779,42 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             prior_trials=prior_trials,
             expanded_dims=expanded_names,
         )
+        return result, study, prior_trials, best_score_before
 
-        # --- Build round summary and fix trial round numbers ---------------------
+    def _assemble_tuning_result(
+        self,
+        raw_result: TuningResult,
+        *,
+        round_number: int,
+        actual_n_trials: int,
+        best_score_before: float | None,
+        expanded_names: tuple[str, ...],
+        space: list[Any],
+        boundary_report: BoundaryReport | None,
+        prior_trials: int,
+    ) -> tuple[TuningResult, tuple[RoundSummary, ...]]:
+        """Build the round summary, fix per-trial round numbers, and
+        assemble the final ``TuningResult``.
+
+        Returns ``(final_result, all_rounds)``. ``all_rounds`` is the new
+        complete tuple including the just-completed round, ready for
+        persistence to ``self._rounds``.
+        """
         round_summary = RoundSummary(
             round=round_number,
             n_trials=actual_n_trials,
             best_score_before=best_score_before,
-            best_score_after=result.best_score,
+            best_score_after=raw_result.best_score,
             expanded_dims=expanded_names,
             space_snapshot=tuple(space),
         )
-
-        # Preserve previous rounds + add current
         all_rounds = tuple(self._rounds) + (round_summary,)
 
-        # Fix up trial round numbers: trials from previous rounds keep their
-        # original round, new trials get current round_number
+        # Fix up trial round numbers: trials from previous rounds keep
+        # their original round, new trials get the current round_number.
         fixed_trials = []
-        for t in result.trials:
+        for t in raw_result.trials:
             if t.number < prior_trials:
-                # Find which round this trial belonged to
                 trial_round = 1
                 cumulative = 0
                 for rs in self._rounds:
@@ -655,33 +826,18 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             else:
                 fixed_trials.append(dataclasses.replace(t, round=round_number))
 
-        # Rebuild result with rounds and boundary_report
         final_result = TuningResult(
-            best_model_params=result.best_model_params,
-            best_smart_params=result.best_smart_params,
-            best_training_params=result.best_training_params,
-            best_score=result.best_score,
+            best_model_params=raw_result.best_model_params,
+            best_smart_params=raw_result.best_smart_params,
+            best_training_params=raw_result.best_training_params,
+            best_score=raw_result.best_score,
             trials=fixed_trials,
-            metric_name=result.metric_name,
-            direction=result.direction,
+            metric_name=raw_result.metric_name,
+            direction=raw_result.direction,
             rounds=all_rounds,
             boundary_report=boundary_report,
         )
-
-        # --- Update internal state -----------------------------------------------
-        self._tuning_result = final_result
-        self._study = study
-        self._round_number = round_number
-        self._rounds = list(all_rounds)
-        self._space = space
-        self._used_default_space = used_default
-
-        _log.info(
-            "event='tune.done' round=%d best_params=%s",
-            round_number,
-            final_result.best_params,
-        )
-        return final_result
+        return final_result, all_rounds
 
     # ------------------------------------------------------------------
     # Properties


### PR DESCRIPTION
## Summary
Closes #114. Replaces #139 (closed; merge conflict with #138 was resolved by rebase, force-push blocked by hook).

`Model.tune()` was a 293-line god method combining input validation, data prep, search-space resolution, boundary detection, objective construction, round execution, and TuningResult assembly. Decomposed into 5 helpers:

| Helper | Lines | Responsibility |
|---|---|---|
| `_validate_tune_inputs` | ~30 | cfg + tune-call invariants → ``LizyMLError`` |
| `_resolve_search_space` | ~28 | (space, used_default, fixed_params) per-call |
| `_maybe_expand_boundary` | ~45 | H-0068 boundary detection + log + expansion |
| `_build_tune_objective` | ~55 | Returns the optuna objective closure |
| `_run_tune_round` | ~45 | Tuner construction + study.tune() + resume bookkeeping |
| `_assemble_tuning_result` | ~50 | Round summary + per-trial round number fixup + final TuningResult |

`tune()` body is now ~110 lines of straight orchestration (down from 293). The signature, docstring and behaviour are unchanged.

## Why this matters
- Each phase is now testable in isolation with mock inputs.
- Adding a new feature (different stopping rule, custom round semantics) edits ≤ 1 helper.
- Stack traces reflect the failing phase, easing debug.

## Skill / DoD
- Skill: `skills/tuning` — refactor of the tune entry point.
- DoD:
  - `Model.tune()` body well under the 293-line baseline; split into 5 named phases.
  - Each helper has a clear single responsibility and a self-contained docstring.
  - All existing tuning + E2E + core tests pass without modification.
  - No public API or behavior change.

## Test plan
- [x] `uv run pytest tests/test_tuning/ tests/test_core/ tests/test_e2e/` — 549 passed.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/core/model.py`

## Notes
- Issue target was `<80 lines` for `tune()`; we landed at ~110 lines of orchestration body (+45 lines docstring). Further extraction (data-prep + state-update consolidation) was considered but rejected — the remaining body is sequential phase calls with no internal complexity, and excessive splitting would obscure the orchestration.
- Each helper takes only the data it needs (no `self._*` reads inside helpers beyond what's necessary), aligning with #112 (FitState) future work.
- Diagnostic context enrichment from #138 is preserved inside `_validate_tune_inputs`.