### PR TITLE
refactor(core): introduce FitState dataclass (H-0074 Phase 1, addresses #112)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1692,3 +1692,4 @@ loaded_model.probability_histogram_plot()
 - `Model` クラスは mixin で構成する（H-0042）。plot 系は `_model_plots.py`、table/accessor 系は `_model_tables.py`、persistence 系は `_model_persistence.py` に分割し、`model.py` には core lifecycle（`__init__`, `fit`, `predict`, `evaluate`, `tune`）とプライベートヘルパーのみを残す。
 - mixin は `_` プレフィックスの非公開モジュールとし、`Model` の import パス（`lizyml.core.model.Model`）は変更しない。
 - 依存関係の切り離しが必要な箇所では Lazy Import を許容する。
+- `Model._get_fit_state()` が返す `FitState` frozen dataclass を mixin の唯一の入口として整備中（H-0074, Phase 1: 型定義 + factory + テスト, Phase 2: 全 mixin 移行）。`FitState` は `cfg / fit_result / refit_result / tuning_result / provider / metrics / y / X / run_dir / output_dir` の post-fit snapshot を持ち、`self._*` への直接アクセスを段階的に置換する。

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -64,6 +64,7 @@ from lizyml.core.specs.problem_spec import ProblemSpec
 from lizyml.core.train_components import TrainComponents
 from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
+from lizyml.core.types.fit_state import FitState
 from lizyml.core.types.predict_result import PredictionResult
 from lizyml.core.types.tuning_result import (
     BoundaryReport,
@@ -1273,3 +1274,39 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 },
             )
         return self._refit_result
+
+    def _get_fit_state(self) -> FitState:
+        """Return a frozen snapshot of post-fit state for Mixin methods (#112).
+
+        H-0074 introduces this as the single read path that Mixin methods
+        will eventually consume. Phase 1 (introduction) keeps the existing
+        ``self._*`` access intact; Phase 2 will migrate Mixins to read
+        only from the returned ``FitState``.
+
+        Raises:
+            :class:`~lizyml.core.exceptions.LizyMLError` with
+            ``MODEL_NOT_FIT`` when called before ``fit()`` (delegated via
+            :meth:`_require_fit`).
+        """
+        fit_result = self._require_fit()
+        if self._provider is None:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message=(
+                    "Provider is not initialised. Call fit() before "
+                    "diagnostic / export APIs."
+                ),
+                context={"method": "_get_fit_state"},
+            )
+        return FitState(
+            cfg=self._cfg,
+            fit_result=fit_result,
+            refit_result=self._refit_result,
+            tuning_result=self._tuning_result,
+            provider=self._provider,
+            metrics=self._metrics,
+            y=self._y,
+            X=self._X,
+            run_dir=self._run_dir,
+            output_dir=self._output_dir,
+        )

--- a/lizyml/core/types/fit_state.py
+++ b/lizyml/core/types/fit_state.py
@@ -1,0 +1,67 @@
+"""FitState — frozen snapshot of Model state consumed by Mixin methods (#112, H-0074).
+
+Created by ``Model._get_fit_state()`` after ``fit()`` / ``tune()`` / ``load()``.
+Mixin methods (``ModelPlotsMixin``, ``ModelTablesMixin``, ``ModelPersistenceMixin``)
+will increasingly receive a ``FitState`` instance instead of reading
+``self._*`` attributes directly. Phase 1 (this introduction PR) only adds
+the dataclass and the factory; Mixin signatures remain backward-compatible.
+Phase 2 will migrate Mixin methods to ``state: FitState`` and remove the
+``self._*`` access path.
+
+The class is frozen and contains only references — it is cheap to build
+once per public-API call. It must NOT capture transient training state
+(e.g. per-fold buffers); only the post-fit handles required by diagnostic
+methods belong here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from lizyml.config.schema import LizyMLConfig
+    from lizyml.core.types.fit_result import FitResult
+    from lizyml.core.types.tuning_result import TuningResult
+    from lizyml.estimators.provider import EstimatorProvider
+    from lizyml.training.refit_trainer import RefitResult
+
+
+@dataclass(frozen=True)
+class FitState:
+    """Frozen snapshot of post-fit Model state for Mixin consumption.
+
+    Attributes:
+        cfg: The active :class:`LizyMLConfig` (always present).
+        fit_result: Output of :meth:`Model.fit`. Required for any
+            diagnostic / plot / table method.
+        refit_result: Output of refit on full data. ``None`` when the
+            user disabled refit or the model was loaded without it.
+        tuning_result: Output of :meth:`Model.tune`. ``None`` when tune
+            was not called.
+        provider: The estimator provider used for the current model.
+            Required for SHAP, params summary, and codegen export.
+        metrics: Pre-computed metrics dict (``{"raw": {...}, "calibrated":
+            {...}}``). Populated by :meth:`Evaluator.evaluate`.
+        y: Training target (transient — absent after :meth:`Model.load` if
+            the artifact does not contain ``analysis_context``).
+        X: Training features (transient — same caveat as ``y``).
+        run_dir: Active run directory for log/artifact output. ``None``
+            until ``fit`` / ``tune`` allocate one.
+        output_dir: User-configured root for run directories. ``None``
+            when neither config nor constructor specified one.
+    """
+
+    cfg: LizyMLConfig
+    fit_result: FitResult
+    refit_result: RefitResult | None
+    tuning_result: TuningResult | None
+    provider: EstimatorProvider
+    metrics: dict[str, Any] | None
+    y: pd.Series | None
+    X: pd.DataFrame | None
+    run_dir: Path | None
+    output_dir: str | Path | None

--- a/tests/test_core/test_fit_state.py
+++ b/tests/test_core/test_fit_state.py
@@ -1,0 +1,132 @@
+"""Tests for ``FitState`` and ``Model._get_fit_state()`` (#112, H-0074).
+
+Phase 1 of the FitState rollout. Verifies:
+
+- ``FitState`` is a frozen dataclass.
+- ``Model._get_fit_state()`` returns a populated ``FitState`` after fit.
+- The error path raises ``LizyMLError(MODEL_NOT_FIT)`` before fit.
+- Mixin-style helpers can be unit-tested by constructing a ``FitState``
+  with mock components — no full Model fit required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lizyml import Model
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.fit_state import FitState
+from tests._helpers import make_config, make_regression_df
+
+
+class TestFitStateContract:
+    def test_is_frozen(self) -> None:
+        """Frozen dataclass — runtime mutation must fail."""
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        with pytest.raises((AttributeError, TypeError)):
+            state.fit_result = None  # type: ignore[misc]
+
+    def test_required_fields_populated_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        # Required fields
+        assert state.cfg is model._cfg
+        assert state.fit_result is not None
+        assert state.provider is not None
+        # Refit produced by default fit()
+        assert state.refit_result is not None
+        # Tuning was not called
+        assert state.tuning_result is None
+
+    def test_y_and_x_present_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        assert state.y is not None
+        assert state.X is not None
+
+    def test_metrics_populated_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        assert state.metrics is not None
+        assert "raw" in state.metrics
+
+
+class TestGetFitStatePreFit:
+    def test_raises_before_fit(self) -> None:
+        cfg = make_config("regression")
+        model = Model(cfg)
+        with pytest.raises(LizyMLError) as exc_info:
+            model._get_fit_state()
+        assert exc_info.value.code == ErrorCode.MODEL_NOT_FIT
+
+
+class TestFitStateForMixinUnitTest:
+    """Demonstrate that a downstream consumer can build a ``FitState`` with
+    mocks and exercise Mixin-style logic without running a full Model fit.
+
+    Phase 2 of H-0074 will migrate Mixin signatures to actually accept
+    ``state: FitState``. This test pins down the data-only nature of the
+    snapshot so the future migration is mechanical.
+    """
+
+    def test_mocked_state_is_constructible(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        # Mock minimal pieces for the dataclass — actual values are
+        # consumer-specific; we only assert constructibility + immutability.
+        class _Sentinel:
+            pass
+
+        state = FitState(
+            cfg=_Sentinel(),  # type: ignore[arg-type]
+            fit_result=_Sentinel(),  # type: ignore[arg-type]
+            refit_result=None,
+            tuning_result=None,
+            provider=_Sentinel(),  # type: ignore[arg-type]
+            metrics={"raw": {}},
+            y=None,
+            X=None,
+            run_dir=None,
+            output_dir=None,
+        )
+        assert state.metrics == {"raw": {}}
+        with pytest.raises((AttributeError, FrozenInstanceError)):
+            state.metrics = {"raw": {"new": 1}}  # type: ignore[misc, assignment]
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["cfg", "fit_result", "provider"],
+    )
+    def test_missing_required_field_raises_typerror(self, missing_field: str) -> None:
+        """Required positional/keyword fields cannot default — guarantees
+        Phase 2 mock builders catch missing pieces at construction time."""
+        kwargs: dict[str, Any] = {
+            "cfg": object(),
+            "fit_result": object(),
+            "refit_result": None,
+            "tuning_result": None,
+            "provider": object(),
+            "metrics": None,
+            "y": None,
+            "X": None,
+            "run_dir": None,
+            "output_dir": None,
+        }
+        kwargs.pop(missing_field)
+        with pytest.raises(TypeError):
+            FitState(**kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Implements [H-0074](HISTORY.md#h-0074) Phase 1 of the FitState rollout (Sprint 3 #2). Lays the foundation for #112 (HIGH) without changing any Mixin signature yet — Phase 2 will migrate them.

### Why
``ModelPlotsMixin`` / ``ModelTablesMixin`` / ``ModelPersistenceMixin`` were extracted in H-0042 to reduce ``model.py`` size, but each Mixin reaches into ``self._y``, ``self._X``, ``self._cfg``, ``self._provider``, ``self._tuning_result``, ``self._metrics``, ``self._run_dir``, ``self._output_dir``. The split is **cosmetic** — Mixins cannot be unit-tested in isolation, and renaming a private Model attribute silently breaks all three.

### Changes
1. **New `FitState` frozen dataclass** in `lizyml/core/types/fit_state.py` carrying every post-fit handle a Mixin currently reads:
   ```python
   @dataclass(frozen=True)
   class FitState:
       cfg: LizyMLConfig
       fit_result: FitResult
       refit_result: RefitResult | None
       tuning_result: TuningResult | None
       provider: EstimatorProvider
       metrics: dict[str, Any] | None
       y: pd.Series | None
       X: pd.DataFrame | None
       run_dir: Path | None
       output_dir: str | Path | None
   ```
2. **`Model._get_fit_state()`** as the single read path. Delegates to `_require_fit()` for the not-yet-fitted error, raises `LizyMLError(MODEL_NOT_FIT)` when the provider is missing.
3. **Unit tests** (`tests/test_core/test_fit_state.py`, 9 tests):
   - Frozen contract.
   - Populated fields after a real `fit()`.
   - `_get_fit_state()` raises before `fit()`.
   - Mock-only constructibility (proves Phase 2 mock builders work).
   - Required-field enforcement (no defaults — Phase 2 mock builders fail fast).
4. **BLUEPRINT.md** updated to document the Phase 1 / Phase 2 rollout.

### Phase 2 (out of scope here)
A follow-up PR will migrate Mixin method signatures to `state: FitState` and remove `self._*` access. That PR is mechanical because every consumer is enumerated by the dataclass.

### Acceptance criteria (Phase 1)
- [x] `FitState` frozen dataclass defined.
- [x] `Model._get_fit_state()` works after fit.
- [x] Pre-fit error path returns `LizyMLError(MODEL_NOT_FIT)`.
- [x] Mock-only `FitState` construction works (Phase 2 prerequisite).
- [x] All existing tests pass.
- [x] mypy clean.

## Skill / DoD
- Skill: `skills/spec-update` + `skills/testing`.
- DoD:
  - Phase 1 introduces the abstraction without behavioral change.
  - Existing 1705 tests continue to pass.

## Test plan
- [x] `uv run pytest tests/test_core/test_fit_state.py -v` — 9 passed.
- [x] `uv run pytest` — **1705 passed** total.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy lizyml/`

## Migration
- No user-visible change.
- Phase 2 PR will be marked as a follow-up and migrate Mixin methods to `state: FitState`.