### PR TITLE
feat(estimators): build_export_params + get_outer_n_splits (H-0073, closes #109 #126)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1237,6 +1237,9 @@ class EstimatorProvider(Protocol):
     def params_summary(
         self, model: BaseEstimatorAdapter, model_cfg: Any,
     ) -> list[dict[str, Any]]: ...
+    def build_export_params(
+        self, adapter: BaseEstimatorAdapter,
+    ) -> ExportParams: ...
 ```
 
 制約:
@@ -1245,6 +1248,7 @@ class EstimatorProvider(Protocol):
 - `runtime_deps()` はアルゴリズム固有の依存パッケージ名とバージョンを返す（例: `{"lightgbm": "4.5.0"}`）。`RunMeta.deps_versions` に使用。
 - `params_summary()` は `params_table()` 用のパラメータ行を返す。smart params + native model params（`metric` を含む、H-0061）の両方を含む。
 - `build_pipeline_factory` は estimator 固有の FeaturePipeline が必要な場合（例: EntityEmbedding のカテゴリ埋め込み）に対応する。デフォルトは `NativeFeaturePipeline` を返す。
+- `build_export_params` は codegen 経路（`Model.export_code()`）が必要とする native params / num_boost_round / feval metadata を `ExportParams` frozen dataclass で返す（H-0073）。`_model_persistence.py` から estimator 具象型（`LGBMAdapter` 等）への直接参照を排除するための入口。
 
 ディレクトリ構成（estimator ごとにサブパッケージ化）:
 

--- a/lizyml/codegen/artifact_writer.py
+++ b/lizyml/codegen/artifact_writer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from lizyml.calibration.base import BaseCalibratorAdapter
-from lizyml.estimators.lgbm.adapter import LGBMAdapter
+from lizyml.estimators.base import BaseEstimatorAdapter
 
 
 def _convert_pipeline_state(
@@ -39,7 +39,7 @@ def write_artifacts(
     *,
     output_dir: str | Path,
     config: dict[str, Any],
-    model_adapter: LGBMAdapter,
+    model_adapter: BaseEstimatorAdapter,
     pipeline_state: dict[str, Any],
     calibrator: BaseCalibratorAdapter | None,
 ) -> Path:
@@ -48,7 +48,10 @@ def write_artifacts(
     Args:
         output_dir: Root directory for the exported code.
         config: Config dict from :func:`build_config`.
-        model_adapter: Fitted LGBMAdapter to export.
+        model_adapter: Fitted estimator adapter to export. Currently only
+            ``LGBMAdapter`` is supported by the codegen templates, but the
+            type is widened to ``BaseEstimatorAdapter`` so callers in
+            ``_model_persistence.py`` can stay estimator-agnostic (H-0073).
         pipeline_state: Serializable pipeline state dict.
         calibrator: Fitted calibrator or None.
 

--- a/lizyml/codegen/generator.py
+++ b/lizyml/codegen/generator.py
@@ -14,7 +14,7 @@ from lizyml.codegen.templates import (
     render_test_equivalence_py,
     render_train_py,
 )
-from lizyml.estimators.lgbm.adapter import LGBMAdapter
+from lizyml.estimators.base import BaseEstimatorAdapter
 
 
 def generate_code(
@@ -30,7 +30,7 @@ def generate_code(
     seed: int,
     calibration_method: str | None,
     calibration_n_splits: int,
-    model_adapter: LGBMAdapter,
+    model_adapter: BaseEstimatorAdapter,
     pipeline_state: dict[str, Any],
     calibrator: BaseCalibratorAdapter | None,
     feval_metrics: list[dict[str, Any]] | None = None,
@@ -64,7 +64,9 @@ def generate_code(
         seed: Random seed.
         calibration_method: Calibration method name or None.
         calibration_n_splits: CV splits for OOF calibration.
-        model_adapter: Fitted LGBMAdapter.
+        model_adapter: Fitted estimator adapter (typed as
+            ``BaseEstimatorAdapter`` post H-0073; the templates currently
+            assume LightGBM internals).
         pipeline_state: Serializable pipeline state dict.
         calibrator: Fitted calibrator or None.
         feval_metrics: List of feval metric descriptors (H-0066).

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -163,6 +163,19 @@ def _build_splitter_for_method(
     )
 
 
+def get_outer_n_splits(cfg: LizyMLConfig) -> int:
+    """Return the outer CV n_splits regardless of split config variant (H-0073).
+
+    ``BlockedGroupKFoldConfig`` exposes ``groups.n_splits`` (the outer
+    KFold over groups) while every other variant has a top-level
+    ``n_splits``. Centralised here so that callers in ``_model_factories``
+    and ``_model_persistence`` use the same resolution.
+    """
+    if isinstance(cfg.split, BlockedGroupKFoldConfig):
+        return cfg.split.groups.n_splits
+    return cfg.split.n_splits
+
+
 def build_splitter(
     cfg: LizyMLConfig,
     *,
@@ -183,17 +196,19 @@ def build_splitter(
             stacklevel=2,
         )
 
-    # BlockedGroupKFoldConfig has no n_splits at top level
+    n_splits = get_outer_n_splits(cfg)
+
+    # BlockedGroupKFoldConfig has no n_splits at top level — pass block_values etc.
     if isinstance(split_cfg, BlockedGroupKFoldConfig):
         return _build_splitter_for_method(
             split_cfg,
-            split_cfg.groups.n_splits,
+            n_splits,
             block_values=block_values,
             task=cfg.task if task is None else task,
             seed=cfg.training.seed if seed is None else seed,
         )
 
-    return _build_splitter_for_method(split_cfg, split_cfg.n_splits)
+    return _build_splitter_for_method(split_cfg, n_splits)
 
 
 def build_calibration_splitter(cfg: LizyMLConfig) -> BaseSplitter:

--- a/lizyml/core/_model_persistence.py
+++ b/lizyml/core/_model_persistence.py
@@ -1,4 +1,9 @@
-"""ModelPersistenceMixin — export/load methods extracted from Model facade."""
+"""ModelPersistenceMixin — export/load methods extracted from Model facade.
+
+After H-0073 this module is fully estimator-agnostic: codegen-relevant
+parameters and feval metadata flow through ``EstimatorProvider`` rather
+than direct ``LGBMAdapter`` access.
+"""
 
 from __future__ import annotations
 
@@ -13,51 +18,10 @@ if TYPE_CHECKING:
 
     from lizyml.config.schema import LizyMLConfig
     from lizyml.core.types.fit_result import FitResult
-    from lizyml.estimators.lgbm.adapter import LGBMAdapter
     from lizyml.estimators.provider import EstimatorProvider
     from lizyml.training.refit_trainer import RefitResult
 
 _log = get_logger("model")
-
-
-def _extract_feval_metadata(
-    adapter: LGBMAdapter,
-) -> list[dict[str, Any]]:
-    """Extract feval metric metadata from adapter params (H-0066).
-
-    Reads the user-specified ``metric`` from the adapter's params dict,
-    identifies which are feval metrics (not LightGBM native), and returns
-    serializable metadata for each.
-    """
-    from lizyml.estimators.lgbm.metric_bridge import _FEVAL_METRICS
-    from lizyml.metrics.registry import get_metric, parse_metric_entries
-
-    user_metric = adapter.params.get("metric")
-    if not user_metric:
-        return []
-
-    if isinstance(user_metric, (str, dict)):
-        user_metric = [user_metric]
-    user_metric = [m for m in user_metric if m]
-    if not user_metric:
-        return []
-
-    feval_for_task = _FEVAL_METRICS.get(adapter.task, frozenset())
-    parsed = parse_metric_entries(user_metric)
-
-    result: list[dict[str, Any]] = []
-    for name, kwargs in parsed:
-        if name in feval_for_task:
-            metric_obj = get_metric(name, **kwargs)
-            result.append(
-                {
-                    "name": name,
-                    "params": kwargs,
-                    "greater_is_better": metric_obj.greater_is_better,
-                    "needs_proba": metric_obj.needs_proba,
-                }
-            )
-    return result
 
 
 class ModelPersistenceMixin:
@@ -151,32 +115,29 @@ class ModelPersistenceMixin:
         refit_result = self._require_refit()
 
         from lizyml.codegen.generator import generate_code
-        from lizyml.estimators.lgbm.adapter import LGBMAdapter
+        from lizyml.core._model_factories import get_outer_n_splits
 
         adapter = refit_result.model
-        if not isinstance(adapter, LGBMAdapter):
+        provider = self._provider
+        if provider is None:
             raise LizyMLError(
-                ErrorCode.UNSUPPORTED_TASK,
-                user_message=("export_code() currently supports LGBMAdapter only."),
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message=(
+                    "Provider is not initialised. Call fit() before export_code()."
+                ),
+                context={"method": "export_code"},
             )
 
-        # Extract LightGBM params from the adapter.
-        # TODO(H-0059): expose via EstimatorProvider protocol in a future PR.
-        lgbm_params, num_boost_round, _, _ = adapter._build_params()
-
-        # Extract feval metric metadata from user config (H-0066).
-        feval_metrics = _extract_feval_metadata(adapter)
+        # Codegen-relevant params and feval metadata go through the
+        # EstimatorProvider so that this module remains
+        # estimator-agnostic (H-0073).
+        export = provider.build_export_params(adapter)
 
         cfg = self._cfg
         es = cfg.training.early_stopping
         calibration_method: str | None = None
         # Use outer CV n_splits for OOF calibration (H-0058: reuses outer splits)
-        from lizyml.config.schema import BlockedGroupKFoldConfig
-
-        if isinstance(cfg.split, BlockedGroupKFoldConfig):
-            calibration_n_splits = cfg.split.groups.n_splits
-        else:
-            calibration_n_splits = cfg.split.n_splits
+        calibration_n_splits = get_outer_n_splits(cfg)
         if cfg.calibration is not None:
             calibration_method = cfg.calibration.method
 
@@ -206,8 +167,8 @@ class ModelPersistenceMixin:
             run_meta=run_meta_dict,
             feature_names=refit_result.feature_names,
             categorical_features=refit_result.categorical_features,
-            lgbm_params=lgbm_params,
-            num_boost_round=num_boost_round,
+            lgbm_params=export.params,
+            num_boost_round=export.num_boost_round,
             early_stopping_rounds=(es.rounds if es.enabled else None),
             validation_ratio=es.validation_ratio or 0.0,
             seed=cfg.training.seed,
@@ -216,7 +177,7 @@ class ModelPersistenceMixin:
             model_adapter=adapter,
             pipeline_state=refit_result.pipeline_state,
             calibrator=calibrator,
-            feval_metrics=feval_metrics,
+            feval_metrics=export.feval_metadata,
             target_classes=target_classes,
         )
         _log.info("event='export_code.done' path=%s", result)

--- a/lizyml/estimators/base.py
+++ b/lizyml/estimators/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
@@ -74,6 +75,20 @@ class BaseEstimatorAdapter(ABC):
     @abstractmethod
     def get_native_model(self) -> Any:
         """Return the underlying native model object."""
+
+    @abstractmethod
+    def save_model_text(self, path: str | Path) -> Path:
+        """Persist the fitted model as a portable text file (H-0073).
+
+        Used by codegen export to emit a LizyML-independent artifact
+        loadable by the native estimator's runtime alone.
+
+        Args:
+            path: Destination file path.
+
+        Returns:
+            The resolved ``Path`` of the written file.
+        """
 
     def set_categorical_features(self, cols: list[str] | None) -> None:
         """Inform the estimator which columns are categorical.

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.search_dim import SearchDim
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.estimators.lgbm.adapter import LGBMAdapter, TaskType
@@ -25,6 +26,7 @@ from lizyml.estimators.lgbm.smart_params import (
     resolve_ratio_params,
     resolve_smart_params,
 )
+from lizyml.estimators.provider import ExportParams
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 from lizyml.features.pipelines_native import NativeFeaturePipeline
 
@@ -186,3 +188,74 @@ class LGBMProvider:
             )
 
         return rows
+
+    def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
+        """Build codegen-relevant params from a fitted ``LGBMAdapter`` (H-0073).
+
+        Wraps the LGBM-private ``_build_params()`` and the feval metadata
+        extraction so that ``_model_persistence.py`` does not need to import
+        ``LGBMAdapter`` or call private methods.
+
+        Raises:
+            LizyMLError with ``UNSUPPORTED_TASK`` when the supplied adapter
+            is not an ``LGBMAdapter``.
+        """
+        if not isinstance(adapter, LGBMAdapter):
+            raise LizyMLError(
+                code=ErrorCode.UNSUPPORTED_TASK,
+                user_message=(
+                    "LGBMProvider.build_export_params() requires an "
+                    "LGBMAdapter instance."
+                ),
+                context={"adapter_type": type(adapter).__name__},
+            )
+        params, num_boost_round, _, _ = adapter._build_params()
+        feval_metadata = _extract_feval_metadata(adapter)
+        return ExportParams(
+            params=params,
+            num_boost_round=num_boost_round,
+            feval_metadata=feval_metadata,
+        )
+
+
+def _extract_feval_metadata(
+    adapter: LGBMAdapter,
+) -> list[dict[str, Any]]:
+    """Extract feval metric metadata from adapter params (H-0066/H-0073).
+
+    Reads the user-specified ``metric`` from the adapter's params dict,
+    identifies which are feval metrics (not LightGBM native), and returns
+    serializable metadata for each.
+
+    Moved from ``_model_persistence.py`` so that the persistence layer
+    no longer reaches into ``LGBMAdapter`` internals.
+    """
+    from lizyml.estimators.lgbm.metric_bridge import _FEVAL_METRICS
+    from lizyml.metrics.registry import get_metric, parse_metric_entries
+
+    user_metric = adapter.params.get("metric")
+    if not user_metric:
+        return []
+
+    if isinstance(user_metric, (str, dict)):
+        user_metric = [user_metric]
+    user_metric = [m for m in user_metric if m]
+    if not user_metric:
+        return []
+
+    feval_for_task = _FEVAL_METRICS.get(adapter.task, frozenset())
+    parsed = parse_metric_entries(user_metric)
+
+    result: list[dict[str, Any]] = []
+    for name, kwargs in parsed:
+        if name in feval_for_task:
+            metric_obj = get_metric(name, **kwargs)
+            result.append(
+                {
+                    "name": name,
+                    "params": kwargs,
+                    "greater_is_better": metric_obj.greater_is_better,
+                    "needs_proba": metric_obj.needs_proba,
+                }
+            )
+    return result

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -9,6 +9,7 @@ See BLUEPRINT §14.4 for the full specification.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import numpy as np
@@ -18,6 +19,28 @@ import pandas as pd
 from lizyml.core.types.search_dim import SearchDim
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.features.pipeline_base import BaseFeaturePipeline
+
+
+@dataclass(frozen=True)
+class ExportParams:
+    """Codegen-relevant params extracted from a fitted estimator (H-0073).
+
+    Returned by :meth:`EstimatorProvider.build_export_params` so that
+    ``ModelPersistenceMixin.export_code()`` does not have to reach into
+    estimator-specific private methods.
+
+    Attributes:
+        params: Native model parameters (e.g. LightGBM Booster API names).
+        num_boost_round: Total training iterations actually used.
+        feval_metadata: User-specified ``feval`` metric descriptors needed
+            by the generated train.py to recompute custom metrics. Each
+            dict has ``name``, ``params``, ``greater_is_better``,
+            ``needs_proba``.
+    """
+
+    params: dict[str, Any]
+    num_boost_round: int
+    feval_metadata: list[dict[str, Any]] = field(default_factory=list)
 
 
 class EstimatorProvider(Protocol):  # pragma: no cover
@@ -105,5 +128,21 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         Each row is ``{"parameter": str, "value": Any}``.
         Should include smart params and resolved native params.
         Per-fold best iterations are added by ``_model_tables.py``.
+        """
+        ...
+
+    def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
+        """Build codegen-relevant export parameters from a fitted adapter (H-0073).
+
+        Used by :class:`~lizyml.core._model_persistence.ModelPersistenceMixin`
+        to populate the codegen pipeline without importing estimator-specific
+        adapter classes. The returned :class:`ExportParams` carries native
+        booster params, the number of boosting rounds, and any ``feval``
+        metric metadata needed to regenerate custom metric callables in the
+        emitted ``train.py``.
+
+        Args:
+            adapter: The fitted estimator to export. The provider is
+                responsible for narrowing the adapter type internally.
         """
         ...

--- a/tests/test_codegen/test_feval_codegen.py
+++ b/tests/test_codegen/test_feval_codegen.py
@@ -434,7 +434,7 @@ class TestTemplateFevalContent:
 
 
 class TestExtractFevalMetadata:
-    """Tests for _extract_feval_metadata in _model_persistence."""
+    """Tests for _extract_feval_metadata in lgbm.provider (moved in H-0073)."""
 
     def _make_adapter(
         self,
@@ -450,19 +450,19 @@ class TestExtractFevalMetadata:
         )
 
     def test_no_metric_returns_empty(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={})
         assert _extract_feval_metadata(adapter) == []
 
     def test_native_only_returns_empty(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "binary_logloss"]})
         assert _extract_feval_metadata(adapter) == []
 
     def test_feval_metric_extracted(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "f1"]})
         result = _extract_feval_metadata(adapter)
@@ -473,7 +473,7 @@ class TestExtractFevalMetadata:
         assert result[0]["params"] == {}
 
     def test_feval_with_params(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": [{"precision_at_k": {"k": 20}}]})
         result = _extract_feval_metadata(adapter)
@@ -484,7 +484,7 @@ class TestExtractFevalMetadata:
         assert result[0]["needs_proba"] is True
 
     def test_mixed_native_and_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "f1", "brier"]})
         result = _extract_feval_metadata(adapter)
@@ -494,7 +494,7 @@ class TestExtractFevalMetadata:
         assert "auc" not in names
 
     def test_regression_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(
             task="regression", params={"metric": ["rmse", "rmsle"]}
@@ -505,7 +505,7 @@ class TestExtractFevalMetadata:
         assert result[0]["greater_is_better"] is False
 
     def test_string_metric(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": "f1"})
         result = _extract_feval_metadata(adapter)
@@ -513,7 +513,7 @@ class TestExtractFevalMetadata:
         assert result[0]["name"] == "f1"
 
     def test_r2_regression_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(
             task="regression", params={"metric": ["rmse", "r2"]}

--- a/tests/test_estimators/test_check_provider.py
+++ b/tests/test_estimators/test_check_provider.py
@@ -118,6 +118,26 @@ class TestProtocolReturnTypes:
     @pytest.mark.parametrize(
         "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
     )
+    def test_build_export_params_returns_export_params(
+        self, provider_name: str, provider: Any
+    ) -> None:
+        """``build_export_params`` returns a populated ``ExportParams``.
+
+        See #109 / H-0073.
+        """
+        from lizyml.estimators.provider import ExportParams
+
+        X, y = _make_data("binary")
+        adapter = _build_and_fit(provider, "binary", X, y)
+        export = provider.build_export_params(adapter)
+        assert isinstance(export, ExportParams)
+        assert isinstance(export.params, dict)
+        assert export.num_boost_round > 0
+        assert isinstance(export.feval_metadata, list)
+
+    @pytest.mark.parametrize(
+        "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
+    )
     @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])
     def test_default_space_returns_search_dims(
         self, provider_name: str, provider: Any, task: str


### PR DESCRIPTION
## Summary
Implements [H-0073](HISTORY.md#h-0073) (Sprint 3 #1). Closes the CRITICAL #109 and the MEDIUM #126 in a single structural refactor.

### Why
`Model.export_code()` was the **only** remaining hole in the EstimatorProvider abstraction (H-0053). `_model_persistence.py` directly imported `LGBMAdapter`, called its private `_build_params()`, and duplicated `BlockedGroupKFoldConfig.groups.n_splits` resolution that already lived in `_model_factories.py`. Adding a new estimator (XGBoost, sklearn) would have required editing the persistence layer, defeating the abstraction.

### Changes
1. **`ExportParams` frozen dataclass** in `estimators/provider.py` — carries `params`, `num_boost_round`, `feval_metadata`.
2. **`EstimatorProvider.build_export_params(adapter) -> ExportParams`** — new protocol method.
3. **`LGBMProvider.build_export_params`** — wraps the existing `LGBMAdapter._build_params()` and the moved `_extract_feval_metadata`. Validates the adapter is an LGBM instance; raises `LizyMLError(UNSUPPORTED_TASK)` otherwise.
4. **`_extract_feval_metadata`** moved from `_model_persistence.py` to `estimators/lgbm/provider.py` (its natural home).
5. **`get_outer_n_splits(cfg) -> int`** in `_model_factories.py` — single source of truth for n_splits resolution. `build_splitter()` and `_model_persistence.py` both call it.
6. **`_model_persistence.py` cleansed** — no `LGBMAdapter` import, no `isinstance(LGBMAdapter)`, no inline `BlockedGroupKFoldConfig` n_splits dispatch.
7. **`save_model_text(path)`** added as abstract method on `BaseEstimatorAdapter` (already implemented by `LGBMAdapter`).
8. **Codegen `generator.py` / `artifact_writer.py`** widen `model_adapter` type to `BaseEstimatorAdapter` (templates still assume LGBM internals — that scope is naturally the codegen subpackage).
9. **BLUEPRINT.md §14.4** updated with `build_export_params` and `ExportParams` spec.
10. **Provider conformance test** for `build_export_params` return type added.

### Acceptance criteria (from H-0073)
- [x] `grep -rn 'LGBMAdapter' lizyml/core/_model_persistence.py` — only one docstring mention, no import or runtime reference.
- [x] `grep -rn 'isinstance.*LGBMAdapter' lizyml/core/` — zero matches.
- [x] `grep -rn 'BlockedGroupKFoldConfig' lizyml/core/_model_persistence.py` — zero matches.
- [x] Existing codegen tests (37 in `test_feval_codegen.py` + 73 across `test_codegen/`) pass.
- [x] New provider conformance test added (`test_build_export_params_returns_export_params`).
- [x] BLUEPRINT.md §14.4 updated.

## Skill / DoD
- Skill: `skills/add-estimator-adapter` + `skills/persistence-and-migration`.
- DoD:
  - `1696 passed` overall (full test suite).
  - `mypy --strict` clean across 101 source files.
  - `ruff check` / `ruff format` clean.
  - Acceptance grep checks all green.

## Test plan
- [x] `uv run pytest tests/test_codegen/ tests/test_persistence/ tests/test_e2e/ tests/test_core/ tests/test_estimators/` — 562+ pass.
- [x] `uv run pytest` — **1696 passed** total.
- [x] `uv run ruff check .` / `uv run ruff format --check lizyml/`
- [x] `uv run mypy lizyml/`
- [x] One existing test in `test_feval_codegen.py` updated (import path moved with `_extract_feval_metadata`); behaviour assertions unchanged.

## Migration
- External Provider implementers (none today) must implement `build_export_params(adapter) -> ExportParams`.
- LizyML users: no impact (internal refactor).
- `format_version` not bumped — Artifacts schema unchanged.

## Notes
- This PR replaces the old `TODO(H-0059)` comment in `_model_persistence.py` with the proper protocol method.
- The codegen templates remain LGBM-specific; future XGBoost support will add an `xgboost_generator.py` and dispatch in the Provider layer.