### PR TITLE
fix(core): code-review followup for Sprint 1+2 (HIGH issues + #124 test gap)

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+from collections.abc import Callable
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -41,7 +42,11 @@ if TYPE_CHECKING:
 
 from lizyml import __version__
 from lizyml.config.loader import load_config
-from lizyml.config.schema import BlockedGroupKFoldConfig, LizyMLConfig
+from lizyml.config.schema import (
+    BlockedGroupKFoldConfig,
+    LizyMLConfig,
+    OptunaParamsConfig,
+)
 from lizyml.core._model_factories import (
     build_inner_valid,
     build_splitter,
@@ -57,7 +62,7 @@ from lizyml.core.logging import generate_run_id, get_logger
 from lizyml.core.specs.feature_spec import FeatureSpec
 from lizyml.core.specs.problem_spec import ProblemSpec
 from lizyml.core.train_components import TrainComponents
-from lizyml.core.types.artifacts import RunMeta
+from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.predict_result import PredictionResult
 from lizyml.core.types.tuning_result import (
@@ -71,6 +76,7 @@ from lizyml.data.dataframe_builder import DataFrameComponents
 from lizyml.data.fingerprint import compute as fp_compute
 from lizyml.estimators.provider import EstimatorProvider
 from lizyml.evaluation.evaluator import Evaluator
+from lizyml.splitters.base import BaseSplitter
 from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
 from lizyml.training.refit_trainer import RefitResult, RefitTrainer
@@ -669,17 +675,17 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         base_smart_params: dict[str, Any],
         fixed: dict[str, Any],
         provider: EstimatorProvider,
-        splitter: Any,
+        splitter: BaseSplitter,
         X: pd.DataFrame,
         y: pd.Series,
         groups: npt.NDArray[Any] | None,
         n_classes: int | None,
-        fingerprint: Any,
+        fingerprint: DataFingerprint,
         run_meta: RunMeta,
         evaluator: Evaluator,
-        first_entry: Any,
+        first_entry: str | dict[str, Any],
         metric_name: str,
-    ) -> Any:
+    ) -> Callable[[Any], float]:
         """Return the optuna objective closure used by ``Tuner``.
 
         Captures all parameters needed by a single trial: the provider,
@@ -731,11 +737,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
     def _run_tune_round(
         self,
-        objective: Any,
+        objective: Callable[[Any], float],
         *,
         space: list[Any],
         actual_n_trials: int,
-        optuna_cfg: Any,
+        optuna_cfg: OptunaParamsConfig,
         metric_name: str,
         progress_callback: TuneProgressCallback | None,
         storage: str | BaseStorage | None,
@@ -1007,7 +1013,9 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 "set data.path in the config."
             ),
             context={
-                "cfg_data_path": self._cfg.data.path,
+                # Defensive: only the boolean is logged so that user file
+                # paths never leak through error logs / repr (cf. #118 audit).
+                "cfg_data_path_set": bool(self._cfg.data.path),
                 "constructor_data": self._data is not None,
             },
         )

--- a/tests/test_training/test_blocked_group_inner_valid.py
+++ b/tests/test_training/test_blocked_group_inner_valid.py
@@ -211,6 +211,16 @@ class TestStratifiedTimeHoldout:
         # Last 20% = 2 rows
         np.testing.assert_array_equal(valid_idx, np.array([8, 9]))
 
+    def test_regression_fallback_raises_when_ratio_consumes_all(self) -> None:
+        """Inline fallback (#124) must reject configurations that would
+        consume the entire training set, matching the pre-refactor contract
+        of ``TimeHoldoutInnerValid``. The trip wire fires for n_samples=1
+        because ``max(1, int(1*r))`` is always 1, leaving zero training rows.
+        """
+        strategy = StratifiedTimeHoldoutInnerValid(ratio=0.5)
+        with pytest.raises(ValueError, match="would consume all"):
+            strategy.split(1, y=None)
+
     def test_complete_coverage(self) -> None:
         y = np.array([0, 1, 0, 1, 0, 1])
         strategy = StratifiedTimeHoldoutInnerValid(ratio=0.3)


### PR DESCRIPTION
## Summary
Follow-up to the post-merge code review of Sprint 1 + Sprint 2 (12 PRs already merged). Addresses **3 HIGH** findings + **1 coverage gap**:

### HIGH 1 — Defensive: never log file paths via error context
``Model._load_data()`` raised ``LizyMLError`` with ``context={"cfg_data_path": self._cfg.data.path, ...}``. The error path is only reached when ``cfg.data.path`` is falsy, so no real path leaks today — but exposing the field by value is fragile. Changed to ``"cfg_data_path_set": bool(self._cfg.data.path)`` so the field is purely diagnostic.

### HIGH 2 — `optuna_cfg: Any` → `OptunaParamsConfig`
`Model._run_tune_round` accepted ``optuna_cfg: Any`` even though callers always pass a concrete ``OptunaParamsConfig``. ``Any`` swallowed the union and disabled mypy for ``.n_trials`` / ``.direction`` / ``.timeout`` access. Tightened to the concrete schema type.

### HIGH 3 — `splitter / fingerprint / first_entry / objective` typed
`Model._build_tune_objective` had four ``Any`` parameters that have well-defined types in the codebase:

- ``splitter: Any`` → ``BaseSplitter``
- ``fingerprint: Any`` → ``DataFingerprint``
- ``first_entry: Any`` → ``str | dict[str, Any]``
- return ``Any`` → ``Callable[[Any], float]``

`_run_tune_round`'s ``objective: Any`` is also tightened to ``Callable[[Any], float]`` for symmetry.

### Coverage gap — `inner_valid.py:227`
The inline fallback ``ValueError`` raised by ``StratifiedTimeHoldoutInnerValid.split(y=None)`` when ``n_valid >= n_samples`` (added in #124) was not covered. Added ``test_regression_fallback_raises_when_ratio_consumes_all`` — the trip wire fires for ``n_samples=1`` because ``max(1, int(1*r))`` is always 1.

## Skill / DoD
- Skill: `skills/exceptions-and-logging` + `skills/tuning` + `skills/testing`.
- DoD:
  - No file paths or other PII flow through `LizyMLError(context=...)`.
  - Every helper signature inside `Model.tune()` orchestration carries concrete types — `mypy --strict` would catch wrong types at every boundary.
  - `inner_valid.py` coverage rises from 96% to 97% (only pre-existing init-validator paths remain uncovered).

## Test plan
- [x] `uv run pytest tests/test_training/test_blocked_group_inner_valid.py` — 16 passed (1 new).
- [x] `uv run pytest --cov=lizyml -q` — 1694 passed, **98% total**.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/core/model.py`

## Notes
- No public API change; the helpers are private.
- MEDIUM/LOW findings from the same review (e.g. `parse_metric_entry` deduplication, `model.py` Mixin re-split, deprecation warning `stacklevel`) are intentionally out of scope here — they will be batched into a separate cleanup PR or addressed alongside Sprint 3 work.