### PR TITLE
docs(deprecations): central registry + v1.0 removal targets (H-0076, closes #120 #121)

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -1,0 +1,101 @@
+# Deprecation Registry
+
+Central tracking of deprecated public surfaces and their removal targets.
+Every `DeprecationWarning` / `UserWarning` raised by LizyML lists "Will be
+removed in v1.0." in its message; this file is the single source of truth.
+
+The CI test `tests/test_core/test_deprecation_registry.py` asserts that
+every deprecation warning emitted during a representative test run carries
+a removal-version suffix matching the pattern `Will be removed in v\d+\.\d+`.
+
+## Schedule
+
+| Target | Replacement | Removal | Deprecated since |
+|---|---|---|---|
+| `EarlyStoppingConfig.validation_ratio` (input) | `inner_valid.ratio` | **v1.0** | H-0069 (2026-04, made `computed_field` in #111) |
+| `CalibrationConfig.n_splits` | (removed; outer split is reused) | **v1.0** | H-0058 (2026-04) |
+| `purged_time_series.purge_window` | `purge_gap` | **v1.0** | H-0021 |
+| `purged_time_series.embargo_pct` | `embargo` (int, observation count) | **v1.0** | H-0021 |
+| `purged_time_series.gap` | `embargo` | **v1.0** | H-0021 |
+| `lizyml.core._model_factories.build_calibration_splitter` | (removed; outer split is reused) | **v1.0** | H-0058 |
+
+## Migration notes
+
+### `validation_ratio` → `inner_valid.ratio`
+
+```yaml
+# Before
+training:
+  early_stopping:
+    enabled: true
+    rounds: 50
+    validation_ratio: 0.15
+
+# After
+training:
+  early_stopping:
+    enabled: true
+    rounds: 50
+    inner_valid:
+      method: holdout
+      ratio: 0.15
+```
+
+`validation_ratio` is now a `computed_field` mirroring `inner_valid.ratio`,
+so `model_dump()` round-trips remain stable. Reading the field via
+`config.training.early_stopping.validation_ratio` keeps working until v1.0.
+
+### `calibration.n_splits` (removed)
+
+The field is silently ignored; calibration cross-fit reuses the outer CV
+splits (H-0058). Drop the key from your config:
+
+```yaml
+# Before
+calibration:
+  method: platt
+  n_splits: 5
+
+# After
+calibration:
+  method: platt
+```
+
+### `purged_time_series` keys
+
+`purge_window` and `gap` were obs-count integers but had distinct semantics
+that have since been unified.
+
+```yaml
+# Before
+split:
+  method: purged_time_series
+  purge_window: 5
+  embargo_pct: 0.05
+
+# After
+split:
+  method: purged_time_series
+  purge_gap: 5
+  embargo: 10        # explicit observation count, not a fraction
+```
+
+### `build_calibration_splitter()` (removed)
+
+Internal API. Users hand-rolling calibration cross-fit should switch to
+`fit_result.splits.outer` (already populated from the CV trainer).
+
+## Adding a new deprecation
+
+1. Append "Will be removed in vX.Y." to the warning message.
+2. Add a row to the table above.
+3. Document the migration path in this file.
+4. Ensure tests using the legacy form wrap calls in
+   `pytest.warns(DeprecationWarning)` so the deprecation contract is
+   exercised in CI.
+
+## Related
+
+- HISTORY.md: H-0076 (this registry), H-0058 (calibration), H-0069
+  (`validation_ratio`), H-0021 (purged_time_series).
+- Code: `lizyml/config/schema.py`, `lizyml/core/_model_factories.py`.

--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -113,7 +113,7 @@ class PurgedTimeSeriesConfig(BaseModel):
         if "purge_window" in data and "purge_gap" not in data:
             warnings.warn(
                 "purged_time_series key 'purge_window' is deprecated; "
-                "use 'purge_gap' instead.",
+                "use 'purge_gap' instead. Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -121,14 +121,16 @@ class PurgedTimeSeriesConfig(BaseModel):
         if "embargo_pct" in data and "embargo" not in data:
             warnings.warn(
                 "purged_time_series key 'embargo_pct' is deprecated; "
-                "use 'embargo' (int, obs count) instead.",
+                "use 'embargo' (int, obs count) instead. "
+                "Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             data["embargo"] = int(data.pop("embargo_pct"))
         if "gap" in data and "embargo" not in data:
             warnings.warn(
-                "purged_time_series key 'gap' is deprecated; use 'embargo' instead.",
+                "purged_time_series key 'gap' is deprecated; "
+                "use 'embargo' instead. Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -500,7 +502,8 @@ class CalibrationConfig(BaseModel):
         ):
             warnings.warn(
                 "calibration.n_splits is deprecated and will be ignored. "
-                "Calibration cross-fit now reuses outer CV splits (H-0058).",
+                "Calibration cross-fit now reuses outer CV splits (H-0058). "
+                "Will be removed in v1.0.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -207,7 +207,8 @@ def build_calibration_splitter(cfg: LizyMLConfig) -> BaseSplitter:
 
     warnings.warn(
         "build_calibration_splitter is deprecated (H-0058). "
-        "Calibration cross-fit now reuses outer CV splits.",
+        "Calibration cross-fit now reuses outer CV splits. "
+        "Will be removed in v1.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/tests/test_core/test_deprecation_registry.py
+++ b/tests/test_core/test_deprecation_registry.py
@@ -1,0 +1,120 @@
+"""Lint-style regression test: deprecation warnings must name a removal version.
+
+See #120, #121, H-0076.
+
+Every ``warnings.warn(..., DeprecationWarning)`` and
+``warnings.warn(..., UserWarning)`` site that talks about deprecated config
+surfaces must include a ``Will be removed in vX.Y`` suffix so users know
+how urgently to migrate. The single source of truth is
+``docs/DEPRECATIONS.md``.
+
+This test scans the warning *messages* themselves (string literals) in
+``lizyml/`` rather than relying on grepping call sites, so multi-line
+messages and f-strings are covered. Sites that are deliberately not
+deprecation-related (no "deprecated" / "deprecat" / "will be removed"
+language) are skipped.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE_ROOT = Path(__file__).parent.parent.parent / "lizyml"
+_REMOVAL_PATTERN = re.compile(r"Will be removed in v\d+\.\d+")
+_DEPRECATION_KEYWORDS = ("deprecated", "deprecat", "will be removed")
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SOURCE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _is_warnings_warn(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "warn"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "warnings"
+    )
+
+
+def _flatten_string_arg(node: ast.expr) -> str | None:
+    """Return the literal text of a warning message arg, or None if dynamic.
+
+    Supports ``"a" "b"`` implicit-concat, ``"a" + "b"``, and constants only.
+    f-strings with non-constant parts are concatenated by their literal
+    fragments — good enough for our keyword + suffix detection.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):  # f-string
+        parts: list[str] = []
+        for v in node.values:
+            if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                parts.append(v.value)
+            else:
+                parts.append("?")  # placeholder for FormattedValue
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _flatten_string_arg(node.left)
+        right = _flatten_string_arg(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _scan_warning_messages() -> list[tuple[Path, int, str]]:
+    """Return (path, line, message) for every ``warnings.warn`` call site
+    whose first arg is a string literal we can resolve."""
+    found: list[tuple[Path, int, str]] = []
+    for path in _iter_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_warnings_warn(node):
+                continue
+            if not node.args:
+                continue
+            msg = _flatten_string_arg(node.args[0])
+            if msg is None:
+                continue
+            found.append((path, node.lineno, msg))
+    return found
+
+
+class TestDeprecationRegistry:
+    def test_source_root_exists(self) -> None:
+        assert _SOURCE_ROOT.is_dir(), f"missing source root: {_SOURCE_ROOT}"
+
+    def test_deprecations_doc_exists(self) -> None:
+        """The central registry referenced by warnings must be present."""
+        path = _SOURCE_ROOT.parent / "docs" / "DEPRECATIONS.md"
+        assert path.is_file(), f"missing {path}"
+
+    def test_every_deprecation_warning_names_a_removal_version(self) -> None:
+        """Each deprecation-flavoured ``warnings.warn`` must include
+        ``Will be removed in vX.Y``."""
+        offenders: list[str] = []
+        for path, lineno, msg in _scan_warning_messages():
+            lower = msg.lower()
+            if not any(kw in lower for kw in _DEPRECATION_KEYWORDS):
+                continue
+            if not _REMOVAL_PATTERN.search(msg):
+                rel = path.relative_to(_SOURCE_ROOT.parent)
+                offenders.append(
+                    f"{rel}:{lineno}: missing 'Will be removed in vX.Y'\n"
+                    f"  message preview: {msg[:120]!r}"
+                )
+        if offenders:
+            pytest.fail(
+                "Deprecation warning(s) missing removal target (H-0076 / "
+                "see docs/DEPRECATIONS.md):\n" + "\n".join(offenders)
+            )


### PR DESCRIPTION
## Summary
Implements [H-0076](HISTORY.md#h-0076) (Sprint 3 #4). Closes #120 and #121.

### Why
Multiple `DeprecationWarning` / `UserWarning` messages did not specify a removal version, so users had no signal for how urgently to migrate. Additionally, `build_calibration_splitter` had been deprecated since H-0058 (2026-04) without a recorded removal plan.

### Changes
1. **Append "Will be removed in v1.0." to every deprecation warning** in `lizyml/`:
   - `purged_time_series.purge_window` / `embargo_pct` / `gap`
   - `CalibrationConfig.n_splits`
   - `build_calibration_splitter()`
   - `validation_ratio` (already had v1.0 from #111)

2. **`docs/DEPRECATIONS.md`** — central registry listing every deprecation, its replacement, removal target, and migration example.

3. **`tests/test_core/test_deprecation_registry.py`** — AST-based lint test that fails CI if any `warnings.warn(..., DeprecationWarning|UserWarning)` site whose message contains "deprecated" / "deprecat" / "will be removed" lacks a `Will be removed in v\d+\.\d+` suffix.

### Acceptance criteria (from H-0076)
- [x] `docs/DEPRECATIONS.md` exists with all 6 deprecation entries.
- [x] Every deprecation warning in `lizyml/` includes "v1.0".
- [x] CI lint test enforces the rule going forward (`test_every_deprecation_warning_names_a_removal_version`).
- [x] Existing tests pass without modification.

## Skill / DoD
- Skill: `skills/exceptions-and-logging` + `skills/release` — deprecation policy.
- DoD:
  - Documentation-driven contract enforced via test.
  - Behaviour unchanged (only message text updated).

## Test plan
- [x] `uv run pytest tests/test_core/test_deprecation_registry.py` — 3 passed (new).
- [x] `uv run pytest` — **1698 passed** total.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/`

## Migration
- No code change required from users in this PR — only the warning text gains "Will be removed in v1.0.".
- Actual removal in v1.0 will be a separate breaking-change PR signposted now.

## Notes
- The MEDIUM/LOW review items L4 (`test_no_empty_context.py` AST extension) was already shipped in PR #142 — this registry test follows the same AST-scanning pattern.