### PR TITLE
refactor(types): centralise TaskType + propagate annotations (H-0075, closes #122)

### DIFF
--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -25,6 +25,7 @@ from lizyml.config.schema import (
     StratifiedKFoldConfig,
     TimeSeriesConfig,
 )
+from lizyml.core.types.task import TaskType
 from lizyml.splitters.base import BaseSplitter
 from lizyml.splitters.blocked_group_kfold import BlockedGroupKFoldSplitter
 from lizyml.splitters.group_kfold import (
@@ -52,7 +53,7 @@ InnerValidType = (
 )
 
 
-def _resolve_stratify(stratify: str | bool, task: str) -> bool:
+def _resolve_stratify(stratify: str | bool, task: TaskType) -> bool:
     """Resolve ``stratify: "auto"`` to a concrete boolean."""
     if isinstance(stratify, bool):
         return stratify
@@ -67,7 +68,7 @@ def _build_splitter_for_method(
     n_splits: int,
     *,
     block_values: npt.NDArray[Any] | None = None,
-    task: str | None = None,
+    task: TaskType | None = None,
     seed: int | None = None,
 ) -> BaseSplitter:
     """Build a splitter from split config, using the given *n_splits*.
@@ -180,7 +181,7 @@ def build_splitter(
     cfg: LizyMLConfig,
     *,
     block_values: npt.NDArray[Any] | None = None,
-    task: str | None = None,
+    task: TaskType | None = None,
     seed: int | None = None,
 ) -> BaseSplitter:
     """Instantiate outer CV splitter from config."""
@@ -236,7 +237,7 @@ def _resolve_auto_inner_valid(
     ratio: float,
     seed: int,
     *,
-    task: str | None = None,
+    task: TaskType | None = None,
 ) -> (
     HoldoutInnerValid
     | GroupHoldoutInnerValid

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -31,7 +31,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -65,6 +65,7 @@ from lizyml.core.train_components import TrainComponents
 from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.predict_result import PredictionResult
+from lizyml.core.types.task import TaskType
 from lizyml.core.types.tuning_result import (
     BoundaryReport,
     RoundSummary,
@@ -96,10 +97,8 @@ from lizyml.tuning.tuner import Tuner
 
 _log = get_logger("model")
 
-TaskType = Literal["regression", "binary", "multiclass"]
-
 # Default metrics per task when none are specified in config.
-_DEFAULT_METRICS: dict[str, list[str | dict[str, dict[str, Any]]]] = {
+_DEFAULT_METRICS: dict[TaskType, list[str | dict[str, dict[str, Any]]]] = {
     "regression": ["rmse", "mae"],
     "binary": ["logloss", "auc"],
     "multiclass": ["logloss", "f1", "accuracy"],

--- a/lizyml/core/types/target_encoder.py
+++ b/lizyml/core/types/target_encoder.py
@@ -7,15 +7,16 @@ a back-dependency on Layer 1 ``data/``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["TargetEncoder", "TaskType"]
 
 
 @dataclass(frozen=True)

--- a/lizyml/core/types/task.py
+++ b/lizyml/core/types/task.py
@@ -1,0 +1,18 @@
+"""TaskType — canonical Literal for the supported ML tasks (#122, H-0075).
+
+Centralised here so every layer (Foundation → Composition) imports the
+same alias and a future addition (e.g. ``"ranking"``, ``"multilabel"``)
+is a single-line change. The runtime values match the public Config
+schema and BLUEPRINT §7.1 — never widen the union without a Proposal.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+TaskType = Literal["regression", "binary", "multiclass"]
+"""The set of ML tasks that LizyML currently supports."""
+
+TASK_TYPES: tuple[TaskType, ...] = ("regression", "binary", "multiclass")
+"""Tuple form for iteration / membership checks where ``Literal`` cannot
+be used directly (e.g. ``pytest.parametrize`` arguments)."""

--- a/lizyml/estimators/lgbm/adapter.py
+++ b/lizyml/estimators/lgbm/adapter.py
@@ -27,7 +27,9 @@ except ImportError as e:  # pragma: no cover
         context={"package": "lightgbm"},
     ) from e
 
-TaskType = Literal["regression", "binary", "multiclass"]
+from lizyml.core.types.task import TaskType  # noqa: E402  re-export for ext
+
+__all__ = ["LGBMAdapter", "TaskType"]
 
 
 class LGBMAdapter(BaseEstimatorAdapter):

--- a/lizyml/estimators/lgbm/defaults.py
+++ b/lizyml/estimators/lgbm/defaults.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from lizyml.core.types.search_dim import CategoricalDim, FloatDim, IntDim, SearchDim
-
-TaskType = str
+from lizyml.core.types.task import TaskType
 
 # Maps task → objective
 _TASK_OBJECTIVE: dict[str, str] = {
@@ -44,7 +43,7 @@ _OBJECTIVE_CHOICES: dict[str, tuple[str, ...]] = {
 }
 
 
-def default_space(task: str) -> list[SearchDim]:
+def default_space(task: TaskType) -> list[SearchDim]:
     """Return the PLAN-specified default search space for LightGBM.
 
     Args:
@@ -75,7 +74,7 @@ def default_space(task: str) -> list[SearchDim]:
     return dims
 
 
-def default_fixed_params(task: str) -> dict[str, Any]:
+def default_fixed_params(task: TaskType) -> dict[str, Any]:
     """Return fixed parameters applied to every trial when using default space.
 
     Only model-level LightGBM parameters belong here.  Smart params

--- a/lizyml/estimators/lgbm/metric_bridge.py
+++ b/lizyml/estimators/lgbm/metric_bridge.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.metrics.base import BaseMetric
 from lizyml.metrics.registry import MetricEntry, get_metric, parse_metric_entries
 
@@ -32,7 +33,7 @@ _LIZYML_TO_LGBM: dict[str, dict[str, str]] = {
 }
 
 
-def translate_metric(name: str, task: str) -> str:
+def translate_metric(name: str, task: TaskType) -> str:
     """Translate a LizyML metric name to its LightGBM equivalent.
 
     If no mapping exists, returns the name unchanged.
@@ -127,7 +128,7 @@ _ALL_FEVAL_NAMES: frozenset[str] = frozenset().union(*_FEVAL_METRICS.values())
 
 def validate_lgbm_metrics(
     metrics: list[str],
-    task: str,
+    task: TaskType,
     *,
     feval_names: frozenset[str],
 ) -> None:
@@ -200,7 +201,7 @@ def _metric_display_name(metric: BaseMetric, kwargs: dict[str, Any]) -> str:
 
 def _build_feval(
     metric: BaseMetric,
-    task: str,
+    task: TaskType,
     num_class: int | None = None,
     *,
     display_name: str | None = None,
@@ -270,7 +271,7 @@ def _build_feval(
 
 def resolve_metrics(
     metrics: list[MetricEntry],
-    task: str,
+    task: TaskType,
     num_class: int | None = None,
 ) -> tuple[list[str], list[Callable[..., tuple[str, float, bool]]], list[str]]:
     """Split metrics into native LightGBM names and feval callables.

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -15,8 +15,9 @@ import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.search_dim import SearchDim
+from lizyml.core.types.task import TaskType
 from lizyml.estimators.base import BaseEstimatorAdapter
-from lizyml.estimators.lgbm.adapter import LGBMAdapter, TaskType
+from lizyml.estimators.lgbm.adapter import LGBMAdapter
 from lizyml.estimators.lgbm.defaults import (
     _COMMON_DEFAULTS,
     default_fixed_params,
@@ -61,7 +62,7 @@ class LGBMProvider:
         n_rows: int,
         feature_names: list[str],
         y: pd.Series,
-        task: str,
+        task: TaskType,
     ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
         """Resolve smart parameters to native LightGBM parameters.
 
@@ -90,7 +91,7 @@ class LGBMProvider:
 
     def build_estimator_factory(
         self,
-        task: str,
+        task: TaskType,
         params: dict[str, Any],
         n_classes: int | None,
         early_stopping_rounds: int | None,
@@ -98,11 +99,10 @@ class LGBMProvider:
     ) -> Callable[[], BaseEstimatorAdapter]:
         """Return a factory that creates a configured LGBMAdapter."""
         final_params = params
-        lgbm_task: TaskType = task  # type: ignore[assignment]
 
         def make_estimator() -> LGBMAdapter:
             return LGBMAdapter(
-                task=lgbm_task,
+                task=task,
                 params=final_params,
                 num_class=n_classes,
                 early_stopping_rounds=early_stopping_rounds,
@@ -115,11 +115,11 @@ class LGBMProvider:
         """Return a factory that creates NativeFeaturePipeline."""
         return NativeFeaturePipeline
 
-    def default_space(self, task: str) -> list[SearchDim]:
+    def default_space(self, task: TaskType) -> list[SearchDim]:
         """Return the default LightGBM search space."""
         return default_space(task)
 
-    def default_fixed_params(self, task: str) -> dict[str, Any]:
+    def default_fixed_params(self, task: TaskType) -> dict[str, Any]:
         """Return fixed params for default search space."""
         return default_fixed_params(task)
 

--- a/lizyml/estimators/lgbm/smart_params.py
+++ b/lizyml/estimators/lgbm/smart_params.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 
 def _compute_num_leaves(max_depth: int | None, ratio: float) -> int:
@@ -29,7 +30,7 @@ def resolve_smart_params(
     n_rows: int,
     feature_names: list[str],
     y: pd.Series,
-    task: str,
+    task: TaskType,
 ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
     """Resolve smart parameters to native LightGBM parameters.
 

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -17,6 +17,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.types.search_dim import SearchDim
+from lizyml.core.types.task import TaskType
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 
@@ -68,7 +69,7 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         n_rows: int,
         feature_names: list[str],
         y: pd.Series,
-        task: str,
+        task: TaskType,
     ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
         """Resolve smart parameters to native estimator parameters.
 
@@ -89,7 +90,7 @@ class EstimatorProvider(Protocol):  # pragma: no cover
 
     def build_estimator_factory(
         self,
-        task: str,
+        task: TaskType,
         params: dict[str, Any],
         n_classes: int | None,
         early_stopping_rounds: int | None,
@@ -102,11 +103,11 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         """Return a zero-arg factory that creates the appropriate FeaturePipeline."""
         ...
 
-    def default_space(self, task: str) -> list[SearchDim]:
+    def default_space(self, task: TaskType) -> list[SearchDim]:
         """Return the default hyperparameter search space for this estimator."""
         ...
 
-    def default_fixed_params(self, task: str) -> dict[str, Any]:
+    def default_fixed_params(self, task: TaskType) -> dict[str, Any]:
         """Return fixed params applied to every trial when using default space."""
         ...
 

--- a/lizyml/evaluation/confusion.py
+++ b/lizyml/evaluation/confusion.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sklearn.metrics import confusion_matrix
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.training.oof_assembly import compute_oof_valid_mask
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ def confusion_matrix_table(
     y_true: npt.NDArray[Any],
     *,
     threshold: float = 0.5,
-    task: str,
+    task: TaskType,
 ) -> dict[str, pd.DataFrame]:
     """Compute IS and OOS confusion matrices.
 

--- a/lizyml/evaluation/evaluator.py
+++ b/lizyml/evaluation/evaluator.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.types.fit_result import FitResult
+from lizyml.core.types.task import TaskType
 from lizyml.metrics.base import BaseMetric
 from lizyml.metrics.registry import MetricEntry, get_metrics_for_task
 from lizyml.training.oof_assembly import compute_oof_valid_mask
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["Evaluator", "TaskType"]
 
 
 def _normalize_multiclass_proba(

--- a/lizyml/explain/shap_explainer.py
+++ b/lizyml/explain/shap_explainer.py
@@ -22,6 +22,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 if TYPE_CHECKING:
     from lizyml.estimators.base import BaseEstimatorAdapter
@@ -38,7 +39,7 @@ except ImportError:  # pragma: no cover
 def compute_shap_values(
     model: BaseEstimatorAdapter,
     X: pd.DataFrame,
-    task: str,
+    task: TaskType,
 ) -> npt.NDArray[np.float64]:
     """Compute SHAP values for *X* using *model*.
 
@@ -93,7 +94,7 @@ def compute_shap_importance(
     models: list[Any],
     X: pd.DataFrame,
     splits_outer: list[tuple[npt.NDArray[Any], npt.NDArray[Any]]],
-    task: str,
+    task: TaskType,
     feature_names: list[str],
     pipeline_state: Any,
     pipeline_factory: Callable[[], Any] | None = None,

--- a/lizyml/persistence/exporter.py
+++ b/lizyml/persistence/exporter.py
@@ -22,6 +22,7 @@ import joblib
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -43,7 +44,7 @@ def export(
     fit_result: FitResult,
     refit_result: RefitResult,
     config: dict[str, Any],
-    task: str,
+    task: TaskType,
     *,
     analysis_context: AnalysisContext | None = None,
 ) -> None:

--- a/lizyml/plots/classification.py
+++ b/lizyml/plots/classification.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 from sklearn.metrics import roc_auc_score, roc_curve
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
@@ -202,7 +203,7 @@ def plot_roc_curve(
     fit_result: FitResult,
     y_true: npt.NDArray[Any],
     *,
-    task: str,
+    task: TaskType,
 ) -> Any:
     """Plot ROC curve(s).
 

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -10,6 +10,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 
 class BaseInnerValidStrategy(ABC):
@@ -270,7 +271,7 @@ class BlockedGroupInnerValid(BaseInnerValidStrategy):
 
     _MIN_GROUPS_FOR_ISOLATION = 4
 
-    def __init__(self, ratio: float = 0.1, task: str = "regression") -> None:
+    def __init__(self, ratio: float = 0.1, task: TaskType = "regression") -> None:
         if not 0.0 < ratio < 1.0:
             raise ValueError(f"ratio must be in (0, 1), got {ratio}")
         self.ratio = ratio

--- a/lizyml/training/oof_assembly.py
+++ b/lizyml/training/oof_assembly.py
@@ -9,16 +9,18 @@ Assembly rules (leakage prevention):
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from lizyml.core.types.task import TaskType
+
 if TYPE_CHECKING:
     from lizyml.estimators.base import BaseEstimatorAdapter
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["TaskType", "compute_oof_valid_mask", "init_oof"]
 
 
 def init_oof(

--- a/tests/test_core/test_task_type.py
+++ b/tests/test_core/test_task_type.py
@@ -1,0 +1,58 @@
+"""Tests for the canonical ``TaskType`` Literal (#122, H-0075).
+
+Pin down two contracts:
+
+1. The runtime values match the public Config schema and BLUEPRINT §7.1.
+2. Every layer that re-exports ``TaskType`` resolves to the same Literal
+   (no silent drift between modules).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizyml.core.types.task import TASK_TYPES, TaskType
+
+
+class TestTaskTypeContract:
+    def test_known_values(self) -> None:
+        assert set(TASK_TYPES) == {"regression", "binary", "multiclass"}
+
+    def test_task_types_is_tuple(self) -> None:
+        """``TASK_TYPES`` is iterable and ordered for parametrize use."""
+        assert isinstance(TASK_TYPES, tuple)
+        assert len(TASK_TYPES) == 3
+
+    @pytest.mark.parametrize("task", TASK_TYPES)
+    def test_each_value_round_trips(self, task: TaskType) -> None:
+        assert task in TASK_TYPES
+
+
+class TestTaskTypeReExports:
+    """Every layer that historically defined its own ``TaskType`` Literal
+    must now resolve to the same alias."""
+
+    def test_target_encoder_re_export(self) -> None:
+        from lizyml.core.types.target_encoder import TaskType as TET
+
+        assert TET is TaskType
+
+    def test_evaluator_re_export(self) -> None:
+        from lizyml.evaluation.evaluator import TaskType as EvalT
+
+        assert EvalT is TaskType
+
+    def test_oof_assembly_re_export(self) -> None:
+        from lizyml.training.oof_assembly import TaskType as OOFTaskType
+
+        assert OOFTaskType is TaskType
+
+    def test_lgbm_adapter_re_export(self) -> None:
+        from lizyml.estimators.lgbm.adapter import TaskType as LGBMT
+
+        assert LGBMT is TaskType
+
+    def test_lgbm_defaults_uses_canonical_alias(self) -> None:
+        from lizyml.estimators.lgbm.defaults import TaskType as DefT
+
+        assert DefT is TaskType


### PR DESCRIPTION
## Summary
Implements [H-0075](HISTORY.md#h-0075) (Sprint 3 #3). Closes #122.

### Why
`TaskType = Literal["regression", "binary", "multiclass"]` was duplicated across 5+ modules (`target_encoder`, `evaluator`, `oof_assembly`, `lgbm.adapter`, `lgbm.defaults` (with the wrong `= str`), `model.py`). New layers picked up `task: str` annotations, hiding typos and inhibiting Literal narrowing in mypy. Adding a future task type (`"ranking"`, `"multilabel"`) would have required hand-editing every one.

### Changes
1. **New canonical module** `lizyml/core/types/task.py`:
   - `TaskType = Literal["regression", "binary", "multiclass"]`
   - `TASK_TYPES: tuple[TaskType, ...]` for iteration / parametrize use.
2. **De-duplicate**: every previous local `TaskType =` is now `from lizyml.core.types.task import TaskType` (kept as a re-export so external imports stay valid).
3. **`task: str` → `task: TaskType`** in 10 modules:
   - `evaluation/confusion.py`, `explain/shap_explainer.py`, `estimators/provider.py`, `training/inner_valid.py`, `core/_model_factories.py`, `plots/classification.py`, `persistence/exporter.py`, `estimators/lgbm/{metric_bridge,smart_params,provider}.py`.
4. **Drop now-unused `# type: ignore[assignment]`** in `lgbm/provider.py:102` — the cast disappeared with the tightened protocol type.
5. **Re-export contract tests** (`tests/test_core/test_task_type.py`, 10 tests): every module that re-exports `TaskType` is asserted to resolve to the same Literal alias as `lizyml.core.types.task.TaskType`.

### Acceptance criteria (from H-0075)
- [x] `lizyml/core/types/task.py` exists with the canonical Literal.
- [x] No `task: str` annotations remain in production (`grep -rn 'task: str' lizyml/` → 0 matches).
- [x] No duplicate `TaskType = Literal[...]` definitions in production.
- [x] Existing tests pass without modification — **1709 passed** total (+10 new).
- [x] `mypy --strict` clean.
- [x] `_DEFAULT_METRICS` in `model.py` typed as `dict[TaskType, ...]`.

### Dispatch dict refactor (deliberately limited)
The Proposal called out `metric_bridge.py` and `evaluator.py` as candidates for `if/elif` → dispatch dict conversion. After audit only **2-branch** patterns exist in those files (the third branch is implicit `else`), so converting to dispatch dicts would *increase* line count without improving readability. Type-annotation tightening still buys exhaustive `mypy --strict` checks via `Literal`.

The 3-branch `metric_bridge._build_feval_callable.feval_fn` (binary / multiclass / regression) is intentionally left as `if/elif` because each branch performs structurally different work (sigmoid, softmax-with-reshape, identity).

## Skill / DoD
- Skill: `skills/config-and-specs` + `skills/spec-update`.
- DoD:
  - Single source of truth for `TaskType`.
  - mypy can now narrow `task` against the Literal at every call site.
  - Foundation for adding a new task type as a single-line widening of the union.

## Test plan
- [x] `uv run pytest tests/test_core/test_task_type.py -v` — 10 passed.
- [x] `uv run pytest` — **1709 passed** total.
- [x] `uv run ruff check .` (after `--fix` for import order)
- [x] `uv run ruff format --check lizyml/`
- [x] `uv run mypy lizyml/`

## Migration
- No public API change. `task` strings still accept the same values.
- External code that did `from lizyml.<module> import TaskType` keeps working — every former site re-exports the canonical alias.