### PR TITLE
release: v0.13.0 — LizyML 0.13.0

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1237,6 +1237,9 @@ class EstimatorProvider(Protocol):
     def params_summary(
         self, model: BaseEstimatorAdapter, model_cfg: Any,
     ) -> list[dict[str, Any]]: ...
+    def build_export_params(
+        self, adapter: BaseEstimatorAdapter,
+    ) -> ExportParams: ...
 ```
 
 制約:
@@ -1245,6 +1248,7 @@ class EstimatorProvider(Protocol):
 - `runtime_deps()` はアルゴリズム固有の依存パッケージ名とバージョンを返す（例: `{"lightgbm": "4.5.0"}`）。`RunMeta.deps_versions` に使用。
 - `params_summary()` は `params_table()` 用のパラメータ行を返す。smart params + native model params（`metric` を含む、H-0061）の両方を含む。
 - `build_pipeline_factory` は estimator 固有の FeaturePipeline が必要な場合（例: EntityEmbedding のカテゴリ埋め込み）に対応する。デフォルトは `NativeFeaturePipeline` を返す。
+- `build_export_params` は codegen 経路（`Model.export_code()`）が必要とする native params / num_boost_round / feval metadata を `ExportParams` frozen dataclass で返す（H-0073）。`_model_persistence.py` から estimator 具象型（`LGBMAdapter` 等）への直接参照を排除するための入口。
 
 ディレクトリ構成（estimator ごとにサブパッケージ化）:
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -475,7 +475,8 @@ LizyML 非依存の学習・推論コードを自動生成する。
 - `target_encoder`（H-0070, format_version=2）
   - `TargetEncoder(classes_: tuple[Any, ...], needs_encoding: bool, original_dtype: str)`
   - 数値 y / regression では `needs_encoding=False` の no-op
-  - 非数値 classification y では `classes_` に sorted 元ラベルを保持
+  - 非数値 classification y では `classes_` に **lexicographically** sorted な元ラベルを保持
+    （`sorted(unique, key=str)`、numeric-string では自然順とは一致しない: `["1","10","2"]` → `("1","10","2")`）
   - `predict()` / codegen / persistence migration で利用
 
 ## 7.2 TuningResult（固定スキーマ）

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1692,3 +1692,4 @@ loaded_model.probability_histogram_plot()
 - `Model` クラスは mixin で構成する（H-0042）。plot 系は `_model_plots.py`、table/accessor 系は `_model_tables.py`、persistence 系は `_model_persistence.py` に分割し、`model.py` には core lifecycle（`__init__`, `fit`, `predict`, `evaluate`, `tune`）とプライベートヘルパーのみを残す。
 - mixin は `_` プレフィックスの非公開モジュールとし、`Model` の import パス（`lizyml.core.model.Model`）は変更しない。
 - 依存関係の切り離しが必要な箇所では Lazy Import を許容する。
+- `Model._get_fit_state()` が返す `FitState` frozen dataclass を mixin の唯一の入口として整備中（H-0074, Phase 1: 型定義 + factory + テスト, Phase 2: 全 mixin 移行）。`FitState` は `cfg / fit_result / refit_result / tuning_result / provider / metrics / y / X / run_dir / output_dir` の post-fit snapshot を持ち、`self._*` への直接アクセスを段階的に置換する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.13.0] - 2026-05-10
+
+### Added
+
+- **`EstimatorProvider.build_export_params()`** (H-0073, [#109](https://github.com/nbx-liz/LizyML/issues/109), [#126](https://github.com/nbx-liz/LizyML/issues/126)) — codegen-relevant booster params and feval metadata are now retrieved through the `EstimatorProvider` Protocol, so `Model.export_code()` is fully estimator-agnostic. Adding a new estimator no longer requires editing `lizyml/core/_model_persistence.py`. The new method also unifies `BlockedGroupKFold` `n_splits` resolution between persistence and factories.
+- **`FitState` / `TuningState` frozen dataclasses + `Model._get_fit_state()` / `_get_tuning_state()`** (H-0074 Phase 1 + H-0077 Phase 2, [#112](https://github.com/nbx-liz/LizyML/issues/112)) — `ModelPlotsMixin` / `ModelTablesMixin` / `ModelPersistenceMixin` now read state exclusively through these snapshots. Direct `self._<private>` access is forbidden inside Mixin bodies and enforced by a static guard test (`tests/test_core/test_mixin_state_isolation.py`). Mixins become unit-testable with synthetic state. Public API unchanged.
+- **`docs/DEPRECATIONS.md` central deprecation registry** (H-0076, [#120](https://github.com/nbx-liz/LizyML/issues/120), [#121](https://github.com/nbx-liz/LizyML/issues/121)) — single source of truth for every deprecated public surface and its removal target version. Every `DeprecationWarning` LizyML raises now contains "Will be removed in vX.Y." (currently "v1.0"); `tests/test_core/test_deprecation_registry.py` enforces this contract in CI.
+
+### Changed
+
+- **`TaskType` Literal centralised + propagated to all dispatch sites** (H-0075, [#122](https://github.com/nbx-liz/LizyML/issues/122)) — `lizyml/core/types/task.py` exposes `TaskType = Literal["regression", "binary", "multiclass"]`. Every branch on task now uses an exhaustive dispatch table, eliminating string-comparison divergence between modules. Public API unchanged; internal type-safety only.
+- **`DeprecationWarning` messages now state the removal target version** (H-0076) — users see "Will be removed in v1.0." in every deprecation message so migration deadlines are explicit.
+- **Inner-valid membership checks vectorised with numpy** (H-0065 follow-up, [#135](https://github.com/nbx-liz/LizyML/issues/135)) — measurable speedup on large CV folds; behaviour unchanged.
+- **`Model.tune()` decomposed into 5 testable helpers** (H-0040 follow-up, [#114](https://github.com/nbx-liz/LizyML/issues/114)) — orchestrator + per-step helpers, no behaviour change.
+- **`LizyMLError.context` enriched at 23 sites** ([#118](https://github.com/nbx-liz/LizyML/issues/118)) — fold index / config path / method name now consistently carried; regression guard added.
+- **`storage` parameter type tightened to `str | BaseStorage | None`** ([#136](https://github.com/nbx-liz/LizyML/issues/136)) — was `Any`; aligns with H-0072 docstring.
+- **Plot theme deduplicated via `apply_default_layout`** ([#134](https://github.com/nbx-liz/LizyML/issues/134)) — `lizyml/plots/_theme.py` is now the single source for default layout settings shared across every plot module.
+- **`StratifiedTimeHoldoutInnerValid` tail-holdout fallback inlined** ([#133](https://github.com/nbx-liz/LizyML/issues/133)) — readability improvement, behaviour unchanged.
+- **`TargetEncoder` lexicographic class ordering documented with example** ([#132](https://github.com/nbx-liz/LizyML/issues/132)).
+
+### Fixed
+
+- **Tuning progress callback warning now includes exception type and message** ([#128](https://github.com/nbx-liz/LizyML/issues/128)) — debugging callback failures no longer requires re-running with logging tweaks.
+- **`FloatDim` linear lower expansion clamped at zero** ([#129](https://github.com/nbx-liz/LizyML/issues/129)) — boundary-detection re-tune (H-0068) no longer drives lower bounds below zero on naturally non-negative parameters.
+- **Legacy top-level `validation_ratio` input emits `DeprecationWarning`** ([#130](https://github.com/nbx-liz/LizyML/issues/130)) — previously a YAML with only `early_stopping.validation_ratio` (and no `inner_valid:` block) was silent. Now the deprecation contract is enforced on input, not just output.
+- **Unhandled `SplitConfig` variants raise `LizyMLError(CONFIG_INVALID)`** ([#131](https://github.com/nbx-liz/LizyML/issues/131)) — previously a silent fallback could mask schema regressions.
+- **Code-review HIGH issues + `#124` test gap closed** ([#141](https://github.com/nbx-liz/LizyML/issues/141)) — Sprint 1+2 follow-up batch.
+- **MEDIUM / LOW code-review batch** ([#142](https://github.com/nbx-liz/LizyML/issues/142)) — accumulated cleanup landed in one PR.
+
+### Internal
+
+- **`TrainComponents` rebuild path extracted to `_sort_and_rebuild_components()`** ([#137](https://github.com/nbx-liz/LizyML/issues/137)) — refactor only.
+- **Mixin source files contain zero direct `self._<private>` access** (H-0077 Phase 2, enforced by `tests/test_core/test_mixin_state_isolation.py`).
+
 ## [0.12.0] - 2026-05-06
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6257,3 +6257,90 @@ H-0042 で `model.py` を行数削減するため `ModelPlotsMixin` / `ModelTabl
 - Result: accepted
 - Notes: ユーザーへの予告と内部の削除計画を一元管理する非機能改善。実際の削除は v1.0 リリースの直前に別 PR で実施する。
 
+## H-0077: H-0074 Phase 2 — Mixin から self._* 直接 access を排除
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
+- **スコープ**: Internal API (`_model_plots.py`, `_model_tables.py`, `_model_persistence.py`, `core/types/fit_state.py`, `core/model.py`)
+- **関連**: [Issue #112](https://github.com/nbx-liz/issues/112) (HIGH), H-0074 (Phase 1)
+
+### 目的
+
+H-0074 Phase 1 で `FitState` frozen dataclass と `Model._get_fit_state()` を導入したが、Mixin (`ModelPlotsMixin` / `ModelTablesMixin` / `ModelPersistenceMixin`) はまだ `self._cfg`, `self._y`, `self._X`, `self._fit_result`, `self._tuning_result`, `self._provider`, `self._metrics`, `self._run_dir`, `self._output_dir` を直接参照している（合計 59 箇所）。Phase 2 として、Mixin の Model 本体への結合を `state: FitState` 経由のみに揃え、Issue #112 の Acceptance criteria（"Mixin methods access only `state.*` and method-local variables"）を満たす。
+
+### 変更内容
+
+1. **`TuningState` frozen dataclass を `core/types/fit_state.py` に追加**
+
+   `tuning_plot` / `tuning_table` / `boundary_table` は `tune()` のみ呼ばれた `fit()` 前の状態でも動作する必要があるため（既存テスト `tests/test_tuning/test_tuning_result.py` / `tests/test_plots/test_tuning_plot.py` で確認済み）、`FitState` の不変条件「fit 後 snapshot」を維持しつつ別経路を提供する。
+
+   ```python
+   @dataclass(frozen=True)
+   class TuningState:
+       cfg: LizyMLConfig
+       tuning_result: TuningResult  # not None — required for tuning APIs
+   ```
+
+2. **`Model._get_tuning_state() -> TuningState` を追加**
+
+   `_tuning_result is None` のとき `LizyMLError(MODEL_NOT_FIT)` を raise する単一の入口。tuning 系 Mixin メソッドはこれを通る。
+
+3. **Mixin 全メソッドの書き換え**
+
+   各メソッド冒頭で `state = self._get_fit_state()`（または `_get_tuning_state()`）を呼び、以降 `state.cfg / state.fit_result / state.y / state.X / state.metrics / state.tuning_result / state.provider / state.run_dir / state.output_dir` のみで完結させる。`self._<attr>` の直接 access を Mixin 内から完全に排除。`TYPE_CHECKING` ブロックの attribute stub も削除。
+
+4. **`_resolve_export_path()` を Model facade に移動**
+
+   既存実装は `self._run_dir = setup_output_dir(...)` で書き戻しを行うため、frozen な `FitState` 経由では実現できない。書き込み責務を Model facade に残し、Mixin の `export()` は facade method を呼ぶ形にする。
+
+5. **Mixin 単体テストの追加**
+
+   `tests/test_core/test_mixin_state_isolation.py` (新規) で mock の `FitState` / `TuningState` を Mixin に渡し、Mixin が `state.*` のみを参照していることを実証する単体テストを追加する。Issue #112 Acceptance criteria の 2 番目を満たす。
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/core/types/fit_state.py`（`TuningState` 追加）
+  - `lizyml/core/model.py`（`_get_tuning_state()` + `_resolve_export_path()` 追加）
+  - `lizyml/core/_model_plots.py`（`self._*` → `state.*`）
+  - `lizyml/core/_model_tables.py`（同上）
+  - `lizyml/core/_model_persistence.py`（同上 + `_resolve_export_path` を facade 委譲化）
+  - `tests/test_core/test_mixin_state_isolation.py`（新規）
+- **無変更**: 公開 API、Persistence 形式、Tuning 挙動、Plots 出力、Tables 形式、Config schema。
+
+### 互換性
+
+- **公開 API 完全互換**。Mixin メソッド signature・戻り値は不変。
+- 内部 attribute (`self._cfg`, `self._fit_result`, `_provider` 等) は Model 本体に維持。`FitState` / `TuningState` はその snapshot。
+- format_version 影響なし。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| `FitState` を `fit_result: FitResult \| None` に緩めて単一入口化 | "fit 後 snapshot" の不変条件が崩れ、すべての Mixin メソッドで null check が必要になる。型安全性が低下 |
+| Mixin メソッドに `state: FitState \| None = None` 引数を追加（外部 inject 可能） | 公開 API 表面が増え、ユーザーが内部構造を知る誘因になる。テスト用の入口は内部 helper で十分 |
+| Mixin を継承から composition に変更 | 既存の継承階層が public 型表面（`isinstance(model, ModelPlotsMixin)` 互換）。本 Issue のスコープ外 |
+| Phase 2 を tuning 系除外で実施 | Issue #112 Acceptance criteria を完全に満たさない |
+
+### 受け入れ基準
+
+- [ ] `grep -nE "self\._(cfg|y|X|fit_result|refit_result|tuning_result|metrics|provider|run_dir|output_dir)" lizyml/core/_model_plots.py lizyml/core/_model_tables.py lizyml/core/_model_persistence.py` の出力が空。
+- [ ] 各 Mixin の `TYPE_CHECKING` ブロックから Model attribute stub が削除されている（`_get_fit_state` / `_get_tuning_state` / `_resolve_export_path` の宣言のみ残す）。
+- [ ] `tests/test_core/test_mixin_state_isolation.py` で mock state を使った単体テストが各 Mixin に存在し、pass する。
+- [ ] 既存 1709 テスト全件 pass。
+- [ ] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy lizyml/` がクリーン。
+
+### Migration
+
+- ユーザーには影響なし（公開 API 互換）。
+- 拡張開発者向け：以後、Mixin に新メソッドを追加する際は `self._<private>` ではなく `state = self._get_fit_state()` パターンに従うこと。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted
+- Notes: Phase 1 (H-0074) で予告した Phase 2 の実装。tuning 系メソッドの fit-前-tune-後 ケースを `TuningState` 別経路で扱うことで `FitState` の "fit 後 snapshot" 不変条件を維持。
+
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5873,3 +5873,387 @@ class Tuner:
 - Result: accepted
 - Notes: Issue #105 に対する upstream 対応として承認。Optuna 標準機能の薄い委譲、後方互換 100%、追加依存なし。round 履歴の永続化は別 Proposal（H-0073 候補）で扱う。
 
+## H-0073: EstimatorProvider に build_export_params() を追加し codegen 経路から LGBM 固有コードを除去
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
+- **スコープ**: Public Protocol (`EstimatorProvider`) | Internal API (`_model_persistence.py`, `_model_factories.py`)
+- **関連**: [Issue #109](https://github.com/nbx-liz/issues/109) (CRITICAL), [Issue #126](https://github.com/nbx-liz/issues/126) (MEDIUM), BLUEPRINT.md §2.2 / §14.4
+
+### 目的
+
+H-0053（EstimatorProvider 導入）で公開された Provider 抽象が、`Model.export_code()` 経路で**たった 1 箇所だけ破られている**。`lizyml/core/_model_persistence.py:154-179` が `LGBMAdapter` を直接 `isinstance` チェックし、private な `_build_params()` を直接呼び出す形でコード生成用パラメータを取得しているため、新しい Estimator（XGBoost / sklearn 等）を追加する際に**必ずこの persistence 層を編集する必要があり、Provider 抽象化の意義を半減させている**（#109 CRITICAL）。
+
+加えて `BlockedGroupKFoldConfig` の `n_splits` 解決ロジックが `_model_persistence.py:174-179` と `_model_factories.py:173-181` に重複している（#126 MEDIUM）。本 Proposal は両者を 1 つの構造変更にまとめて解消する。
+
+### 変更内容
+
+1. **Provider Protocol に `build_export_params()` を追加** (`lizyml/estimators/provider.py`)
+
+   ```python
+   class EstimatorProvider(Protocol):
+       ...
+       def build_export_params(self, adapter: Any) -> dict[str, Any]:
+           """Return booster params suitable for codegen export.
+
+           Used by Model.export_code() to emit a self-contained train.py
+           that does not depend on LizyML at runtime."""
+   ```
+
+2. **`LGBMProvider.build_export_params()` を実装** (`lizyml/estimators/lgbm/provider.py`)
+
+   ```python
+   def build_export_params(self, adapter: LGBMAdapter) -> dict[str, Any]:
+       return adapter._build_params()  # private は LGBM パッケージ内で閉じる
+   ```
+
+   - `_build_params()` は `LGBMAdapter` の private のままで OK（同パッケージ内 access）
+   - 将来 `XGBoostProvider` を追加するときも、同じ public method を実装するだけ
+
+3. **`get_outer_n_splits(cfg) -> int` ユーティリティを `_model_factories.py` に追加**
+
+   ```python
+   def get_outer_n_splits(cfg: LizyMLConfig) -> int:
+       if isinstance(cfg.split, BlockedGroupKFoldConfig):
+           return cfg.split.groups.n_splits
+       return cfg.split.n_splits
+   ```
+
+4. **`_model_persistence.py` 全面刷新**
+   - `from lizyml.estimators.lgbm.adapter import LGBMAdapter` → 削除
+   - `isinstance(adapter, LGBMAdapter)` → 削除
+   - `adapter._build_params()` → `provider.build_export_params(adapter)` に置換
+   - inline n_splits 解決 → `get_outer_n_splits(cfg)` 呼び出しに置換
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/estimators/provider.py`（Protocol に 1 method 追加）
+  - `lizyml/estimators/lgbm/provider.py`（実装追加）
+  - `lizyml/core/_model_persistence.py`（LGBMAdapter import 削除 + dispatch 経由化）
+  - `lizyml/core/_model_factories.py`（`get_outer_n_splits` 追加）
+  - `tests/test_persistence/`（既存 73 codegen テストが pass することを確認、 isinstance ゼロを確認するテストを追加）
+  - BLUEPRINT.md §14.4（Provider spec に `build_export_params` を追記）
+- **無変更**: `Model` public API、`FitResult`、`PredictionResult`、Artifacts schema、Calibration、Tuning。
+
+### 互換性
+
+- **Provider Protocol への method 追加は破壊的**（既存の Provider 実装は新メソッドを実装する必要あり）。ただし現状 `LGBMProvider` のみ存在するため実害なし。
+- `format_version` バンプ不要（Artifacts schema は無変更）。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| `LGBMAdapter._build_params()` を public 化 | LGBM 内部詳細をパッケージ外に漏らす。Provider 抽象の存在意義に反する |
+| `_model_persistence.py` を Provider に丸ごと移管 | 過剰な責務移動。export 形式の決定は Facade 層の仕事 |
+| `n_splits` 重複だけ解消し #109 は別 PR | #126 は #109 のサブセット。同じ refactor 経路で同時解消が効率的 |
+
+### 受け入れ基準
+
+- [ ] `grep -rn 'LGBMAdapter' lizyml/core/` → ゼロマッチ。
+- [ ] `grep -rn 'isinstance.*LGBMAdapter' lizyml/core/` → ゼロマッチ。
+- [ ] `grep -rn 'BlockedGroupKFoldConfig' lizyml/core/_model_persistence.py` → ゼロマッチ（factories へ集約）。
+- [ ] 既存 codegen テスト（73 件）が無修正で pass。
+- [ ] `EstimatorProvider.build_export_params` の契約テストを追加（呼び出すと `dict[str, Any]` が返る）。
+- [ ] BLUEPRINT.md §14.4 に新メソッドが記載されている。
+
+### Migration
+
+- 外部の Provider 実装者向け（現状ゼロだが将来用）：`build_export_params(adapter) -> dict` を実装する必要がある。
+- LizyML 利用者には影響なし（内部 refactor）。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted
+- Notes: コードレビューで CRITICAL とマークされた #109 + その subset の #126 を一括解消する内部 refactor。Provider 抽象化の整合性を取り戻すことで XGBoost / sklearn 拡張の素地を整える。
+
+---
+
+## H-0074: FitState frozen dataclass を導入し Mixin の private state 直接参照を解消
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
+- **スコープ**: Internal API (Mixin classes), Testability
+- **関連**: [Issue #112](https://github.com/nbx-liz/issues/112) (HIGH)
+
+### 目的
+
+H-0042 で `model.py` を行数削減するため `ModelPlotsMixin` / `ModelTablesMixin` / `ModelPersistenceMixin` を切り出したが、各 Mixin が `self._y`、`self._X`、`self._cfg`、`self._provider`、`self._tuning_result`、`self._metrics`、`self._run_dir`、`self._output_dir` 等を**直接読み書きしている**。結果として:
+
+1. **責務分離が見かけだけ**：Mixin 単独でユニットテスト不可（fit 済み Model が必要）
+2. **silent breakage**：Model の private 属性をリネームすると Mixin が**型チェックなしに壊れる**（mypy は `if TYPE_CHECKING` ブロックで属性宣言される範囲しか追えない）
+3. **入力契約が暗黙**：各 Mixin が必要とする state が分散しており、API として不明瞭
+
+本 Proposal は **`FitState`（frozen dataclass）を中継層に導入**し、Mixin が必要な値を明示的に受け取る形に変える。
+
+### 変更内容
+
+1. **`FitState` を新規追加** (`lizyml/core/types/fit_state.py`)
+
+   ```python
+   from dataclasses import dataclass
+   from pathlib import Path
+   from lizyml.config.schema import LizyMLConfig
+   from lizyml.core.types.fit_result import FitResult
+   from lizyml.core.types.tuning_result import TuningResult
+   from lizyml.estimators.provider import EstimatorProvider
+   from lizyml.training.refit_trainer import RefitResult
+
+   @dataclass(frozen=True)
+   class FitState:
+       """Snapshot of Model fit state consumed by Mixin methods (#112).
+
+       Created by ``Model._get_fit_state()`` after fit/tune. Mixin methods
+       receive this instead of reading ``self._*`` directly.
+       """
+       cfg: LizyMLConfig
+       fit_result: FitResult
+       refit_result: RefitResult | None
+       tuning_result: TuningResult | None
+       provider: EstimatorProvider
+       output_dir: Path | None
+       run_dir: Path | None
+       y: pd.Series | None    # transient; absent after Model.load() w/o analysis_context
+       X: pd.DataFrame | None
+       metrics: dict[str, Any] | None
+   ```
+
+2. **`Model._get_fit_state() -> FitState` を追加**
+   - 内部の `self._*` を 1 箇所に集約。Mixin 経由の参照は全てこれを通る。
+   - 失敗時（`fit_result is None`）は既存の `_require_fit()` と同じ `LizyMLError` を raise。
+
+3. **Mixin signatures を `state: FitState` 受け取りに変更**
+   - 例: `ModelPlotsMixin.calibration_plot(self, *, state: FitState | None = None)` で渡されない場合は `self._get_fit_state()` 経由でフォールバック（破壊的変更回避）
+   - 段階的移行：Phase 1 = `FitState` 経由でも `self._*` 経由でも動く / Phase 2 = `self._*` 直接 access を削除
+
+4. **Mixin の単体テスト追加**
+   - `tests/test_core/test_model_plots_mixin.py`：`FitState` を mock で組み立てて Mixin 単体で動作確認
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/core/types/fit_state.py`（新規）
+  - `lizyml/core/_model_plots.py`、`_model_tables.py`、`_model_persistence.py`（Mixin signatures + body 更新）
+  - `lizyml/core/model.py`（`_get_fit_state()` 追加 + Mixin 呼び出し経路調整）
+  - `tests/test_core/test_model_plots_mixin.py`（新規）
+  - BLUEPRINT.md §3（責務分離の記述更新）
+- **無変更**: 公開 API、Persistence 形式、Tuning、Plots 出力、Tables 形式。
+
+### 互換性
+
+- **公開 API 完全互換**。Model のメソッド名・シグネチャ・戻り値は変更なし。
+- 内部 attribute (`self._cfg`, `self._fit_result`, ...) も維持（FitState はその snapshot）。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| Mixin を継承から composition に変更 | 既存の継承階層（Model(ModelPlotsMixin, ...)）が public 型表面なので破壊的 |
+| `Protocol` で Model attrs を宣言 | mypy は通るが runtime 結合は変わらず、テスト可能性が改善しない |
+| Phase 2（self._* 直接 access 削除）を同 PR で実施 | refactor 量が大きく review 負荷が跳ね上がる。段階的に進める |
+
+### 受け入れ基準
+
+- [ ] `FitState` frozen dataclass が定義されている。
+- [ ] `Model._get_fit_state()` が動作し、既存テスト（特に `test_model_facade.py`）が pass。
+- [ ] 各 Mixin に少なくとも 1 件の **mock FitState を使った単体テスト** を追加。
+- [ ] 既存の Mixin tests がすべて pass。
+- [ ] mypy --strict が pass。
+
+### Migration
+
+- ユーザーには影響なし。
+- 拡張開発者向け：将来的に Mixin 内部から `self._*` 直接 access を削除する Phase 2 PR を予告（H-0074-Phase2 として別 Proposal）。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted
+- Notes: Mixin の責務分離を実態化する構造改善。Phase 1 では後方互換を保つ二重経路を許容し、Phase 2 で完全移行する段階的アプローチを承認。
+
+---
+
+## H-0075: TaskType Literal を全分岐サイトに伝搬し dispatch dict 化
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
+- **スコープ**: Internal type annotations, Code organisation
+- **関連**: [Issue #122](https://github.com/nbx-liz/issues/122) (MEDIUM)
+
+### 目的
+
+`TaskType = Literal["regression", "binary", "multiclass"]` は既に `core/types/target_encoder.py` で定義されているが、コードベース内に `if task == "regression"` / `elif task == "binary"` 形式の分岐が **6 ファイル以上に散在**している。新しい task type（例: "ranking"、"multilabel"）を追加する際、全箇所を手で grep して書き換える必要があり、**漏れによる silent bug のリスクが高い**。
+
+### 変更内容
+
+1. **`TaskType` を全分岐サイトに type annotation として伝搬**
+
+   対象ファイル（grep で確認）:
+   - `lizyml/core/model.py:349` 等
+   - `lizyml/evaluation/evaluator.py:57,59`
+   - `lizyml/estimators/lgbm/metric_bridge.py:239,241`
+   - `lizyml/core/_model_factories.py:55-62` (`_resolve_stratify`)
+   - `lizyml/core/types/target_encoder.py`（既に使用済）
+   - 他 grep で発見された箇所
+
+2. **形が同じ `if/elif` チェーンを dispatch dict に置換**
+
+   ```python
+   # before
+   if task == "regression":
+       handler = handle_regression
+   elif task == "binary":
+       handler = handle_binary
+   else:  # multiclass
+       handler = handle_multiclass
+
+   # after
+   _TASK_DISPATCH: dict[TaskType, Callable[..., R]] = {
+       "regression": handle_regression,
+       "binary": handle_binary,
+       "multiclass": handle_multiclass,
+   }
+   handler = _TASK_DISPATCH[task]
+   ```
+
+3. **特に metric_bridge.py / evaluator.py は確実に dispatch dict 化**
+   - 同形分岐が 3 つ以上ある site のみが対象（`if-elif-else` を残す価値の低いケース）
+
+4. **task が "regression" / "binary" / "multiclass" 以外を取れる箇所を grep で網羅し、エラーパスは `LizyMLError(UNSUPPORTED_TASK)` に統一**
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/core/model.py`、`evaluation/evaluator.py`、`estimators/lgbm/metric_bridge.py`、`core/_model_factories.py` 等
+  - `tests/test_*` 全般（既存 task 別パラメトリックテストは影響なし）
+- **無変更**: 公開 API、戻り値の意味、metric の挙動、`TaskType` の値そのもの。
+
+### 互換性
+
+- **公開 API 完全互換**。`task` 文字列の値は変えない。
+- 型注釈強化と内部リファクタのみ。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| `Task` Enum 化 | `TaskType` は外部 Config（YAML/JSON）から `str` で来るため Enum 化は変換コストを増やす。`Literal` のままが pydantic と相性が良い |
+| `functools.singledispatch` | task は型ではなく value。singledispatch は不適切 |
+| 全 if/elif を dispatch dict 化 | 1〜2 分岐の小さい if/elif は可読性が落ちる。3 分岐以上だけが対象 |
+
+### 受け入れ基準
+
+- [ ] `metric_bridge.py` と `evaluator.py` が dispatch dict を使用している。
+- [ ] 全分岐サイトで `task` の type annotation が `TaskType` または `str` ではなく `TaskType`（後者は禁止）。
+- [ ] 既存テスト全件 pass。
+- [ ] mypy --strict が `task: TaskType` を正しく narrowing する（dispatch dict 経由で全 key カバレッジを確認）。
+
+### Migration
+
+- ユーザー影響なし。
+- 拡張開発者向け：新しい task type を追加するときは `TaskType` Literal を更新するだけで dispatch table が mypy エラーで網羅性を強制できる。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted
+- Notes: 内部 refactor。新 task 追加時の漏れリスク削減と、mypy による網羅性チェックを獲得する。
+
+---
+
+## H-0076: Deprecation Warning に削除目標バージョンを明記し中央レジストリ化
+
+- **ステータス**: Accepted
+- **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
+- **スコープ**: Documentation, User-facing warnings
+- **関連**: [Issue #120](https://github.com/nbx-liz/issues/120) (MEDIUM), [Issue #121](https://github.com/nbx-liz/issues/121) (MEDIUM), [H-0058](#h-0058)
+
+### 目的
+
+複数の `DeprecationWarning` / `UserWarning` で「いつ削除するか」が記述されておらず、ユーザーは migration の緊急度を判断できない。具体的には:
+
+- `lizyml/config/schema.py:115` (`purge_window`)
+- `lizyml/config/schema.py:123` (`embargo_pct`)
+- `lizyml/config/schema.py:131` (`gap` for purged_time_series)
+- `lizyml/config/schema.py:475,495` (`CalibrationConfig.n_splits`)
+- `lizyml/core/_model_factories.py:196` (`build_calibration_splitter`)
+
+加えて H-0058 で `build_calibration_splitter` を deprecated にして以来、**実際の削除計画が記録されていない**ためテスト側も具体挙動を依存してしまっている（#120）。
+
+### 変更内容
+
+1. **すべての deprecation 文言に "Will be removed in v1.0." を追記**
+
+   ```python
+   warnings.warn(
+       "`purge_window` is deprecated; use `purge_gap` instead. "
+       "Will be removed in v1.0.",
+       DeprecationWarning,
+       stacklevel=2,
+   )
+   ```
+
+2. **削除目標を `docs/DEPRECATIONS.md` に集約**（新規）
+
+   | 対象 | 代替 | 削除予定 | Deprecated since |
+   |---|---|---|---|
+   | `EarlyStoppingConfig.validation_ratio` | `inner_valid.ratio` | v1.0 | H-0069 (2026-04) |
+   | `CalibrationConfig.n_splits` | （outer split を再利用） | v1.0 | H-0058 (2026-04) |
+   | `purge_window` | `purge_gap` | v1.0 | H-0021 |
+   | `embargo_pct` | `embargo` | v1.0 | H-0021 |
+   | `build_calibration_splitter()` | （内部実装で OOF split を再利用） | v1.0 | H-0058 |
+   | `gap` (purged_time_series) | `purge_gap` | v1.0 | H-0021 |
+
+3. **deprecation テストの整理**
+   - `build_calibration_splitter` の動作に依存する既存テストを `pytest.warns(DeprecationWarning)` チェックに変更（実装非依存化）。
+   - 削除時に最小コミットで除去できる状態にする。
+
+4. **CI で `pytest.warns(DeprecationWarning, match="Will be removed in v")` を強制するテストを追加**
+   - 全 deprecation メッセージに削除予定が含まれることをリグレッションテストで保証。
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/config/schema.py`（deprecation 文言更新）
+  - `lizyml/core/_model_factories.py`（同）
+  - `docs/DEPRECATIONS.md`（新規）
+  - `tests/test_config/`、`tests/test_calibration/`（テスト整理）
+- **無変更**: 削除そのもの（v1.0 リリースまでは互換維持）、public API、Artifacts。
+
+### 互換性
+
+- **完全互換**。文言追加のみ、挙動は変えない。
+- 実際の削除（v1.0）は別 Proposal（H-XXXX-removal）で扱う。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| 削除を即実施 | 互換性ポリシー違反。v1.0 は別タイムライン |
+| バージョン記述を `pyproject.toml` のメタに集約 | warning メッセージから乖離する。docs/DEPRECATIONS.md が docs と warn 両方の SSOT として機能する |
+| Python `@deprecated` decorator 移行 | Python 3.13+ の機能。3.10 サポート期間中は採用不可 |
+
+### 受け入れ基準
+
+- [ ] `docs/DEPRECATIONS.md` が存在し、上記 6 項目を含む。
+- [ ] `grep -E "DeprecationWarning|deprecated" lizyml/` の全 warning に "v1.0" が含まれる（CI test で強制）。
+- [ ] `build_calibration_splitter` の挙動依存テストが `pytest.warns` ベースに置き換わっている。
+- [ ] 既存テスト全件 pass。
+
+### Migration
+
+- ユーザー向け：v1.0 までは現状の deprecation を継続。v1.0 リリース時に対応 PR で完全削除。
+- 内部開発：新規の deprecation を追加する際は必ず DEPRECATIONS.md と "Will be removed in vX.Y." 形式の文言を伴うこと（CONTRIBUTING.md / CLAUDE.md にルール追記）。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted
+- Notes: ユーザーへの予告と内部の削除計画を一元管理する非機能改善。実際の削除は v1.0 リリースの直前に別 PR で実施する。
+

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -1,0 +1,101 @@
+# Deprecation Registry
+
+Central tracking of deprecated public surfaces and their removal targets.
+Every `DeprecationWarning` / `UserWarning` raised by LizyML lists "Will be
+removed in v1.0." in its message; this file is the single source of truth.
+
+The CI test `tests/test_core/test_deprecation_registry.py` asserts that
+every deprecation warning emitted during a representative test run carries
+a removal-version suffix matching the pattern `Will be removed in v\d+\.\d+`.
+
+## Schedule
+
+| Target | Replacement | Removal | Deprecated since |
+|---|---|---|---|
+| `EarlyStoppingConfig.validation_ratio` (input) | `inner_valid.ratio` | **v1.0** | H-0069 (2026-04, made `computed_field` in #111) |
+| `CalibrationConfig.n_splits` | (removed; outer split is reused) | **v1.0** | H-0058 (2026-04) |
+| `purged_time_series.purge_window` | `purge_gap` | **v1.0** | H-0021 |
+| `purged_time_series.embargo_pct` | `embargo` (int, observation count) | **v1.0** | H-0021 |
+| `purged_time_series.gap` | `embargo` | **v1.0** | H-0021 |
+| `lizyml.core._model_factories.build_calibration_splitter` | (removed; outer split is reused) | **v1.0** | H-0058 |
+
+## Migration notes
+
+### `validation_ratio` → `inner_valid.ratio`
+
+```yaml
+# Before
+training:
+  early_stopping:
+    enabled: true
+    rounds: 50
+    validation_ratio: 0.15
+
+# After
+training:
+  early_stopping:
+    enabled: true
+    rounds: 50
+    inner_valid:
+      method: holdout
+      ratio: 0.15
+```
+
+`validation_ratio` is now a `computed_field` mirroring `inner_valid.ratio`,
+so `model_dump()` round-trips remain stable. Reading the field via
+`config.training.early_stopping.validation_ratio` keeps working until v1.0.
+
+### `calibration.n_splits` (removed)
+
+The field is silently ignored; calibration cross-fit reuses the outer CV
+splits (H-0058). Drop the key from your config:
+
+```yaml
+# Before
+calibration:
+  method: platt
+  n_splits: 5
+
+# After
+calibration:
+  method: platt
+```
+
+### `purged_time_series` keys
+
+`purge_window` and `gap` were obs-count integers but had distinct semantics
+that have since been unified.
+
+```yaml
+# Before
+split:
+  method: purged_time_series
+  purge_window: 5
+  embargo_pct: 0.05
+
+# After
+split:
+  method: purged_time_series
+  purge_gap: 5
+  embargo: 10        # explicit observation count, not a fraction
+```
+
+### `build_calibration_splitter()` (removed)
+
+Internal API. Users hand-rolling calibration cross-fit should switch to
+`fit_result.splits.outer` (already populated from the CV trainer).
+
+## Adding a new deprecation
+
+1. Append "Will be removed in vX.Y." to the warning message.
+2. Add a row to the table above.
+3. Document the migration path in this file.
+4. Ensure tests using the legacy form wrap calls in
+   `pytest.warns(DeprecationWarning)` so the deprecation contract is
+   exercised in CI.
+
+## Related
+
+- HISTORY.md: H-0076 (this registry), H-0058 (calibration), H-0069
+  (`validation_ratio`), H-0021 (purged_time_series).
+- Code: `lizyml/config/schema.py`, `lizyml/core/_model_factories.py`.

--- a/lizyml/codegen/artifact_writer.py
+++ b/lizyml/codegen/artifact_writer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from lizyml.calibration.base import BaseCalibratorAdapter
-from lizyml.estimators.lgbm.adapter import LGBMAdapter
+from lizyml.estimators.base import BaseEstimatorAdapter
 
 
 def _convert_pipeline_state(
@@ -39,7 +39,7 @@ def write_artifacts(
     *,
     output_dir: str | Path,
     config: dict[str, Any],
-    model_adapter: LGBMAdapter,
+    model_adapter: BaseEstimatorAdapter,
     pipeline_state: dict[str, Any],
     calibrator: BaseCalibratorAdapter | None,
 ) -> Path:
@@ -48,7 +48,10 @@ def write_artifacts(
     Args:
         output_dir: Root directory for the exported code.
         config: Config dict from :func:`build_config`.
-        model_adapter: Fitted LGBMAdapter to export.
+        model_adapter: Fitted estimator adapter to export. Currently only
+            ``LGBMAdapter`` is supported by the codegen templates, but the
+            type is widened to ``BaseEstimatorAdapter`` so callers in
+            ``_model_persistence.py`` can stay estimator-agnostic (H-0073).
         pipeline_state: Serializable pipeline state dict.
         calibrator: Fitted calibrator or None.
 

--- a/lizyml/codegen/generator.py
+++ b/lizyml/codegen/generator.py
@@ -14,7 +14,7 @@ from lizyml.codegen.templates import (
     render_test_equivalence_py,
     render_train_py,
 )
-from lizyml.estimators.lgbm.adapter import LGBMAdapter
+from lizyml.estimators.base import BaseEstimatorAdapter
 
 
 def generate_code(
@@ -30,7 +30,7 @@ def generate_code(
     seed: int,
     calibration_method: str | None,
     calibration_n_splits: int,
-    model_adapter: LGBMAdapter,
+    model_adapter: BaseEstimatorAdapter,
     pipeline_state: dict[str, Any],
     calibrator: BaseCalibratorAdapter | None,
     feval_metrics: list[dict[str, Any]] | None = None,
@@ -64,7 +64,9 @@ def generate_code(
         seed: Random seed.
         calibration_method: Calibration method name or None.
         calibration_n_splits: CV splits for OOF calibration.
-        model_adapter: Fitted LGBMAdapter.
+        model_adapter: Fitted estimator adapter (typed as
+            ``BaseEstimatorAdapter`` post H-0073; the templates currently
+            assume LightGBM internals).
         pipeline_state: Serializable pipeline state dict.
         calibrator: Fitted calibrator or None.
         feval_metrics: List of feval metric descriptors (H-0066).

--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -113,7 +113,7 @@ class PurgedTimeSeriesConfig(BaseModel):
         if "purge_window" in data and "purge_gap" not in data:
             warnings.warn(
                 "purged_time_series key 'purge_window' is deprecated; "
-                "use 'purge_gap' instead.",
+                "use 'purge_gap' instead. Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -121,14 +121,16 @@ class PurgedTimeSeriesConfig(BaseModel):
         if "embargo_pct" in data and "embargo" not in data:
             warnings.warn(
                 "purged_time_series key 'embargo_pct' is deprecated; "
-                "use 'embargo' (int, obs count) instead.",
+                "use 'embargo' (int, obs count) instead. "
+                "Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             data["embargo"] = int(data.pop("embargo_pct"))
         if "gap" in data and "embargo" not in data:
             warnings.warn(
-                "purged_time_series key 'gap' is deprecated; use 'embargo' instead.",
+                "purged_time_series key 'gap' is deprecated; "
+                "use 'embargo' instead. Will be removed in v1.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -500,7 +502,8 @@ class CalibrationConfig(BaseModel):
         ):
             warnings.warn(
                 "calibration.n_splits is deprecated and will be ignored. "
-                "Calibration cross-fit now reuses outer CV splits (H-0058).",
+                "Calibration cross-fit now reuses outer CV splits (H-0058). "
+                "Will be removed in v1.0.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -373,6 +373,13 @@ class EarlyStoppingConfig(BaseModel):
                 iv_value = data.get("inner_valid")
                 if iv_value is None:
                     if legacy_ratio is not None:
+                        warnings.warn(
+                            "`validation_ratio` is deprecated; use "
+                            "`inner_valid.ratio` instead. "
+                            "Will be removed in v1.0.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
                         data["inner_valid"] = {
                             "method": "holdout",
                             "ratio": legacy_ratio,

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -139,15 +139,25 @@ def _build_splitter_for_method(
             max_train_size=split_cfg.train_size_max,
             max_test_size=split_cfg.test_size_max,
         )
-    # Default: KFoldConfig (or any unmatched variant)
     if isinstance(split_cfg, KFoldConfig):
         return KFoldSplitter(
             n_splits=n_splits,
             shuffle=split_cfg.shuffle,
             random_state=split_cfg.random_state,
         )
-    # Fallback — should not be reachable with the current union
-    return KFoldSplitter(n_splits=n_splits, shuffle=True, random_state=42)
+    # Loud fail — adding a new SplitConfig variant without updating this
+    # dispatch must not silently produce KFold splits (#119).
+    from lizyml.core.exceptions import ErrorCode, LizyMLError
+
+    type_name = type(split_cfg).__name__
+    raise LizyMLError(
+        code=ErrorCode.CONFIG_INVALID,
+        user_message=(
+            f"Unhandled SplitConfig type: {type_name}. "
+            "Update _build_splitter_for_method dispatch when adding a new variant."
+        ),
+        context={"split_config_type": type_name},
+    )
 
 
 def build_splitter(

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -86,7 +86,10 @@ def _build_splitter_for_method(
                     "blocked_group_kfold requires block_values "
                     "(extracted from blocks.col by Facade)."
                 ),
-                context={},
+                context={
+                    "split_method": "blocked_group_kfold",
+                    "blocks_col": split_cfg.blocks.col,
+                },
             )
         stratify_bool = _resolve_stratify(
             split_cfg.groups.stratify, task or "regression"

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -163,6 +163,19 @@ def _build_splitter_for_method(
     )
 
 
+def get_outer_n_splits(cfg: LizyMLConfig) -> int:
+    """Return the outer CV n_splits regardless of split config variant (H-0073).
+
+    ``BlockedGroupKFoldConfig`` exposes ``groups.n_splits`` (the outer
+    KFold over groups) while every other variant has a top-level
+    ``n_splits``. Centralised here so that callers in ``_model_factories``
+    and ``_model_persistence`` use the same resolution.
+    """
+    if isinstance(cfg.split, BlockedGroupKFoldConfig):
+        return cfg.split.groups.n_splits
+    return cfg.split.n_splits
+
+
 def build_splitter(
     cfg: LizyMLConfig,
     *,
@@ -183,17 +196,19 @@ def build_splitter(
             stacklevel=2,
         )
 
-    # BlockedGroupKFoldConfig has no n_splits at top level
+    n_splits = get_outer_n_splits(cfg)
+
+    # BlockedGroupKFoldConfig has no n_splits at top level — pass block_values etc.
     if isinstance(split_cfg, BlockedGroupKFoldConfig):
         return _build_splitter_for_method(
             split_cfg,
-            split_cfg.groups.n_splits,
+            n_splits,
             block_values=block_values,
             task=cfg.task if task is None else task,
             seed=cfg.training.seed if seed is None else seed,
         )
 
-    return _build_splitter_for_method(split_cfg, split_cfg.n_splits)
+    return _build_splitter_for_method(split_cfg, n_splits)
 
 
 def build_calibration_splitter(cfg: LizyMLConfig) -> BaseSplitter:

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -25,6 +25,7 @@ from lizyml.config.schema import (
     StratifiedKFoldConfig,
     TimeSeriesConfig,
 )
+from lizyml.core.types.task import TaskType
 from lizyml.splitters.base import BaseSplitter
 from lizyml.splitters.blocked_group_kfold import BlockedGroupKFoldSplitter
 from lizyml.splitters.group_kfold import (
@@ -52,7 +53,7 @@ InnerValidType = (
 )
 
 
-def _resolve_stratify(stratify: str | bool, task: str) -> bool:
+def _resolve_stratify(stratify: str | bool, task: TaskType) -> bool:
     """Resolve ``stratify: "auto"`` to a concrete boolean."""
     if isinstance(stratify, bool):
         return stratify
@@ -67,7 +68,7 @@ def _build_splitter_for_method(
     n_splits: int,
     *,
     block_values: npt.NDArray[Any] | None = None,
-    task: str | None = None,
+    task: TaskType | None = None,
     seed: int | None = None,
 ) -> BaseSplitter:
     """Build a splitter from split config, using the given *n_splits*.
@@ -180,7 +181,7 @@ def build_splitter(
     cfg: LizyMLConfig,
     *,
     block_values: npt.NDArray[Any] | None = None,
-    task: str | None = None,
+    task: TaskType | None = None,
     seed: int | None = None,
 ) -> BaseSplitter:
     """Instantiate outer CV splitter from config."""
@@ -236,7 +237,7 @@ def _resolve_auto_inner_valid(
     ratio: float,
     seed: int,
     *,
-    task: str | None = None,
+    task: TaskType | None = None,
 ) -> (
     HoldoutInnerValid
     | GroupHoldoutInnerValid

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -222,7 +222,8 @@ def build_calibration_splitter(cfg: LizyMLConfig) -> BaseSplitter:
 
     warnings.warn(
         "build_calibration_splitter is deprecated (H-0058). "
-        "Calibration cross-fit now reuses outer CV splits.",
+        "Calibration cross-fit now reuses outer CV splits. "
+        "Will be removed in v1.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/lizyml/core/_model_persistence.py
+++ b/lizyml/core/_model_persistence.py
@@ -1,8 +1,9 @@
 """ModelPersistenceMixin — export/load methods extracted from Model facade.
 
-After H-0073 this module is fully estimator-agnostic: codegen-relevant
-parameters and feval metadata flow through ``EstimatorProvider`` rather
-than direct ``LGBMAdapter`` access.
+After H-0077 (Phase 2) every method reads state exclusively through
+``self._get_fit_state()`` — direct ``self._<private>`` access is
+forbidden. Path resolution that mutates ``Model._run_dir`` lives on the
+Model facade as ``Model._resolve_export_path``.
 """
 
 from __future__ import annotations
@@ -10,15 +11,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from lizyml.core.exceptions import ErrorCode, LizyMLError
-from lizyml.core.logging import generate_run_id, get_logger
+from lizyml.core.logging import get_logger
 
 if TYPE_CHECKING:
-    import pandas as pd
-
-    from lizyml.config.schema import LizyMLConfig
-    from lizyml.core.types.fit_result import FitResult
-    from lizyml.estimators.provider import EstimatorProvider
+    from lizyml.core.types.fit_state import FitState
     from lizyml.training.refit_trainer import RefitResult
 
 _log = get_logger("model")
@@ -27,21 +23,14 @@ _log = get_logger("model")
 class ModelPersistenceMixin:
     """Mixin providing export/load methods for :class:`Model`."""
 
-    # Attributes provided by Model — declared for type checking only.
+    # Facade entry points provided by Model — declared for type checking only.
     if TYPE_CHECKING:
-        _cfg: LizyMLConfig
-        _fit_result: FitResult | None
-        _refit_result: RefitResult | None
-        _metrics: dict[str, Any] | None
-        _y: pd.Series | None
-        _X: pd.DataFrame | None
-        _run_dir: Path | None
-        _output_dir: str | Path | None
-        _provider: EstimatorProvider | None
 
-        def _require_fit(self) -> FitResult: ...
+        def _get_fit_state(self) -> FitState: ...
 
         def _require_refit(self) -> RefitResult: ...
+
+        def _resolve_export_path(self, path: str | Path | None) -> Path: ...
 
     def export(self, path: str | Path | None = None) -> Path:
         """Export Model artifacts to a directory.
@@ -73,7 +62,7 @@ class ModelPersistenceMixin:
             The ``.pkl`` files use joblib/pickle.  Only load artifacts from
             trusted sources.
         """
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         refit_result = self._require_refit()
 
         resolved_path = self._resolve_export_path(path)
@@ -82,15 +71,15 @@ class ModelPersistenceMixin:
         from lizyml.persistence.exporter import export as _export
 
         ctx: AnalysisContext | None = None
-        if self._y is not None and self._X is not None:
-            ctx = AnalysisContext(y_true=self._y, X_for_explain=self._X)
+        if state.y is not None and state.X is not None:
+            ctx = AnalysisContext(y_true=state.y, X_for_explain=state.X)
 
         _export(
             path=resolved_path,
-            fit_result=fit_result,
+            fit_result=state.fit_result,
             refit_result=refit_result,
-            config=self._cfg.model_dump(),
-            task=self._cfg.task,
+            config=state.cfg.model_dump(),
+            task=state.cfg.task,
             analysis_context=ctx,
         )
         _log.info("event='export.done' path=%s", resolved_path)
@@ -111,29 +100,20 @@ class ModelPersistenceMixin:
         Raises:
             LizyMLError with ``MODEL_NOT_FIT`` when called before ``fit``.
         """
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         refit_result = self._require_refit()
 
         from lizyml.codegen.generator import generate_code
         from lizyml.core._model_factories import get_outer_n_splits
 
         adapter = refit_result.model
-        provider = self._provider
-        if provider is None:
-            raise LizyMLError(
-                code=ErrorCode.MODEL_NOT_FIT,
-                user_message=(
-                    "Provider is not initialised. Call fit() before export_code()."
-                ),
-                context={"method": "export_code"},
-            )
 
         # Codegen-relevant params and feval metadata go through the
         # EstimatorProvider so that this module remains
         # estimator-agnostic (H-0073).
-        export = provider.build_export_params(adapter)
+        export = state.provider.build_export_params(adapter)
 
-        cfg = self._cfg
+        cfg = state.cfg
         es = cfg.training.early_stopping
         calibration_method: str | None = None
         # Use outer CV n_splits for OOF calibration (H-0058: reuses outer splits)
@@ -143,12 +123,12 @@ class ModelPersistenceMixin:
 
         # Extract c_final calibrator from CalibrationResult
         calibrator = None
-        cal_result = fit_result.calibrator
+        cal_result = state.fit_result.calibrator
         if cal_result is not None and hasattr(cal_result, "c_final"):
             calibrator = cal_result.c_final
 
         # Build run_meta dict from FitResult
-        meta = fit_result.run_meta
+        meta = state.fit_result.run_meta
         run_meta_dict: dict[str, Any] = {
             "lizyml_version": meta.lizyml_version,
             "run_id": meta.run_id,
@@ -159,8 +139,8 @@ class ModelPersistenceMixin:
         # H-0070: bake target encoder classes into config so train.py /
         # predict.py can re-encode and decode the original labels.
         target_classes: list[Any] | None = None
-        if fit_result.target_encoder.needs_encoding:
-            target_classes = list(fit_result.target_encoder.classes_)
+        if state.fit_result.target_encoder.needs_encoding:
+            target_classes = list(state.fit_result.target_encoder.classes_)
 
         result = generate_code(
             output_dir=path,
@@ -183,26 +163,6 @@ class ModelPersistenceMixin:
         _log.info("event='export_code.done' path=%s", result)
         return result
 
-    def _resolve_export_path(self, path: str | Path | None) -> Path:
-        """Resolve the export destination directory."""
-        if path is not None:
-            return Path(path)
-        if self._run_dir is not None:
-            return Path(self._run_dir) / "export"
-        if self._output_dir is not None:
-            from lizyml.core.logging import setup_output_dir
-
-            export_run_id = generate_run_id()
-            self._run_dir = setup_output_dir(self._output_dir, export_run_id)
-            return Path(self._run_dir) / "export"
-        raise LizyMLError(
-            ErrorCode.SERIALIZATION_FAILED,
-            user_message=(
-                "No export path provided and no output_dir configured. "
-                "Pass an explicit path or set output_dir in Config / constructor."
-            ),
-        )
-
     @classmethod
     def load(cls, path: str | Path) -> Any:
         """Restore a Model from a directory created by :meth:`export`.
@@ -224,7 +184,11 @@ class ModelPersistenceMixin:
 
         fit_result, refit_result, metadata, analysis_context = _load(path)
         config = metadata["config"]
-        instance = cls(config)  # type: ignore[call-arg]  # cls is Model at runtime
+        # ``load`` is the canonical re-hydration path — direct private-attr
+        # writes here are confined to this classmethod and intentionally
+        # rebuild the Model body. The Mixin state-isolation guard targets
+        # instance methods only.
+        instance: Any = cls(config)  # type: ignore[call-arg]  # cls is Model at runtime
         instance._fit_result = fit_result
         instance._refit_result = refit_result
         instance._metrics = fit_result.metrics

--- a/lizyml/core/_model_persistence.py
+++ b/lizyml/core/_model_persistence.py
@@ -1,4 +1,9 @@
-"""ModelPersistenceMixin — export/load methods extracted from Model facade."""
+"""ModelPersistenceMixin — export/load methods extracted from Model facade.
+
+After H-0073 this module is fully estimator-agnostic: codegen-relevant
+parameters and feval metadata flow through ``EstimatorProvider`` rather
+than direct ``LGBMAdapter`` access.
+"""
 
 from __future__ import annotations
 
@@ -13,51 +18,10 @@ if TYPE_CHECKING:
 
     from lizyml.config.schema import LizyMLConfig
     from lizyml.core.types.fit_result import FitResult
-    from lizyml.estimators.lgbm.adapter import LGBMAdapter
     from lizyml.estimators.provider import EstimatorProvider
     from lizyml.training.refit_trainer import RefitResult
 
 _log = get_logger("model")
-
-
-def _extract_feval_metadata(
-    adapter: LGBMAdapter,
-) -> list[dict[str, Any]]:
-    """Extract feval metric metadata from adapter params (H-0066).
-
-    Reads the user-specified ``metric`` from the adapter's params dict,
-    identifies which are feval metrics (not LightGBM native), and returns
-    serializable metadata for each.
-    """
-    from lizyml.estimators.lgbm.metric_bridge import _FEVAL_METRICS
-    from lizyml.metrics.registry import get_metric, parse_metric_entries
-
-    user_metric = adapter.params.get("metric")
-    if not user_metric:
-        return []
-
-    if isinstance(user_metric, (str, dict)):
-        user_metric = [user_metric]
-    user_metric = [m for m in user_metric if m]
-    if not user_metric:
-        return []
-
-    feval_for_task = _FEVAL_METRICS.get(adapter.task, frozenset())
-    parsed = parse_metric_entries(user_metric)
-
-    result: list[dict[str, Any]] = []
-    for name, kwargs in parsed:
-        if name in feval_for_task:
-            metric_obj = get_metric(name, **kwargs)
-            result.append(
-                {
-                    "name": name,
-                    "params": kwargs,
-                    "greater_is_better": metric_obj.greater_is_better,
-                    "needs_proba": metric_obj.needs_proba,
-                }
-            )
-    return result
 
 
 class ModelPersistenceMixin:
@@ -151,32 +115,29 @@ class ModelPersistenceMixin:
         refit_result = self._require_refit()
 
         from lizyml.codegen.generator import generate_code
-        from lizyml.estimators.lgbm.adapter import LGBMAdapter
+        from lizyml.core._model_factories import get_outer_n_splits
 
         adapter = refit_result.model
-        if not isinstance(adapter, LGBMAdapter):
+        provider = self._provider
+        if provider is None:
             raise LizyMLError(
-                ErrorCode.UNSUPPORTED_TASK,
-                user_message=("export_code() currently supports LGBMAdapter only."),
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message=(
+                    "Provider is not initialised. Call fit() before export_code()."
+                ),
+                context={"method": "export_code"},
             )
 
-        # Extract LightGBM params from the adapter.
-        # TODO(H-0059): expose via EstimatorProvider protocol in a future PR.
-        lgbm_params, num_boost_round, _, _ = adapter._build_params()
-
-        # Extract feval metric metadata from user config (H-0066).
-        feval_metrics = _extract_feval_metadata(adapter)
+        # Codegen-relevant params and feval metadata go through the
+        # EstimatorProvider so that this module remains
+        # estimator-agnostic (H-0073).
+        export = provider.build_export_params(adapter)
 
         cfg = self._cfg
         es = cfg.training.early_stopping
         calibration_method: str | None = None
         # Use outer CV n_splits for OOF calibration (H-0058: reuses outer splits)
-        from lizyml.config.schema import BlockedGroupKFoldConfig
-
-        if isinstance(cfg.split, BlockedGroupKFoldConfig):
-            calibration_n_splits = cfg.split.groups.n_splits
-        else:
-            calibration_n_splits = cfg.split.n_splits
+        calibration_n_splits = get_outer_n_splits(cfg)
         if cfg.calibration is not None:
             calibration_method = cfg.calibration.method
 
@@ -206,8 +167,8 @@ class ModelPersistenceMixin:
             run_meta=run_meta_dict,
             feature_names=refit_result.feature_names,
             categorical_features=refit_result.categorical_features,
-            lgbm_params=lgbm_params,
-            num_boost_round=num_boost_round,
+            lgbm_params=export.params,
+            num_boost_round=export.num_boost_round,
             early_stopping_rounds=(es.rounds if es.enabled else None),
             validation_ratio=es.validation_ratio or 0.0,
             seed=cfg.training.seed,
@@ -216,7 +177,7 @@ class ModelPersistenceMixin:
             model_adapter=adapter,
             pipeline_state=refit_result.pipeline_state,
             calibrator=calibrator,
-            feval_metrics=feval_metrics,
+            feval_metrics=export.feval_metadata,
             target_classes=target_classes,
         )
         _log.info("event='export_code.done' path=%s", result)

--- a/lizyml/core/_model_plots.py
+++ b/lizyml/core/_model_plots.py
@@ -1,4 +1,10 @@
-"""ModelPlotsMixin — plot methods extracted from Model facade."""
+"""ModelPlotsMixin — plot methods extracted from Model facade.
+
+After H-0077 (Phase 2) every method reads state exclusively through
+``self._get_fit_state()`` / ``self._get_tuning_state()`` — direct access
+to ``self._<private>`` attributes is forbidden inside this module
+(enforced by ``tests/test_core/test_mixin_state_isolation.py``).
+"""
 
 from __future__ import annotations
 
@@ -10,25 +16,19 @@ from lizyml.core.exceptions import ErrorCode, LizyMLError
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    import pandas as pd
 
-    from lizyml.config.schema import LizyMLConfig
-    from lizyml.core.types.fit_result import FitResult
-    from lizyml.core.types.tuning_result import TuningResult
+    from lizyml.core.types.fit_state import FitState, TuningState
 
 
 class ModelPlotsMixin:
     """Mixin providing plot methods for :class:`Model`."""
 
-    # Attributes provided by Model — declared for type checking only.
+    # Facade entry points provided by Model — declared for type checking only.
     if TYPE_CHECKING:
-        _cfg: LizyMLConfig
-        _fit_result: FitResult | None
-        _y: pd.Series | None
-        _X: pd.DataFrame | None
-        _tuning_result: TuningResult | None
 
-        def _require_fit(self) -> FitResult: ...
+        def _get_fit_state(self) -> FitState: ...
+
+        def _get_tuning_state(self) -> TuningState: ...
 
         def residuals(self) -> npt.NDArray[np.float64]: ...
 
@@ -56,10 +56,10 @@ class ModelPlotsMixin:
         """
         # Validate state (raises MODEL_NOT_FIT / UNSUPPORTED_TASK as needed)
         self.residuals()
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         from lizyml.plots.residuals import plot_residuals
 
-        return plot_residuals(fit_result, np.asarray(self._y), kind=kind)
+        return plot_residuals(state.fit_result, np.asarray(state.y), kind=kind)
 
     def roc_curve_plot(self) -> Any:
         """Plot ROC Curve. Binary: IS/OOS overlay. Multiclass: OvR subplots.
@@ -73,8 +73,8 @@ class ModelPlotsMixin:
             LizyMLError with ``UNSUPPORTED_TASK`` for regression.
             LizyMLError with ``OPTIONAL_DEP_MISSING`` when plotly is not installed.
         """
-        fit_result = self._require_fit()
-        if self._y is None:
+        state = self._get_fit_state()
+        if state.y is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -82,17 +82,19 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={"task": self._cfg.task, "loaded_from_artifact": True},
+                context={"task": state.cfg.task, "loaded_from_artifact": True},
             )
-        if self._cfg.task == "regression":
+        if state.cfg.task == "regression":
             raise LizyMLError(
                 code=ErrorCode.UNSUPPORTED_TASK,
                 user_message="roc_curve_plot() requires a binary or multiclass task.",
-                context={"task": self._cfg.task},
+                context={"task": state.cfg.task},
             )
         from lizyml.plots.classification import plot_roc_curve
 
-        return plot_roc_curve(fit_result, np.asarray(self._y), task=self._cfg.task)
+        return plot_roc_curve(
+            state.fit_result, np.asarray(state.y), task=state.cfg.task
+        )
 
     def calibration_plot(self) -> Any:
         """Plot calibration reliability diagram. Binary + calibration only.
@@ -108,8 +110,8 @@ class ModelPlotsMixin:
                 is not enabled.
             LizyMLError with ``OPTIONAL_DEP_MISSING`` when plotly is not installed.
         """
-        fit_result = self._require_fit()
-        if self._y is None:
+        state = self._get_fit_state()
+        if state.y is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -117,17 +119,17 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={"task": self._cfg.task, "loaded_from_artifact": True},
+                context={"task": state.cfg.task, "loaded_from_artifact": True},
             )
-        if self._cfg.task != "binary":
+        if state.cfg.task != "binary":
             raise LizyMLError(
                 code=ErrorCode.UNSUPPORTED_TASK,
                 user_message="calibration_plot() requires a binary task.",
-                context={"task": self._cfg.task},
+                context={"task": state.cfg.task},
             )
         from lizyml.plots.calibration import plot_calibration_curve
 
-        return plot_calibration_curve(fit_result, np.asarray(self._y))
+        return plot_calibration_curve(state.fit_result, np.asarray(state.y))
 
     def probability_histogram_plot(self) -> Any:
         """Plot raw vs calibrated probability histogram. Binary + calibration only.
@@ -143,8 +145,8 @@ class ModelPlotsMixin:
                 is not enabled.
             LizyMLError with ``OPTIONAL_DEP_MISSING`` when plotly is not installed.
         """
-        self._require_fit()
-        if self._y is None:
+        state = self._get_fit_state()
+        if state.y is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -152,18 +154,17 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={"task": self._cfg.task, "loaded_from_artifact": True},
+                context={"task": state.cfg.task, "loaded_from_artifact": True},
             )
-        if self._cfg.task != "binary":
+        if state.cfg.task != "binary":
             raise LizyMLError(
                 code=ErrorCode.UNSUPPORTED_TASK,
                 user_message="probability_histogram_plot() requires a binary task.",
-                context={"task": self._cfg.task},
+                context={"task": state.cfg.task},
             )
-        fit_result = self._require_fit()
         from lizyml.plots.calibration import plot_probability_histogram
 
-        return plot_probability_histogram(fit_result)
+        return plot_probability_histogram(state.fit_result)
 
     def importance_plot(self, kind: str = "split", top_n: int | None = 20) -> Any:
         """Plot fold-averaged feature importances as a horizontal bar chart.
@@ -186,10 +187,10 @@ class ModelPlotsMixin:
 
             return plot_importance_from_dict(imp, top_n=top_n)
 
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         from lizyml.plots.importance import plot_importance
 
-        return plot_importance(fit_result, kind=kind, top_n=top_n)
+        return plot_importance(state.fit_result, kind=kind, top_n=top_n)
 
     def plot_learning_curve(
         self,
@@ -211,10 +212,10 @@ class ModelPlotsMixin:
             LizyMLError with OPTIONAL_DEP_MISSING when plotly is not installed.
             LizyMLError with CONFIG_INVALID when *metrics* matches nothing.
         """
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         from lizyml.plots.learning_curve import plot_learning_curve
 
-        return plot_learning_curve(fit_result, metrics=metrics)
+        return plot_learning_curve(state.fit_result, metrics=metrics)
 
     def plot_oof_distribution(self) -> Any:
         """Plot the distribution of out-of-fold predictions.
@@ -226,10 +227,10 @@ class ModelPlotsMixin:
             LizyMLError with MODEL_NOT_FIT when called before fit.
             LizyMLError with OPTIONAL_DEP_MISSING when plotly is not installed.
         """
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
         from lizyml.plots.oof_distribution import plot_oof_distribution
 
-        return plot_oof_distribution(fit_result)
+        return plot_oof_distribution(state.fit_result)
 
     def tuning_plot(self) -> Any:
         """Plot tuning history. Requires ``tune()`` to have been called.
@@ -241,12 +242,7 @@ class ModelPlotsMixin:
             LizyMLError with ``MODEL_NOT_FIT`` when ``tune()`` has not been called.
             LizyMLError with ``OPTIONAL_DEP_MISSING`` when plotly is not installed.
         """
-        if self._tuning_result is None:
-            raise LizyMLError(
-                code=ErrorCode.MODEL_NOT_FIT,
-                user_message="tune() has not been called yet.",
-                context={"plot": "tuning_history", "task": self._cfg.task},
-            )
+        state = self._get_tuning_state()
         from lizyml.plots.tuning import plot_tuning_history
 
-        return plot_tuning_history(self._tuning_result)
+        return plot_tuning_history(state.tuning_result)

--- a/lizyml/core/_model_plots.py
+++ b/lizyml/core/_model_plots.py
@@ -82,7 +82,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task == "regression":
             raise LizyMLError(
@@ -117,7 +117,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task != "binary":
             raise LizyMLError(
@@ -152,7 +152,7 @@ class ModelPlotsMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task != "binary":
             raise LizyMLError(
@@ -245,7 +245,7 @@ class ModelPlotsMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="tune() has not been called yet.",
-                context={},
+                context={"plot": "tuning_history", "task": self._cfg.task},
             )
         from lizyml.plots.tuning import plot_tuning_history
 

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -81,7 +81,11 @@ class ModelTablesMixin:
                     "Re-export the model with the latest version to enable "
                     "diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={
+                    "task": self._cfg.task,
+                    "loaded_from_artifact": True,
+                    "method": "residuals",
+                },
             )
         result: npt.NDArray[np.float64] = np.asarray(self._y) - fit_result.oof_pred
         return result
@@ -109,7 +113,7 @@ class ModelTablesMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={},
+                context={"task": self._cfg.task, "loaded_from_artifact": True},
             )
         if self._cfg.task == "regression":
             raise LizyMLError(
@@ -157,7 +161,11 @@ class ModelTablesMixin:
                         "Re-export the model with the latest version to enable "
                         "diagnostic APIs after Model.load()."
                     ),
-                    context={},
+                    context={
+                        "task": self._cfg.task,
+                        "kind": kind,
+                        "method": "importance",
+                    },
                 )
             from lizyml.explain.shap_explainer import compute_shap_importance
 
@@ -201,7 +209,7 @@ class ModelTablesMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="tune() has not been called yet.",
-                context={},
+                context={"method": "tuning_table", "task": self._cfg.task},
             )
         tr = self._tuning_result
         rows = []
@@ -236,7 +244,10 @@ class ModelTablesMixin:
                     "No boundary report available. "
                     "Run tune(resume=True) to generate a boundary report."
                 ),
-                context={},
+                context={
+                    "method": "boundary_table",
+                    "tune_called": self._tuning_result is not None,
+                },
             )
         report = self._tuning_result.boundary_report
         rows = []
@@ -274,7 +285,7 @@ class ModelTablesMixin:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="No trained models available.",
-                context={},
+                context={"method": "params_table", "task": self._cfg.task},
             )
 
         rows: list[dict[str, Any]] = []

--- a/lizyml/core/_model_tables.py
+++ b/lizyml/core/_model_tables.py
@@ -1,4 +1,8 @@
-"""ModelTablesMixin — table/accessor methods extracted from Model facade."""
+"""ModelTablesMixin — table/accessor methods extracted from Model facade.
+
+After H-0077 (Phase 2) every method reads state exclusively through
+``self._get_fit_state()`` / ``self._get_tuning_state()``.
+"""
 
 from __future__ import annotations
 
@@ -11,26 +15,18 @@ import pandas as pd
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 
 if TYPE_CHECKING:
-    from lizyml.config.schema import LizyMLConfig
-    from lizyml.core.types.fit_result import FitResult
-    from lizyml.core.types.tuning_result import TuningResult
-    from lizyml.estimators.provider import EstimatorProvider
+    from lizyml.core.types.fit_state import FitState, TuningState
 
 
 class ModelTablesMixin:
     """Mixin providing table/accessor methods for :class:`Model`."""
 
-    # Attributes provided by Model — declared for type checking only.
+    # Facade entry points provided by Model — declared for type checking only.
     if TYPE_CHECKING:
-        _cfg: LizyMLConfig
-        _fit_result: FitResult | None
-        _y: pd.Series | None
-        _X: pd.DataFrame | None
-        _metrics: dict[str, Any] | None
-        _tuning_result: TuningResult | None
-        _provider: EstimatorProvider | None
 
-        def _require_fit(self) -> FitResult: ...
+        def _get_fit_state(self) -> FitState: ...
+
+        def _get_tuning_state(self) -> TuningState: ...
 
     def evaluate_table(self) -> pd.DataFrame:
         """Return evaluation metrics as a formatted DataFrame.
@@ -46,11 +42,11 @@ class ModelTablesMixin:
             :class:`~lizyml.core.exceptions.LizyMLError` with
             ``MODEL_NOT_FIT`` when called before ``fit``.
         """
-        self._require_fit()
+        state = self._get_fit_state()
         from lizyml.evaluation.table_formatter import format_metrics_table
 
-        assert self._metrics is not None  # noqa: S101 — set by fit()
-        return format_metrics_table(self._metrics)
+        assert state.metrics is not None  # noqa: S101 — populated after fit()
+        return format_metrics_table(state.metrics)
 
     def residuals(self) -> npt.NDArray[np.float64]:
         """Return OOF residuals ``(y_true - oof_pred)``.  Regression only.
@@ -63,17 +59,17 @@ class ModelTablesMixin:
                 or when loaded artifacts lack ``analysis_context``.
             LizyMLError with ``UNSUPPORTED_TASK`` for non-regression tasks.
         """
-        fit_result = self._require_fit()
-        if self._cfg.task != "regression":
+        state = self._get_fit_state()
+        if state.cfg.task != "regression":
             raise LizyMLError(
                 code=ErrorCode.UNSUPPORTED_TASK,
                 user_message=(
                     "residuals() is only supported for regression tasks. "
-                    f"Got task='{self._cfg.task}'."
+                    f"Got task='{state.cfg.task}'."
                 ),
-                context={"task": self._cfg.task},
+                context={"task": state.cfg.task},
             )
-        if self._y is None:
+        if state.y is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -82,12 +78,14 @@ class ModelTablesMixin:
                     "diagnostic APIs after Model.load()."
                 ),
                 context={
-                    "task": self._cfg.task,
+                    "task": state.cfg.task,
                     "loaded_from_artifact": True,
                     "method": "residuals",
                 },
             )
-        result: npt.NDArray[np.float64] = np.asarray(self._y) - fit_result.oof_pred
+        result: npt.NDArray[np.float64] = (
+            np.asarray(state.y) - state.fit_result.oof_pred
+        )
         return result
 
     def confusion_matrix(self, threshold: float = 0.5) -> dict[str, pd.DataFrame]:
@@ -104,8 +102,8 @@ class ModelTablesMixin:
                 or when loaded artifacts lack ``analysis_context``.
             LizyMLError with ``UNSUPPORTED_TASK`` for regression.
         """
-        fit_result = self._require_fit()
-        if self._y is None:
+        state = self._get_fit_state()
+        if state.y is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -113,21 +111,21 @@ class ModelTablesMixin:
                     "Re-export the model with the latest version "
                     "to enable diagnostic APIs after Model.load()."
                 ),
-                context={"task": self._cfg.task, "loaded_from_artifact": True},
+                context={"task": state.cfg.task, "loaded_from_artifact": True},
             )
-        if self._cfg.task == "regression":
+        if state.cfg.task == "regression":
             raise LizyMLError(
                 code=ErrorCode.UNSUPPORTED_TASK,
                 user_message="confusion_matrix() requires a binary or multiclass task.",
-                context={"task": self._cfg.task},
+                context={"task": state.cfg.task},
             )
         from lizyml.evaluation.confusion import confusion_matrix_table
 
         return confusion_matrix_table(
-            fit_result,
-            np.asarray(self._y),
+            state.fit_result,
+            np.asarray(state.y),
             threshold=threshold,
-            task=self._cfg.task,
+            task=state.cfg.task,
         )
 
     def importance(self, kind: str = "split") -> dict[str, float]:
@@ -150,10 +148,10 @@ class ModelTablesMixin:
             ``OPTIONAL_DEP_MISSING`` when ``kind="shap"`` and shap is
             not installed.
         """
-        fit_result = self._require_fit()
+        state = self._get_fit_state()
 
         if kind == "shap":
-            if self._X is None:
+            if state.X is None:
                 raise LizyMLError(
                     code=ErrorCode.MODEL_NOT_FIT,
                     user_message=(
@@ -162,7 +160,7 @@ class ModelTablesMixin:
                         "diagnostic APIs after Model.load()."
                     ),
                     context={
-                        "task": self._cfg.task,
+                        "task": state.cfg.task,
                         "kind": kind,
                         "method": "importance",
                     },
@@ -170,20 +168,16 @@ class ModelTablesMixin:
             from lizyml.explain.shap_explainer import compute_shap_importance
 
             return compute_shap_importance(
-                models=fit_result.models,
-                X=self._X,
-                splits_outer=fit_result.splits.outer,
-                task=self._cfg.task,
-                feature_names=fit_result.feature_names,
-                pipeline_state=fit_result.pipeline_state,
-                pipeline_factory=(
-                    self._provider.build_pipeline_factory()
-                    if self._provider is not None
-                    else None
-                ),
+                models=state.fit_result.models,
+                X=state.X,
+                splits_outer=state.fit_result.splits.outer,
+                task=state.cfg.task,
+                feature_names=state.fit_result.feature_names,
+                pipeline_state=state.fit_result.pipeline_state,
+                pipeline_factory=state.provider.build_pipeline_factory(),
             )
 
-        models = fit_result.models
+        models = state.fit_result.models
         if not models:
             return {}
 
@@ -205,13 +199,8 @@ class ModelTablesMixin:
         Raises:
             LizyMLError with MODEL_NOT_FIT when ``tune()`` has not been called.
         """
-        if self._tuning_result is None:
-            raise LizyMLError(
-                code=ErrorCode.MODEL_NOT_FIT,
-                user_message="tune() has not been called yet.",
-                context={"method": "tuning_table", "task": self._cfg.task},
-            )
-        tr = self._tuning_result
+        state = self._get_tuning_state()
+        tr = state.tuning_result
         rows = []
         for t in tr.trials:
             row: dict[str, Any] = {
@@ -237,7 +226,8 @@ class ModelTablesMixin:
             LizyMLError with MODEL_NOT_FIT when ``tune(resume=True)`` has
             not been called or no boundary report exists.
         """
-        if self._tuning_result is None or self._tuning_result.boundary_report is None:
+        state = self._get_tuning_state()
+        if state.tuning_result.boundary_report is None:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message=(
@@ -246,10 +236,10 @@ class ModelTablesMixin:
                 ),
                 context={
                     "method": "boundary_table",
-                    "tune_called": self._tuning_result is not None,
+                    "tune_called": True,
                 },
             )
-        report = self._tuning_result.boundary_report
+        report = state.tuning_result.boundary_report
         rows = []
         for s in report.dims:
             rows.append(
@@ -280,22 +270,22 @@ class ModelTablesMixin:
             :class:`~lizyml.core.exceptions.LizyMLError` with
             ``MODEL_NOT_FIT`` when called before ``fit``.
         """
-        fr = self._require_fit()
+        state = self._get_fit_state()
+        fr = state.fit_result
         if not fr.models:
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="No trained models available.",
-                context={"method": "params_table", "task": self._cfg.task},
+                context={"method": "params_table", "task": state.cfg.task},
             )
 
         rows: list[dict[str, Any]] = []
 
         # --- Estimator-specific params via provider (H-0054) ---
-        if self._provider is not None:
-            rows.extend(self._provider.params_summary(fr.models[0], self._cfg.model))
+        rows.extend(state.provider.params_summary(fr.models[0], state.cfg.model))
 
         # --- Config training params ---
-        es = self._cfg.training.early_stopping
+        es = state.cfg.training.early_stopping
         if es is not None:
             rows.append({"parameter": "early_stopping_rounds", "value": es.rounds})
             rows.append({"parameter": "validation_ratio", "value": es.validation_ratio})
@@ -321,7 +311,8 @@ class ModelTablesMixin:
             :class:`~lizyml.core.exceptions.LizyMLError` with
             ``MODEL_NOT_FIT`` when called before ``fit``.
         """
-        fr = self._require_fit()
+        state = self._get_fit_state()
+        fr = state.fit_result
         rows: list[dict[str, Any]] = []
         for i, (train_idx, valid_idx) in enumerate(fr.splits.outer):
             row: dict[str, Any] = {

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -30,11 +30,14 @@ import sys
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+
+if TYPE_CHECKING:
+    from optuna.storages import BaseStorage
 
 from lizyml import __version__
 from lizyml.config.loader import load_config
@@ -394,7 +397,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         expand_boundary: bool | None = None,
         boundary_threshold: float = 0.05,
         progress_callback: TuneProgressCallback | None = None,
-        storage: str | Any | None = None,
+        storage: str | BaseStorage | None = None,
         study_name: str | None = None,
     ) -> TuningResult:
         """Run hyperparameter search with optuna (H-0068: resume + expand,

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -64,7 +64,7 @@ from lizyml.core.specs.problem_spec import ProblemSpec
 from lizyml.core.train_components import TrainComponents
 from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
-from lizyml.core.types.fit_state import FitState
+from lizyml.core.types.fit_state import FitState, TuningState
 from lizyml.core.types.predict_result import PredictionResult
 from lizyml.core.types.task import TaskType
 from lizyml.core.types.tuning_result import (
@@ -1277,10 +1277,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
     def _get_fit_state(self) -> FitState:
         """Return a frozen snapshot of post-fit state for Mixin methods (#112).
 
-        H-0074 introduces this as the single read path that Mixin methods
-        will eventually consume. Phase 1 (introduction) keeps the existing
-        ``self._*`` access intact; Phase 2 will migrate Mixins to read
-        only from the returned ``FitState``.
+        Single read path for ``ModelPlotsMixin`` / ``ModelTablesMixin`` /
+        ``ModelPersistenceMixin``. After H-0077 (Phase 2) Mixin methods read
+        state exclusively from the returned ``FitState`` — direct ``self._*``
+        access from Mixin bodies is forbidden.
 
         Raises:
             :class:`~lizyml.core.exceptions.LizyMLError` with
@@ -1308,4 +1308,61 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             X=self._X,
             run_dir=self._run_dir,
             output_dir=self._output_dir,
+        )
+
+    def _get_tuning_state(self) -> TuningState:
+        """Return a frozen snapshot of post-tune state for tuning Mixin methods.
+
+        Used by ``tuning_plot`` / ``tuning_table`` / ``boundary_table`` which
+        operate on tuning artefacts even when ``fit()`` has not been called.
+        Kept distinct from :meth:`_get_fit_state` to preserve the latter's
+        "fit-required" invariant (H-0077).
+
+        Raises:
+            :class:`~lizyml.core.exceptions.LizyMLError` with
+            ``MODEL_NOT_FIT`` when ``tune()`` has not been called.
+        """
+        if self._tuning_result is None:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message="tune() has not been called yet.",
+                context={"method": "_get_tuning_state", "task": self._cfg.task},
+            )
+        return TuningState(cfg=self._cfg, tuning_result=self._tuning_result)
+
+    def _resolve_export_path(self, path: str | Path | None) -> Path:
+        """Resolve the export destination directory (H-0077: moved from Mixin).
+
+        Path resolution (first match wins):
+
+        1. Explicit *path* argument.
+        2. ``{run_dir}/export`` when a run directory exists from
+           ``fit()`` / ``tune()``.
+        3. New run directory under ``output_dir`` if configured.
+        4. Error — no destination available.
+
+        This method writes to ``self._run_dir`` when allocating a new run
+        directory in case 3, which is why it lives on the Model facade rather
+        than on the (frozen-state) Mixin.
+
+        Raises:
+            :class:`~lizyml.core.exceptions.LizyMLError` with
+            ``SERIALIZATION_FAILED`` when no destination can be resolved.
+        """
+        if path is not None:
+            return Path(path)
+        if self._run_dir is not None:
+            return Path(self._run_dir) / "export"
+        if self._output_dir is not None:
+            from lizyml.core.logging import setup_output_dir
+
+            export_run_id = generate_run_id()
+            self._run_dir = setup_output_dir(self._output_dir, export_run_id)
+            return Path(self._run_dir) / "export"
+        raise LizyMLError(
+            ErrorCode.SERIALIZATION_FAILED,
+            user_message=(
+                "No export path provided and no output_dir configured. "
+                "Pass an explicit path or set output_dir in Config / constructor."
+            ),
         )

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -31,7 +31,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -66,6 +66,7 @@ from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.fit_state import FitState
 from lizyml.core.types.predict_result import PredictionResult
+from lizyml.core.types.task import TaskType
 from lizyml.core.types.tuning_result import (
     BoundaryReport,
     RoundSummary,
@@ -97,10 +98,8 @@ from lizyml.tuning.tuner import Tuner
 
 _log = get_logger("model")
 
-TaskType = Literal["regression", "binary", "multiclass"]
-
 # Default metrics per task when none are specified in config.
-_DEFAULT_METRICS: dict[str, list[str | dict[str, dict[str, Any]]]] = {
+_DEFAULT_METRICS: dict[TaskType, list[str | dict[str, dict[str, Any]]]] = {
     "regression": ["rmse", "mae"],
     "binary": ["logloss", "auc"],
     "multiclass": ["logloss", "f1", "accuracy"],

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -64,6 +64,7 @@ from lizyml.core.specs.problem_spec import ProblemSpec
 from lizyml.core.train_components import TrainComponents
 from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
+from lizyml.core.types.fit_state import FitState
 from lizyml.core.types.predict_result import PredictionResult
 from lizyml.core.types.tuning_result import (
     BoundaryReport,
@@ -1273,3 +1274,39 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 },
             )
         return self._refit_result
+
+    def _get_fit_state(self) -> FitState:
+        """Return a frozen snapshot of post-fit state for Mixin methods (#112).
+
+        H-0074 introduces this as the single read path that Mixin methods
+        will eventually consume. Phase 1 (introduction) keeps the existing
+        ``self._*`` access intact; Phase 2 will migrate Mixins to read
+        only from the returned ``FitState``.
+
+        Raises:
+            :class:`~lizyml.core.exceptions.LizyMLError` with
+            ``MODEL_NOT_FIT`` when called before ``fit()`` (delegated via
+            :meth:`_require_fit`).
+        """
+        fit_result = self._require_fit()
+        if self._provider is None:
+            raise LizyMLError(
+                code=ErrorCode.MODEL_NOT_FIT,
+                user_message=(
+                    "Provider is not initialised. Call fit() before "
+                    "diagnostic / export APIs."
+                ),
+                context={"method": "_get_fit_state"},
+            )
+        return FitState(
+            cfg=self._cfg,
+            fit_result=fit_result,
+            refit_result=self._refit_result,
+            tuning_result=self._tuning_result,
+            provider=self._provider,
+            metrics=self._metrics,
+            y=self._y,
+            X=self._X,
+            run_dir=self._run_dir,
+            output_dir=self._output_dir,
+        )

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -898,23 +898,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             tc = components.time_col
             assert tc is not None  # noqa: S101
             sort_order = tc.argsort()
-            X = X.iloc[sort_order].reset_index(drop=True)
-            y = y.iloc[sort_order].reset_index(drop=True)
+            components = self._sort_and_rebuild_components(sort_order, components)
+            X, y = components.X, components.y
             if groups is not None:
                 groups = groups[sort_order]
-            sorted_time = tc.iloc[sort_order].reset_index(drop=True)
-            sorted_group = (
-                components.group_col.iloc[sort_order].reset_index(drop=True)
-                if components.group_col is not None
-                else None
-            )
-            components = DataFrameComponents(
-                X=X,
-                y=y,
-                time_col=sorted_time,
-                group_col=sorted_group,
-                target_encoder=components.target_encoder,
-            )
 
         if cfg.split.method in _BLOCK_METHODS:
             if not isinstance(cfg.split, BlockedGroupKFoldConfig):
@@ -951,35 +938,53 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             block_series = df[blocks_col_name]
             group_series = df[groups_col_name]
 
-            # Sort by blocks.col
+            # Sort by blocks.col, then rebuild via shared helper.
             sort_order = block_series.argsort()
-            X = X.iloc[sort_order].reset_index(drop=True)
-            y = y.iloc[sort_order].reset_index(drop=True)
+            components = self._sort_and_rebuild_components(sort_order, components)
+            X, y = components.X, components.y
 
             # Override groups with groups.col (not data.group_col)
             groups = group_series.iloc[sort_order].to_numpy()
             self._block_values = block_series.iloc[sort_order].to_numpy()
 
-            # Update components
-            block_sorted_time: pd.Series | None = (
-                components.time_col.iloc[sort_order].reset_index(drop=True)
-                if components.time_col is not None
-                else None
-            )
-            block_sorted_group: pd.Series | None = (
-                components.group_col.iloc[sort_order].reset_index(drop=True)
-                if components.group_col is not None
-                else None
-            )
-            components = DataFrameComponents(
-                X=X,
-                y=y,
-                time_col=block_sorted_time,
-                group_col=block_sorted_group,
-                target_encoder=components.target_encoder,
-            )
-
         return X, y, groups, components
+
+    @staticmethod
+    def _sort_and_rebuild_components(
+        sort_order: npt.NDArray[np.intp] | pd.Series,
+        components: DataFrameComponents,
+    ) -> DataFrameComponents:
+        """Apply *sort_order* to every Series in *components* and return a
+        new :class:`DataFrameComponents` (#115).
+
+        Shared by the time-series and blocked-group branches of
+        :meth:`_prepare_training_data`. The two callers previously contained
+        nearly-identical sort-and-reset blocks; the only difference is the
+        sort key, which the caller computes.
+
+        ``groups`` (``np.ndarray`` outside ``components``) is *not* touched
+        here — each branch handles it differently (TS reuses, Block
+        replaces). The ``target_encoder`` is propagated unchanged.
+        """
+        X = components.X.iloc[sort_order].reset_index(drop=True)
+        y = components.y.iloc[sort_order].reset_index(drop=True)
+        sorted_time = (
+            components.time_col.iloc[sort_order].reset_index(drop=True)
+            if components.time_col is not None
+            else None
+        )
+        sorted_group = (
+            components.group_col.iloc[sort_order].reset_index(drop=True)
+            if components.group_col is not None
+            else None
+        )
+        return DataFrameComponents(
+            X=X,
+            y=y,
+            time_col=sorted_time,
+            group_col=sorted_group,
+            target_encoder=components.target_encoder,
+        )
 
     def _build_run_meta(self, run_id: str) -> RunMeta:
         def _ver(pkg: str) -> str:

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+from collections.abc import Callable
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -41,7 +42,11 @@ if TYPE_CHECKING:
 
 from lizyml import __version__
 from lizyml.config.loader import load_config
-from lizyml.config.schema import BlockedGroupKFoldConfig, LizyMLConfig
+from lizyml.config.schema import (
+    BlockedGroupKFoldConfig,
+    LizyMLConfig,
+    OptunaParamsConfig,
+)
 from lizyml.core._model_factories import (
     build_inner_valid,
     build_splitter,
@@ -57,7 +62,7 @@ from lizyml.core.logging import generate_run_id, get_logger
 from lizyml.core.specs.feature_spec import FeatureSpec
 from lizyml.core.specs.problem_spec import ProblemSpec
 from lizyml.core.train_components import TrainComponents
-from lizyml.core.types.artifacts import RunMeta
+from lizyml.core.types.artifacts import DataFingerprint, RunMeta
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.predict_result import PredictionResult
 from lizyml.core.types.tuning_result import (
@@ -71,6 +76,7 @@ from lizyml.data.dataframe_builder import DataFrameComponents
 from lizyml.data.fingerprint import compute as fp_compute
 from lizyml.estimators.provider import EstimatorProvider
 from lizyml.evaluation.evaluator import Evaluator
+from lizyml.splitters.base import BaseSplitter
 from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
 from lizyml.training.refit_trainer import RefitResult, RefitTrainer
@@ -669,17 +675,17 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         base_smart_params: dict[str, Any],
         fixed: dict[str, Any],
         provider: EstimatorProvider,
-        splitter: Any,
+        splitter: BaseSplitter,
         X: pd.DataFrame,
         y: pd.Series,
         groups: npt.NDArray[Any] | None,
         n_classes: int | None,
-        fingerprint: Any,
+        fingerprint: DataFingerprint,
         run_meta: RunMeta,
         evaluator: Evaluator,
-        first_entry: Any,
+        first_entry: str | dict[str, Any],
         metric_name: str,
-    ) -> Any:
+    ) -> Callable[[Any], float]:
         """Return the optuna objective closure used by ``Tuner``.
 
         Captures all parameters needed by a single trial: the provider,
@@ -731,11 +737,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
     def _run_tune_round(
         self,
-        objective: Any,
+        objective: Callable[[Any], float],
         *,
         space: list[Any],
         actual_n_trials: int,
-        optuna_cfg: Any,
+        optuna_cfg: OptunaParamsConfig,
         metric_name: str,
         progress_callback: TuneProgressCallback | None,
         storage: str | BaseStorage | None,
@@ -1007,7 +1013,9 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 "set data.path in the config."
             ),
             context={
-                "cfg_data_path": self._cfg.data.path,
+                # Defensive: only the boolean is logged so that user file
+                # paths never leak through error logs / repr (cf. #118 audit).
+                "cfg_data_path_set": bool(self._cfg.data.path),
                 "constructor_data": self._data is not None,
             },
         )

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -287,7 +287,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Metrics not computed. Call fit() first.",
-                context={},
+                context={"task": self._cfg.task, "fit_called": False},
             )
 
         if metrics is None:
@@ -444,7 +444,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                     "No tuning configuration found. "
                     "Add a 'tuning' section to the config to enable tuning."
                 ),
-                context={},
+                context={"task": cfg.task, "model": getattr(cfg.model, "name", None)},
             )
 
         if resume and self._study is None:
@@ -454,7 +454,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                     "Cannot resume tuning: no previous tune() call. "
                     "Run tune() first, then tune(resume=True)."
                 ),
-                context={},
+                context={"resume": True, "round_number": self._round_number},
             )
 
         if not 0.0 < boundary_threshold < 0.5:
@@ -850,7 +850,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 "No data provided. Pass a DataFrame to fit(data=df) or "
                 "set data.path in the config."
             ),
-            context={},
+            context={
+                "cfg_data_path": self._cfg.data.path,
+                "constructor_data": self._data is not None,
+            },
         )
 
     def _prepare_training_data(
@@ -1077,7 +1080,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Model has not been fitted. Call fit() first.",
-                context={},
+                context={"task": self._cfg.task, "method": "fit"},
             )
         return self._fit_result
 
@@ -1086,6 +1089,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             raise LizyMLError(
                 code=ErrorCode.MODEL_NOT_FIT,
                 user_message="Model has not been fitted. Call fit() first.",
-                context={},
+                context={
+                    "task": self._cfg.task,
+                    "method": "refit",
+                    "fit_done": self._fit_result is not None,
+                },
             )
         return self._refit_result

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -437,6 +437,120 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 prior tune().
         """
         cfg = self._cfg
+        self._validate_tune_inputs(resume=resume, boundary_threshold=boundary_threshold)
+
+        optuna_cfg = cfg.tuning.optuna.params  # type: ignore[union-attr]
+        actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
+
+        _log.info(
+            "event='tune.start' task=%s resume=%s n_trials=%d",
+            cfg.task,
+            resume,
+            actual_n_trials,
+        )
+
+        self._ensure_run_dir(generate_run_id())
+        X, y, groups, _ = self._prepare_training_data(data)
+        self._X, self._y = X, y
+
+        provider = get_provider(cfg.model)
+        self._provider = provider
+        n_classes = int(y.nunique()) if cfg.task == "multiclass" else None
+        splitter = build_splitter(
+            cfg,
+            block_values=self._block_values,
+            task=cfg.task,
+            seed=cfg.training.seed,
+        )
+        base_model_params, base_smart_params = self._merge_params(provider)
+
+        space, used_default, fixed = self._resolve_search_space(
+            resume=resume, provider=provider
+        )
+        space, boundary_report, expanded_names = self._maybe_expand_boundary(
+            space,
+            resume=resume,
+            used_default=used_default,
+            expand_boundary=expand_boundary,
+            boundary_threshold=boundary_threshold,
+        )
+
+        # --- Metric & evaluator setup --------------------------------------------
+        metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
+        from lizyml.metrics.registry import parse_metric_entry
+
+        first_entry = metric_entries[0]
+        metric_name, _ = parse_metric_entry(first_entry)
+
+        evaluator = Evaluator(task=cfg.task)
+        fingerprint = fp_compute(X, file_path=None)
+        run_meta = self._build_run_meta(generate_run_id())
+
+        objective = self._build_tune_objective(
+            space=space,
+            base_model_params=base_model_params,
+            base_smart_params=base_smart_params,
+            fixed=fixed,
+            provider=provider,
+            splitter=splitter,
+            X=X,
+            y=y,
+            groups=groups,
+            n_classes=n_classes,
+            fingerprint=fingerprint,
+            run_meta=run_meta,
+            evaluator=evaluator,
+            first_entry=first_entry,
+            metric_name=metric_name,
+        )
+
+        round_number = self._round_number + 1
+        result, study, prior_trials, best_score_before = self._run_tune_round(
+            objective,
+            space=space,
+            actual_n_trials=actual_n_trials,
+            optuna_cfg=optuna_cfg,
+            metric_name=metric_name,
+            progress_callback=progress_callback,
+            storage=storage,
+            study_name=study_name,
+            resume=resume,
+            round_number=round_number,
+            expanded_names=expanded_names,
+        )
+
+        final_result, all_rounds = self._assemble_tuning_result(
+            result,
+            round_number=round_number,
+            actual_n_trials=actual_n_trials,
+            best_score_before=best_score_before,
+            expanded_names=expanded_names,
+            space=space,
+            boundary_report=boundary_report,
+            prior_trials=prior_trials,
+        )
+
+        # --- Update internal state -----------------------------------------------
+        self._tuning_result = final_result
+        self._study = study
+        self._round_number = round_number
+        self._rounds = list(all_rounds)
+        self._space = space
+        self._used_default_space = used_default
+
+        _log.info(
+            "event='tune.done' round=%d best_params=%s",
+            round_number,
+            final_result.best_params,
+        )
+        return final_result
+
+    # --- tune() helpers (#114 — split god method) -------------------------------
+
+    def _validate_tune_inputs(self, *, resume: bool, boundary_threshold: float) -> None:
+        """Validate cfg + tune-call invariants. Raises ``LizyMLError`` on
+        violation."""
+        cfg = self._cfg
         if cfg.tuning is None:
             raise LizyMLError(
                 code=ErrorCode.CONFIG_INVALID,
@@ -467,32 +581,20 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
                 context={"boundary_threshold": boundary_threshold},
             )
 
-        optuna_cfg = cfg.tuning.optuna.params
-        actual_n_trials = n_trials if n_trials is not None else optuna_cfg.n_trials
+    def _resolve_search_space(
+        self,
+        *,
+        resume: bool,
+        provider: EstimatorProvider,
+    ) -> tuple[list[Any], bool, dict[str, Any]]:
+        """Return the search space for this tune call.
 
-        _log.info(
-            "event='tune.start' task=%s resume=%s n_trials=%d",
-            cfg.task,
-            resume,
-            actual_n_trials,
-        )
-
-        self._ensure_run_dir(generate_run_id())
-        X, y, groups, _ = self._prepare_training_data(data)
-        self._X, self._y = X, y
-
-        provider = get_provider(cfg.model)
-        self._provider = provider
-        n_classes = int(y.nunique()) if cfg.task == "multiclass" else None
-        splitter = build_splitter(
-            cfg,
-            block_values=self._block_values,
-            task=cfg.task,
-            seed=cfg.training.seed,
-        )
-        base_model_params, base_smart_params = self._merge_params(provider)
-
-        # --- Resolve search space ------------------------------------------------
+        Returns a tuple ``(space, used_default, fixed_params)`` where
+        ``used_default`` signals that no user-supplied space was provided
+        (drives the H-0068 expand-boundary default).
+        """
+        cfg = self._cfg
+        assert cfg.tuning is not None  # noqa: S101 — validated upstream
         if resume and self._space is not None:
             space = list(self._space)
             used_default = self._used_default_space
@@ -508,52 +610,86 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         fixed: dict[str, Any] = (
             provider.default_fixed_params(cfg.task) if used_default else {}
         )
+        return space, used_default, fixed
 
-        # --- H-0068: boundary detection + expansion ------------------------------
-        boundary_report: BoundaryReport | None = None
-        expanded_names: tuple[str, ...] = ()
-        if resume and self._tuning_result is not None:
-            should_expand = expand_boundary
-            if should_expand is None:
-                should_expand = used_default
+    def _maybe_expand_boundary(
+        self,
+        space: list[Any],
+        *,
+        resume: bool,
+        used_default: bool,
+        expand_boundary: bool | None,
+        boundary_threshold: float,
+    ) -> tuple[list[Any], BoundaryReport | None, tuple[str, ...]]:
+        """Apply H-0068 boundary detection + expansion when applicable.
 
-            if should_expand:
-                boundary_report = detect_boundary(
-                    space, self._tuning_result.best_params, boundary_threshold
-                )
-                expanded_names = boundary_report.expanded_names
-                if expanded_names:
-                    space = expand_dims(space, boundary_report)
-                    for name in expanded_names:
-                        status = next(s for s in boundary_report.dims if s.name == name)
-                        _log.info(
-                            "event='tune.expand' dim=%s edge=%s "
-                            "old=[%s, %s] new=[%s, %s] best=%s",
-                            name,
-                            status.edge,
-                            status.low,
-                            status.high,
-                            status.new_low,
-                            status.new_high,
-                            status.best_value,
-                        )
-                else:
-                    _log.info("event='tune.resume' no dims near boundary")
-            else:
-                _log.info("event='tune.resume' expand_boundary=False")
+        Returns ``(new_space, boundary_report, expanded_names)``. Without
+        a prior tune() or when ``expand_boundary`` is False, the input
+        ``space`` is returned unchanged with ``(None, ())``.
+        """
+        if not (resume and self._tuning_result is not None):
+            return space, None, ()
 
-        # --- Metric & evaluator setup --------------------------------------------
-        metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
-        from lizyml.metrics.registry import parse_metric_entry
+        should_expand = expand_boundary
+        if should_expand is None:
+            should_expand = used_default
 
-        first_entry = metric_entries[0]
-        metric_name, _ = parse_metric_entry(first_entry)
+        if not should_expand:
+            _log.info("event='tune.resume' expand_boundary=False")
+            return space, None, ()
 
-        evaluator = Evaluator(task=cfg.task)
-        fingerprint = fp_compute(X, file_path=None)
-        run_meta = self._build_run_meta(generate_run_id())
+        boundary_report = detect_boundary(
+            space, self._tuning_result.best_params, boundary_threshold
+        )
+        expanded_names = boundary_report.expanded_names
+        if not expanded_names:
+            _log.info("event='tune.resume' no dims near boundary")
+            return space, boundary_report, expanded_names
 
-        # --- Build objective closure (H-0050: uses _build_train_components) -------
+        new_space = expand_dims(space, boundary_report)
+        for name in expanded_names:
+            status = next(s for s in boundary_report.dims if s.name == name)
+            _log.info(
+                "event='tune.expand' dim=%s edge=%s old=[%s, %s] new=[%s, %s] best=%s",
+                name,
+                status.edge,
+                status.low,
+                status.high,
+                status.new_low,
+                status.new_high,
+                status.best_value,
+            )
+        return new_space, boundary_report, expanded_names
+
+    def _build_tune_objective(
+        self,
+        *,
+        space: list[Any],
+        base_model_params: dict[str, Any],
+        base_smart_params: dict[str, Any],
+        fixed: dict[str, Any],
+        provider: EstimatorProvider,
+        splitter: Any,
+        X: pd.DataFrame,
+        y: pd.Series,
+        groups: npt.NDArray[Any] | None,
+        n_classes: int | None,
+        fingerprint: Any,
+        run_meta: RunMeta,
+        evaluator: Evaluator,
+        first_entry: Any,
+        metric_name: str,
+    ) -> Any:
+        """Return the optuna objective closure used by ``Tuner``.
+
+        Captures all parameters needed by a single trial: the provider,
+        splitter, training data, fingerprint/run-meta and the metric to
+        optimise. The closure rebuilds ``TrainComponents`` and ``CVTrainer``
+        per trial because trial-level params (``smart``, ``training``)
+        change per call.
+        """
+        cfg = self._cfg
+
         def objective(trial: Any) -> float:
             trial_params = suggest_params(trial, space)
             model_p, smart_p, training_p = split_by_category(trial_params, space)
@@ -591,15 +727,35 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             score: float = metrics["raw"]["oof"][metric_name]
             return score
 
-        # --- Run tuner ------------------------------------------------------------
-        round_number = self._round_number + 1
+        return objective
+
+    def _run_tune_round(
+        self,
+        objective: Any,
+        *,
+        space: list[Any],
+        actual_n_trials: int,
+        optuna_cfg: Any,
+        metric_name: str,
+        progress_callback: TuneProgressCallback | None,
+        storage: str | BaseStorage | None,
+        study_name: str | None,
+        resume: bool,
+        round_number: int,
+        expanded_names: tuple[str, ...],
+    ) -> tuple[TuningResult, Any, int, float | None]:
+        """Construct the ``Tuner`` and execute one round of optuna search.
+
+        Returns ``(raw_result, study, prior_trials, best_score_before)``.
+        ``prior_trials`` and ``best_score_before`` are populated only when
+        ``resume`` is True (validated upstream by ``_validate_tune_inputs``).
+        """
         prior_trials = 0
         best_score_before: float | None = None
         enqueue: dict[str, Any] | None = None
         if resume:
-            # Guaranteed non-None: validated at the top of tune()
-            assert self._study is not None
-            assert self._tuning_result is not None
+            assert self._study is not None  # noqa: S101 — validated upstream
+            assert self._tuning_result is not None  # noqa: S101
             prior_trials = len(self._study.trials)
             best_score_before = self._tuning_result.best_score
             enqueue = dict(self._tuning_result.best_params)
@@ -609,12 +765,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             n_trials=actual_n_trials,
             direction=optuna_cfg.direction,
             timeout=optuna_cfg.timeout,
-            seed=cfg.training.seed,
+            seed=self._cfg.training.seed,
             progress_callback=progress_callback,
             storage=storage,
             study_name=study_name,
         )
-
         result, study = tuner.tune(
             objective,
             metric_name=metric_name,
@@ -624,26 +779,42 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             prior_trials=prior_trials,
             expanded_dims=expanded_names,
         )
+        return result, study, prior_trials, best_score_before
 
-        # --- Build round summary and fix trial round numbers ---------------------
+    def _assemble_tuning_result(
+        self,
+        raw_result: TuningResult,
+        *,
+        round_number: int,
+        actual_n_trials: int,
+        best_score_before: float | None,
+        expanded_names: tuple[str, ...],
+        space: list[Any],
+        boundary_report: BoundaryReport | None,
+        prior_trials: int,
+    ) -> tuple[TuningResult, tuple[RoundSummary, ...]]:
+        """Build the round summary, fix per-trial round numbers, and
+        assemble the final ``TuningResult``.
+
+        Returns ``(final_result, all_rounds)``. ``all_rounds`` is the new
+        complete tuple including the just-completed round, ready for
+        persistence to ``self._rounds``.
+        """
         round_summary = RoundSummary(
             round=round_number,
             n_trials=actual_n_trials,
             best_score_before=best_score_before,
-            best_score_after=result.best_score,
+            best_score_after=raw_result.best_score,
             expanded_dims=expanded_names,
             space_snapshot=tuple(space),
         )
-
-        # Preserve previous rounds + add current
         all_rounds = tuple(self._rounds) + (round_summary,)
 
-        # Fix up trial round numbers: trials from previous rounds keep their
-        # original round, new trials get current round_number
+        # Fix up trial round numbers: trials from previous rounds keep
+        # their original round, new trials get the current round_number.
         fixed_trials = []
-        for t in result.trials:
+        for t in raw_result.trials:
             if t.number < prior_trials:
-                # Find which round this trial belonged to
                 trial_round = 1
                 cumulative = 0
                 for rs in self._rounds:
@@ -655,33 +826,18 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             else:
                 fixed_trials.append(dataclasses.replace(t, round=round_number))
 
-        # Rebuild result with rounds and boundary_report
         final_result = TuningResult(
-            best_model_params=result.best_model_params,
-            best_smart_params=result.best_smart_params,
-            best_training_params=result.best_training_params,
-            best_score=result.best_score,
+            best_model_params=raw_result.best_model_params,
+            best_smart_params=raw_result.best_smart_params,
+            best_training_params=raw_result.best_training_params,
+            best_score=raw_result.best_score,
             trials=fixed_trials,
-            metric_name=result.metric_name,
-            direction=result.direction,
+            metric_name=raw_result.metric_name,
+            direction=raw_result.direction,
             rounds=all_rounds,
             boundary_report=boundary_report,
         )
-
-        # --- Update internal state -----------------------------------------------
-        self._tuning_result = final_result
-        self._study = study
-        self._round_number = round_number
-        self._rounds = list(all_rounds)
-        self._space = space
-        self._used_default_space = used_default
-
-        _log.info(
-            "event='tune.done' round=%d best_params=%s",
-            round_number,
-            final_result.best_params,
-        )
-        return final_result
+        return final_result, all_rounds
 
     # ------------------------------------------------------------------
     # Properties

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -76,6 +76,11 @@ from lizyml.data.dataframe_builder import DataFrameComponents
 from lizyml.data.fingerprint import compute as fp_compute
 from lizyml.estimators.provider import EstimatorProvider
 from lizyml.evaluation.evaluator import Evaluator
+from lizyml.metrics.registry import (
+    get_metrics_for_task,
+    parse_metric_entries,
+    parse_metric_entry,
+)
 from lizyml.splitters.base import BaseSplitter
 from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
@@ -300,8 +305,6 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             return self._metrics
 
         # Validate task compatibility first (raises UNSUPPORTED_METRIC if invalid)
-        from lizyml.metrics.registry import get_metrics_for_task, parse_metric_entries
-
         get_metrics_for_task(metrics, self._cfg.task)  # raises on unknown/incompatible
 
         # Extract metric names for filtering (H-0065)
@@ -456,7 +459,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         )
 
         self._ensure_run_dir(generate_run_id())
-        X, y, groups, _ = self._prepare_training_data(data)
+        # Components are dropped: tune() only needs the sorted X/y/groups for
+        # the objective closure; FeaturePipeline state is built per-trial via
+        # `provider.build_pipeline_factory()`.
+        X, y, groups, _components = self._prepare_training_data(data)
+        del _components
         self._X, self._y = X, y
 
         provider = get_provider(cfg.model)
@@ -483,7 +490,6 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
         # --- Metric & evaluator setup --------------------------------------------
         metric_entries = cfg.evaluation.metrics or _DEFAULT_METRICS[cfg.task]
-        from lizyml.metrics.registry import parse_metric_entry
 
         first_entry = metric_entries[0]
         metric_name, _ = parse_metric_entry(first_entry)
@@ -818,19 +824,26 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
         # Fix up trial round numbers: trials from previous rounds keep
         # their original round, new trials get the current round_number.
+        # Pre-compute (cumulative_count, round) so the per-trial lookup is
+        # a small linear scan over rounds (O(n + m) total) instead of
+        # O(n × m).
+        round_boundaries: list[tuple[int, int]] = []
+        running = 0
+        for rs in self._rounds:
+            running += rs.n_trials
+            round_boundaries.append((running, rs.round))
+
         fixed_trials = []
         for t in raw_result.trials:
-            if t.number < prior_trials:
-                trial_round = 1
-                cumulative = 0
-                for rs in self._rounds:
-                    cumulative += rs.n_trials
-                    if t.number < cumulative:
-                        trial_round = rs.round
-                        break
-                fixed_trials.append(dataclasses.replace(t, round=trial_round))
-            else:
+            if t.number >= prior_trials:
                 fixed_trials.append(dataclasses.replace(t, round=round_number))
+                continue
+            trial_round = 1
+            for cumulative, rs_round in round_boundaries:
+                if t.number < cumulative:
+                    trial_round = rs_round
+                    break
+            fixed_trials.append(dataclasses.replace(t, round=trial_round))
 
         final_result = TuningResult(
             best_model_params=raw_result.best_model_params,

--- a/lizyml/core/types/fit_state.py
+++ b/lizyml/core/types/fit_state.py
@@ -1,16 +1,20 @@
-"""FitState — frozen snapshot of Model state consumed by Mixin methods (#112, H-0074).
+"""FitState / TuningState — frozen snapshots of Model state for Mixin methods (#112).
 
-Created by ``Model._get_fit_state()`` after ``fit()`` / ``tune()`` / ``load()``.
-Mixin methods (``ModelPlotsMixin``, ``ModelTablesMixin``, ``ModelPersistenceMixin``)
-will increasingly receive a ``FitState`` instance instead of reading
-``self._*`` attributes directly. Phase 1 (this introduction PR) only adds
-the dataclass and the factory; Mixin signatures remain backward-compatible.
-Phase 2 will migrate Mixin methods to ``state: FitState`` and remove the
-``self._*`` access path.
+Created by ``Model._get_fit_state()`` / ``Model._get_tuning_state()`` and consumed by
+``ModelPlotsMixin`` / ``ModelTablesMixin`` / ``ModelPersistenceMixin``. After H-0077
+(Phase 2) Mixin methods read state exclusively from these snapshots — direct
+``self._*`` access is forbidden inside Mixin bodies.
 
-The class is frozen and contains only references — it is cheap to build
-once per public-API call. It must NOT capture transient training state
-(e.g. per-fold buffers); only the post-fit handles required by diagnostic
+Two state types are distinguished by lifecycle:
+
+* :class:`FitState` — post-``fit()`` / ``tune()`` / ``load()`` snapshot. Required
+  for any diagnostic API that depends on ``fit_result`` (plots, tables, export).
+* :class:`TuningState` — post-``tune()`` snapshot, valid even before ``fit()`` is
+  called. Required for ``tuning_plot`` / ``tuning_table`` / ``boundary_table``.
+
+Both classes are frozen and contain only references — they are cheap to build
+once per public-API call. They must NOT capture transient training state
+(e.g. per-fold buffers); only the handles required by diagnostic / export
 methods belong here.
 """
 
@@ -65,3 +69,24 @@ class FitState:
     X: pd.DataFrame | None
     run_dir: Path | None
     output_dir: str | Path | None
+
+
+@dataclass(frozen=True)
+class TuningState:
+    """Frozen snapshot of post-``tune()`` Model state for Mixin consumption.
+
+    Used by ``tuning_plot`` / ``tuning_table`` / ``boundary_table`` which must
+    work after ``tune()`` even when ``fit()`` has not been called. Keeping this
+    distinct from :class:`FitState` preserves the latter's "fit-required"
+    invariant and avoids forcing every Mixin method to handle a ``None``
+    ``fit_result``.
+
+    Attributes:
+        cfg: The active :class:`LizyMLConfig`.
+        tuning_result: Output of :meth:`Model.tune`. Always non-``None`` —
+            :meth:`Model._get_tuning_state` raises ``MODEL_NOT_FIT`` when
+            ``tune()`` has not been called.
+    """
+
+    cfg: LizyMLConfig
+    tuning_result: TuningResult

--- a/lizyml/core/types/fit_state.py
+++ b/lizyml/core/types/fit_state.py
@@ -1,0 +1,67 @@
+"""FitState — frozen snapshot of Model state consumed by Mixin methods (#112, H-0074).
+
+Created by ``Model._get_fit_state()`` after ``fit()`` / ``tune()`` / ``load()``.
+Mixin methods (``ModelPlotsMixin``, ``ModelTablesMixin``, ``ModelPersistenceMixin``)
+will increasingly receive a ``FitState`` instance instead of reading
+``self._*`` attributes directly. Phase 1 (this introduction PR) only adds
+the dataclass and the factory; Mixin signatures remain backward-compatible.
+Phase 2 will migrate Mixin methods to ``state: FitState`` and remove the
+``self._*`` access path.
+
+The class is frozen and contains only references — it is cheap to build
+once per public-API call. It must NOT capture transient training state
+(e.g. per-fold buffers); only the post-fit handles required by diagnostic
+methods belong here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from lizyml.config.schema import LizyMLConfig
+    from lizyml.core.types.fit_result import FitResult
+    from lizyml.core.types.tuning_result import TuningResult
+    from lizyml.estimators.provider import EstimatorProvider
+    from lizyml.training.refit_trainer import RefitResult
+
+
+@dataclass(frozen=True)
+class FitState:
+    """Frozen snapshot of post-fit Model state for Mixin consumption.
+
+    Attributes:
+        cfg: The active :class:`LizyMLConfig` (always present).
+        fit_result: Output of :meth:`Model.fit`. Required for any
+            diagnostic / plot / table method.
+        refit_result: Output of refit on full data. ``None`` when the
+            user disabled refit or the model was loaded without it.
+        tuning_result: Output of :meth:`Model.tune`. ``None`` when tune
+            was not called.
+        provider: The estimator provider used for the current model.
+            Required for SHAP, params summary, and codegen export.
+        metrics: Pre-computed metrics dict (``{"raw": {...}, "calibrated":
+            {...}}``). Populated by :meth:`Evaluator.evaluate`.
+        y: Training target (transient — absent after :meth:`Model.load` if
+            the artifact does not contain ``analysis_context``).
+        X: Training features (transient — same caveat as ``y``).
+        run_dir: Active run directory for log/artifact output. ``None``
+            until ``fit`` / ``tune`` allocate one.
+        output_dir: User-configured root for run directories. ``None``
+            when neither config nor constructor specified one.
+    """
+
+    cfg: LizyMLConfig
+    fit_result: FitResult
+    refit_result: RefitResult | None
+    tuning_result: TuningResult | None
+    provider: EstimatorProvider
+    metrics: dict[str, Any] | None
+    y: pd.Series | None
+    X: pd.DataFrame | None
+    run_dir: Path | None
+    output_dir: str | Path | None

--- a/lizyml/core/types/target_encoder.py
+++ b/lizyml/core/types/target_encoder.py
@@ -29,9 +29,27 @@ class TargetEncoder:
     can map predicted codes back to the original labels via
     :meth:`inverse_transform`.
 
+    Class ordering:
+        Class labels are sorted **lexicographically** by their string form
+        (``sorted(unique, key=str)``). This is deterministic and works for
+        heterogeneous label types (e.g. mixed ``str``/``int``) but does
+        **not** match natural numeric order for numeric-string labels::
+
+            input y:   ["1", "10", "2"]
+            classes_:  ("1", "10", "2")     # NOT ("1", "2", "10")
+            codes:      0     1     2
+
+        Downstream metric tables (``f1_score`` per class, etc.) inherit
+        this order. If natural numeric ordering is required, cast the
+        target to a numeric dtype before fitting (then the encoder becomes
+        a no-op and the model uses the numeric values directly). This
+        ordering rule is part of the public contract — see
+        BLUEPRINT.md §7.1.
+
     Attributes:
-        classes_: Sorted original labels. Empty tuple when ``needs_encoding``
-            is False. ``classes_[i]`` corresponds to int code ``i``.
+        classes_: Lexicographically sorted original labels (see *Class
+            ordering* above). Empty tuple when ``needs_encoding`` is False.
+            ``classes_[i]`` corresponds to int code ``i``.
         needs_encoding: Whether ``transform`` / ``inverse_transform`` perform
             actual mapping. False for regression and numeric classification.
         original_dtype: String form of the original y dtype (e.g. ``"object"``,

--- a/lizyml/core/types/target_encoder.py
+++ b/lizyml/core/types/target_encoder.py
@@ -7,15 +7,16 @@ a back-dependency on Layer 1 ``data/``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["TargetEncoder", "TaskType"]
 
 
 @dataclass(frozen=True)

--- a/lizyml/core/types/task.py
+++ b/lizyml/core/types/task.py
@@ -1,0 +1,18 @@
+"""TaskType — canonical Literal for the supported ML tasks (#122, H-0075).
+
+Centralised here so every layer (Foundation → Composition) imports the
+same alias and a future addition (e.g. ``"ranking"``, ``"multilabel"``)
+is a single-line change. The runtime values match the public Config
+schema and BLUEPRINT §7.1 — never widen the union without a Proposal.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+TaskType = Literal["regression", "binary", "multiclass"]
+"""The set of ML tasks that LizyML currently supports."""
+
+TASK_TYPES: tuple[TaskType, ...] = ("regression", "binary", "multiclass")
+"""Tuple form for iteration / membership checks where ``Literal`` cannot
+be used directly (e.g. ``pytest.parametrize`` arguments)."""

--- a/lizyml/estimators/base.py
+++ b/lizyml/estimators/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
@@ -74,6 +75,20 @@ class BaseEstimatorAdapter(ABC):
     @abstractmethod
     def get_native_model(self) -> Any:
         """Return the underlying native model object."""
+
+    @abstractmethod
+    def save_model_text(self, path: str | Path) -> Path:
+        """Persist the fitted model as a portable text file (H-0073).
+
+        Used by codegen export to emit a LizyML-independent artifact
+        loadable by the native estimator's runtime alone.
+
+        Args:
+            path: Destination file path.
+
+        Returns:
+            The resolved ``Path`` of the written file.
+        """
 
     def set_categorical_features(self, cols: list[str] | None) -> None:
         """Inform the estimator which columns are categorical.

--- a/lizyml/estimators/lgbm/adapter.py
+++ b/lizyml/estimators/lgbm/adapter.py
@@ -27,7 +27,9 @@ except ImportError as e:  # pragma: no cover
         context={"package": "lightgbm"},
     ) from e
 
-TaskType = Literal["regression", "binary", "multiclass"]
+from lizyml.core.types.task import TaskType  # noqa: E402  re-export for ext
+
+__all__ = ["LGBMAdapter", "TaskType"]
 
 
 class LGBMAdapter(BaseEstimatorAdapter):

--- a/lizyml/estimators/lgbm/defaults.py
+++ b/lizyml/estimators/lgbm/defaults.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from lizyml.core.types.search_dim import CategoricalDim, FloatDim, IntDim, SearchDim
-
-TaskType = str
+from lizyml.core.types.task import TaskType
 
 # Maps task → objective
 _TASK_OBJECTIVE: dict[str, str] = {
@@ -44,7 +43,7 @@ _OBJECTIVE_CHOICES: dict[str, tuple[str, ...]] = {
 }
 
 
-def default_space(task: str) -> list[SearchDim]:
+def default_space(task: TaskType) -> list[SearchDim]:
     """Return the PLAN-specified default search space for LightGBM.
 
     Args:
@@ -75,7 +74,7 @@ def default_space(task: str) -> list[SearchDim]:
     return dims
 
 
-def default_fixed_params(task: str) -> dict[str, Any]:
+def default_fixed_params(task: TaskType) -> dict[str, Any]:
     """Return fixed parameters applied to every trial when using default space.
 
     Only model-level LightGBM parameters belong here.  Smart params

--- a/lizyml/estimators/lgbm/metric_bridge.py
+++ b/lizyml/estimators/lgbm/metric_bridge.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.metrics.base import BaseMetric
 from lizyml.metrics.registry import MetricEntry, get_metric, parse_metric_entries
 
@@ -32,7 +33,7 @@ _LIZYML_TO_LGBM: dict[str, dict[str, str]] = {
 }
 
 
-def translate_metric(name: str, task: str) -> str:
+def translate_metric(name: str, task: TaskType) -> str:
     """Translate a LizyML metric name to its LightGBM equivalent.
 
     If no mapping exists, returns the name unchanged.
@@ -127,7 +128,7 @@ _ALL_FEVAL_NAMES: frozenset[str] = frozenset().union(*_FEVAL_METRICS.values())
 
 def validate_lgbm_metrics(
     metrics: list[str],
-    task: str,
+    task: TaskType,
     *,
     feval_names: frozenset[str],
 ) -> None:
@@ -200,7 +201,7 @@ def _metric_display_name(metric: BaseMetric, kwargs: dict[str, Any]) -> str:
 
 def _build_feval(
     metric: BaseMetric,
-    task: str,
+    task: TaskType,
     num_class: int | None = None,
     *,
     display_name: str | None = None,
@@ -270,7 +271,7 @@ def _build_feval(
 
 def resolve_metrics(
     metrics: list[MetricEntry],
-    task: str,
+    task: TaskType,
     num_class: int | None = None,
 ) -> tuple[list[str], list[Callable[..., tuple[str, float, bool]]], list[str]]:
     """Split metrics into native LightGBM names and feval callables.

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -15,8 +15,9 @@ import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.search_dim import SearchDim
+from lizyml.core.types.task import TaskType
 from lizyml.estimators.base import BaseEstimatorAdapter
-from lizyml.estimators.lgbm.adapter import LGBMAdapter, TaskType
+from lizyml.estimators.lgbm.adapter import LGBMAdapter
 from lizyml.estimators.lgbm.defaults import (
     _COMMON_DEFAULTS,
     default_fixed_params,
@@ -61,7 +62,7 @@ class LGBMProvider:
         n_rows: int,
         feature_names: list[str],
         y: pd.Series,
-        task: str,
+        task: TaskType,
     ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
         """Resolve smart parameters to native LightGBM parameters.
 
@@ -90,7 +91,7 @@ class LGBMProvider:
 
     def build_estimator_factory(
         self,
-        task: str,
+        task: TaskType,
         params: dict[str, Any],
         n_classes: int | None,
         early_stopping_rounds: int | None,
@@ -98,11 +99,10 @@ class LGBMProvider:
     ) -> Callable[[], BaseEstimatorAdapter]:
         """Return a factory that creates a configured LGBMAdapter."""
         final_params = params
-        lgbm_task: TaskType = task  # type: ignore[assignment]
 
         def make_estimator() -> LGBMAdapter:
             return LGBMAdapter(
-                task=lgbm_task,
+                task=task,
                 params=final_params,
                 num_class=n_classes,
                 early_stopping_rounds=early_stopping_rounds,
@@ -115,11 +115,11 @@ class LGBMProvider:
         """Return a factory that creates NativeFeaturePipeline."""
         return NativeFeaturePipeline
 
-    def default_space(self, task: str) -> list[SearchDim]:
+    def default_space(self, task: TaskType) -> list[SearchDim]:
         """Return the default LightGBM search space."""
         return default_space(task)
 
-    def default_fixed_params(self, task: str) -> dict[str, Any]:
+    def default_fixed_params(self, task: TaskType) -> dict[str, Any]:
         """Return fixed params for default search space."""
         return default_fixed_params(task)
 

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.search_dim import SearchDim
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.estimators.lgbm.adapter import LGBMAdapter, TaskType
@@ -25,6 +26,7 @@ from lizyml.estimators.lgbm.smart_params import (
     resolve_ratio_params,
     resolve_smart_params,
 )
+from lizyml.estimators.provider import ExportParams
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 from lizyml.features.pipelines_native import NativeFeaturePipeline
 
@@ -186,3 +188,74 @@ class LGBMProvider:
             )
 
         return rows
+
+    def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
+        """Build codegen-relevant params from a fitted ``LGBMAdapter`` (H-0073).
+
+        Wraps the LGBM-private ``_build_params()`` and the feval metadata
+        extraction so that ``_model_persistence.py`` does not need to import
+        ``LGBMAdapter`` or call private methods.
+
+        Raises:
+            LizyMLError with ``UNSUPPORTED_TASK`` when the supplied adapter
+            is not an ``LGBMAdapter``.
+        """
+        if not isinstance(adapter, LGBMAdapter):
+            raise LizyMLError(
+                code=ErrorCode.UNSUPPORTED_TASK,
+                user_message=(
+                    "LGBMProvider.build_export_params() requires an "
+                    "LGBMAdapter instance."
+                ),
+                context={"adapter_type": type(adapter).__name__},
+            )
+        params, num_boost_round, _, _ = adapter._build_params()
+        feval_metadata = _extract_feval_metadata(adapter)
+        return ExportParams(
+            params=params,
+            num_boost_round=num_boost_round,
+            feval_metadata=feval_metadata,
+        )
+
+
+def _extract_feval_metadata(
+    adapter: LGBMAdapter,
+) -> list[dict[str, Any]]:
+    """Extract feval metric metadata from adapter params (H-0066/H-0073).
+
+    Reads the user-specified ``metric`` from the adapter's params dict,
+    identifies which are feval metrics (not LightGBM native), and returns
+    serializable metadata for each.
+
+    Moved from ``_model_persistence.py`` so that the persistence layer
+    no longer reaches into ``LGBMAdapter`` internals.
+    """
+    from lizyml.estimators.lgbm.metric_bridge import _FEVAL_METRICS
+    from lizyml.metrics.registry import get_metric, parse_metric_entries
+
+    user_metric = adapter.params.get("metric")
+    if not user_metric:
+        return []
+
+    if isinstance(user_metric, (str, dict)):
+        user_metric = [user_metric]
+    user_metric = [m for m in user_metric if m]
+    if not user_metric:
+        return []
+
+    feval_for_task = _FEVAL_METRICS.get(adapter.task, frozenset())
+    parsed = parse_metric_entries(user_metric)
+
+    result: list[dict[str, Any]] = []
+    for name, kwargs in parsed:
+        if name in feval_for_task:
+            metric_obj = get_metric(name, **kwargs)
+            result.append(
+                {
+                    "name": name,
+                    "params": kwargs,
+                    "greater_is_better": metric_obj.greater_is_better,
+                    "needs_proba": metric_obj.needs_proba,
+                }
+            )
+    return result

--- a/lizyml/estimators/lgbm/smart_params.py
+++ b/lizyml/estimators/lgbm/smart_params.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 
 def _compute_num_leaves(max_depth: int | None, ratio: float) -> int:
@@ -29,7 +30,7 @@ def resolve_smart_params(
     n_rows: int,
     feature_names: list[str],
     y: pd.Series,
-    task: str,
+    task: TaskType,
 ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
     """Resolve smart parameters to native LightGBM parameters.
 

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -17,6 +17,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.types.search_dim import SearchDim
+from lizyml.core.types.task import TaskType
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 
@@ -68,7 +69,7 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         n_rows: int,
         feature_names: list[str],
         y: pd.Series,
-        task: str,
+        task: TaskType,
     ) -> tuple[dict[str, Any], npt.NDArray[np.float64] | None]:
         """Resolve smart parameters to native estimator parameters.
 
@@ -89,7 +90,7 @@ class EstimatorProvider(Protocol):  # pragma: no cover
 
     def build_estimator_factory(
         self,
-        task: str,
+        task: TaskType,
         params: dict[str, Any],
         n_classes: int | None,
         early_stopping_rounds: int | None,
@@ -102,11 +103,11 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         """Return a zero-arg factory that creates the appropriate FeaturePipeline."""
         ...
 
-    def default_space(self, task: str) -> list[SearchDim]:
+    def default_space(self, task: TaskType) -> list[SearchDim]:
         """Return the default hyperparameter search space for this estimator."""
         ...
 
-    def default_fixed_params(self, task: str) -> dict[str, Any]:
+    def default_fixed_params(self, task: TaskType) -> dict[str, Any]:
         """Return fixed params applied to every trial when using default space."""
         ...
 

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -9,6 +9,7 @@ See BLUEPRINT §14.4 for the full specification.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import numpy as np
@@ -18,6 +19,28 @@ import pandas as pd
 from lizyml.core.types.search_dim import SearchDim
 from lizyml.estimators.base import BaseEstimatorAdapter
 from lizyml.features.pipeline_base import BaseFeaturePipeline
+
+
+@dataclass(frozen=True)
+class ExportParams:
+    """Codegen-relevant params extracted from a fitted estimator (H-0073).
+
+    Returned by :meth:`EstimatorProvider.build_export_params` so that
+    ``ModelPersistenceMixin.export_code()`` does not have to reach into
+    estimator-specific private methods.
+
+    Attributes:
+        params: Native model parameters (e.g. LightGBM Booster API names).
+        num_boost_round: Total training iterations actually used.
+        feval_metadata: User-specified ``feval`` metric descriptors needed
+            by the generated train.py to recompute custom metrics. Each
+            dict has ``name``, ``params``, ``greater_is_better``,
+            ``needs_proba``.
+    """
+
+    params: dict[str, Any]
+    num_boost_round: int
+    feval_metadata: list[dict[str, Any]] = field(default_factory=list)
 
 
 class EstimatorProvider(Protocol):  # pragma: no cover
@@ -105,5 +128,21 @@ class EstimatorProvider(Protocol):  # pragma: no cover
         Each row is ``{"parameter": str, "value": Any}``.
         Should include smart params and resolved native params.
         Per-fold best iterations are added by ``_model_tables.py``.
+        """
+        ...
+
+    def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
+        """Build codegen-relevant export parameters from a fitted adapter (H-0073).
+
+        Used by :class:`~lizyml.core._model_persistence.ModelPersistenceMixin`
+        to populate the codegen pipeline without importing estimator-specific
+        adapter classes. The returned :class:`ExportParams` carries native
+        booster params, the number of boosting rounds, and any ``feval``
+        metric metadata needed to regenerate custom metric callables in the
+        emitted ``train.py``.
+
+        Args:
+            adapter: The fitted estimator to export. The provider is
+                responsible for narrowing the adapter type internally.
         """
         ...

--- a/lizyml/evaluation/confusion.py
+++ b/lizyml/evaluation/confusion.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sklearn.metrics import confusion_matrix
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.training.oof_assembly import compute_oof_valid_mask
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ def confusion_matrix_table(
     y_true: npt.NDArray[Any],
     *,
     threshold: float = 0.5,
-    task: str,
+    task: TaskType,
 ) -> dict[str, pd.DataFrame]:
     """Compute IS and OOS confusion matrices.
 

--- a/lizyml/evaluation/evaluator.py
+++ b/lizyml/evaluation/evaluator.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.types.fit_result import FitResult
+from lizyml.core.types.task import TaskType
 from lizyml.metrics.base import BaseMetric
 from lizyml.metrics.registry import MetricEntry, get_metrics_for_task
 from lizyml.training.oof_assembly import compute_oof_valid_mask
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["Evaluator", "TaskType"]
 
 
 def _normalize_multiclass_proba(

--- a/lizyml/explain/shap_explainer.py
+++ b/lizyml/explain/shap_explainer.py
@@ -22,6 +22,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 if TYPE_CHECKING:
     from lizyml.estimators.base import BaseEstimatorAdapter
@@ -38,7 +39,7 @@ except ImportError:  # pragma: no cover
 def compute_shap_values(
     model: BaseEstimatorAdapter,
     X: pd.DataFrame,
-    task: str,
+    task: TaskType,
 ) -> npt.NDArray[np.float64]:
     """Compute SHAP values for *X* using *model*.
 
@@ -93,7 +94,7 @@ def compute_shap_importance(
     models: list[Any],
     X: pd.DataFrame,
     splits_outer: list[tuple[npt.NDArray[Any], npt.NDArray[Any]]],
-    task: str,
+    task: TaskType,
     feature_names: list[str],
     pipeline_state: Any,
     pipeline_factory: Callable[[], Any] | None = None,

--- a/lizyml/persistence/exporter.py
+++ b/lizyml/persistence/exporter.py
@@ -22,6 +22,7 @@ import joblib
 import pandas as pd
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -43,7 +44,7 @@ def export(
     fit_result: FitResult,
     refit_result: RefitResult,
     config: dict[str, Any],
-    task: str,
+    task: TaskType,
     *,
     analysis_context: AnalysisContext | None = None,
 ) -> None:

--- a/lizyml/plots/_theme.py
+++ b/lizyml/plots/_theme.py
@@ -58,5 +58,8 @@ def apply_default_layout(
         final_layout["height"] = DEFAULT_HEIGHT
     if "width" not in layout:
         final_layout["width"] = DEFAULT_WIDTH
+    # Only ``None`` is filtered out so plotly's auto-sizing kicks in for that
+    # key. Falsy-but-meaningful values (``0``, ``False``, ``""``) are valid
+    # plotly inputs and pass through untouched.
     final_layout.update({k: v for k, v in layout.items() if v is not None})
     fig.update_layout(**final_layout)

--- a/lizyml/plots/_theme.py
+++ b/lizyml/plots/_theme.py
@@ -1,0 +1,62 @@
+"""Common plot layout / theme helpers (#123).
+
+Centralises the ``fig.update_layout(...)`` call so a future theme change
+(template, brand colors, fonts, dark mode) can be made in one place rather
+than across every plot module.
+
+Public helper:
+
+    apply_default_layout(fig, *, title, **layout)
+
+Each plot module routes its layout call through this helper. Existing
+per-plot kwargs (``height``, ``width``, ``xaxis_title``, ``barmode`` ...)
+remain plot-specific data and are forwarded as ``**layout``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_TEMPLATE = "plotly"
+"""Plotly template applied to every LizyML plot. Centralised here to make
+future theme switches a one-line change."""
+
+DEFAULT_HEIGHT = 400
+"""Default height in pixels when a plot does not pick its own."""
+
+DEFAULT_WIDTH = 600
+"""Default width in pixels when a plot does not pick its own."""
+
+
+def apply_default_layout(
+    fig: Any,
+    *,
+    title: str,
+    **layout: Any,
+) -> None:
+    """Apply LizyML's default layout to ``fig`` in place.
+
+    Args:
+        fig: A plotly ``Figure`` (typed as ``Any`` so this module does not
+            require plotly at import time).
+        title: Figure title — required so every plot has one.
+        **layout: Forwarded to ``fig.update_layout``. Recognised keys
+            include ``height``, ``width``, ``xaxis_title``, ``yaxis_title``,
+            ``barmode``, ``margin``, etc. Unset ``height`` / ``width``
+            inherit ``DEFAULT_HEIGHT`` / ``DEFAULT_WIDTH``.
+
+    Notes:
+        Pass ``height=None`` / ``width=None`` explicitly to omit a default
+        (rare — only the multiclass OOF distribution and one residuals
+        sub-plot currently rely on plotly's auto-sizing).
+    """
+    final_layout: dict[str, Any] = {
+        "template": DEFAULT_TEMPLATE,
+        "title": title,
+    }
+    if "height" not in layout:
+        final_layout["height"] = DEFAULT_HEIGHT
+    if "width" not in layout:
+        final_layout["width"] = DEFAULT_WIDTH
+    final_layout.update({k: v for k, v in layout.items() if v is not None})
+    fig.update_layout(**final_layout)

--- a/lizyml/plots/calibration.py
+++ b/lizyml/plots/calibration.py
@@ -48,7 +48,7 @@ def _require_calibrator(fit_result: FitResult) -> Any:
                 "Calibration plots require calibration to be enabled. "
                 "Set calibration.method in the config."
             ),
-            context={},
+            context={"calibrator_type": type(fit_result.calibrator).__name__},
         )
     return fit_result.calibrator
 

--- a/lizyml/plots/calibration.py
+++ b/lizyml/plots/calibration.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -112,7 +113,8 @@ def plot_calibration_curve(
             line=dict(color="darkorange"),
         )
     )
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="Calibration Curve (Reliability Diagram)",
         xaxis_title="Mean Predicted Probability",
         yaxis_title="Fraction of Positives",
@@ -160,7 +162,8 @@ def plot_probability_histogram(fit_result: FitResult) -> Any:
             marker_color="darkorange",
         )
     )
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="Probability Histogram (Raw vs Calibrated)",
         xaxis_title="Predicted Probability",
         yaxis_title="Count",

--- a/lizyml/plots/classification.py
+++ b/lizyml/plots/classification.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 from sklearn.metrics import roc_auc_score, roc_curve
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
@@ -202,7 +203,7 @@ def plot_roc_curve(
     fit_result: FitResult,
     y_true: npt.NDArray[Any],
     *,
-    task: str,
+    task: TaskType,
 ) -> Any:
     """Plot ROC curve(s).
 

--- a/lizyml/plots/classification.py
+++ b/lizyml/plots/classification.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 from sklearn.metrics import roc_auc_score, roc_curve
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -103,7 +104,8 @@ def _plot_roc_binary(fit_result: FitResult, y_true: npt.NDArray[Any]) -> Any:
             showlegend=False,
         )
     )
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="ROC Curve (IS vs OOS)",
         xaxis_title="False Positive Rate",
         yaxis_title="True Positive Rate",
@@ -182,7 +184,8 @@ def _plot_roc_multiclass(fit_result: FitResult, y_true: npt.NDArray[Any]) -> Any
         fig.update_yaxes(title_text="True Positive Rate", row=1, col=col)
 
     macro_auc = float(roc_auc_score(y_bin, oof_pred, average="macro"))
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title=f"ROC Curves OvR (Macro AUC={macro_auc:.3f})",
         height=500,
         width=1000,

--- a/lizyml/plots/importance.py
+++ b/lizyml/plots/importance.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -49,7 +50,8 @@ def _render_bar_chart(
             orientation="h",
         )
     )
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title=title,
         xaxis_title="Importance",
         yaxis_title="Feature",

--- a/lizyml/plots/importance.py
+++ b/lizyml/plots/importance.py
@@ -87,7 +87,7 @@ def plot_importance(
         raise LizyMLError(
             code=ErrorCode.MODEL_NOT_FIT,
             user_message="No trained models found in FitResult.",
-            context={},
+            context={"plot": "importance", "kind": kind},
         )
 
     # Average importance across folds

--- a/lizyml/plots/learning_curve.py
+++ b/lizyml/plots/learning_curve.py
@@ -61,7 +61,7 @@ def plot_learning_curve(
         raise LizyMLError(
             code=ErrorCode.MODEL_NOT_FIT,
             user_message="No training history found in FitResult.",
-            context={},
+            context={"plot": "learning_curve", "n_history": 0},
         )
 
     # Gather eval_history entries; skip folds with empty history
@@ -86,7 +86,10 @@ def plot_learning_curve(
                 "No evaluation history found. "
                 "Enable early stopping to record validation metrics per fold."
             ),
-            context={},
+            context={
+                "plot": "learning_curve",
+                "n_folds": len(fit_result.history),
+            },
         )
 
     # Use first fold's keys as reference

--- a/lizyml/plots/learning_curve.py
+++ b/lizyml/plots/learning_curve.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -134,7 +135,8 @@ def plot_learning_curve(
         fig.update_xaxes(title_text="Iteration", row=1, col=col + 1)
         fig.update_yaxes(title_text="Loss", row=1, col=col + 1)
 
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="Learning Curve",
         height=400,
         width=500 * n_metrics,

--- a/lizyml/plots/oof_distribution.py
+++ b/lizyml/plots/oof_distribution.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -64,7 +65,8 @@ def plot_oof_distribution(fit_result: FitResult) -> Any:
                     nbinsx=30,
                 )
             )
-        fig.update_layout(
+        apply_default_layout(
+            fig,
             title="OOF Prediction Distribution (Multiclass)",
             xaxis_title="Predicted probability",
             yaxis_title="Count",
@@ -75,7 +77,8 @@ def plot_oof_distribution(fit_result: FitResult) -> Any:
         has_proba = bool(np.all((oof >= 0) & (oof <= 1)))
         xlabel = "Predicted probability" if has_proba else "Predicted value"
         fig.add_trace(_plotly.Histogram(x=oof, nbinsx=30))
-        fig.update_layout(
+        apply_default_layout(
+            fig,
             title="OOF Prediction Distribution",
             xaxis_title=xlabel,
             yaxis_title="Count",

--- a/lizyml/plots/residuals.py
+++ b/lizyml/plots/residuals.py
@@ -16,6 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
@@ -318,15 +319,19 @@ def plot_residuals(
     if kind == "scatter":
         fig = _plotly.Figure()
         _add_scatter_traces(fig, oof_pred, y_arr, is_pred_ds, is_actual_ds)
-        fig.update_layout(
-            title="Actual vs Predicted (IS vs OOS)", height=450, width=700
+        apply_default_layout(
+            fig,
+            title="Actual vs Predicted (IS vs OOS)",
+            height=450,
+            width=700,
         )
         return fig
 
     if kind == "histogram":
         fig = _plotly.Figure()
         _add_histogram_traces(fig, oos_resid, is_resid_ds, show_annotation=True)
-        fig.update_layout(
+        apply_default_layout(
+            fig,
             title="Residual Distribution (IS vs OOS)",
             barmode="overlay",
             height=400,
@@ -337,7 +342,7 @@ def plot_residuals(
     if kind == "qq":
         fig = _plotly.Figure()
         _add_qq_traces(fig, oos_resid)
-        fig.update_layout(title="QQ Plot (OOS)", height=450, width=500)
+        apply_default_layout(fig, title="QQ Plot (OOS)", height=450, width=500)
         return fig
 
     # kind == "all"
@@ -370,7 +375,8 @@ def plot_residuals(
         show_annotation=False,
     )
     _add_qq_traces(fig, oos_resid, row=1, col=3)
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="Residual Analysis",
         barmode="overlay",
         height=400,

--- a/lizyml/plots/tuning.py
+++ b/lizyml/plots/tuning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.plots._theme import apply_default_layout
 
 if TYPE_CHECKING:
     from lizyml.core.types.tuning_result import TuningResult
@@ -128,7 +129,8 @@ def plot_tuning_history(tuning_result: TuningResult) -> Any:
             )
             cumulative += rs.n_trials
 
-    fig.update_layout(
+    apply_default_layout(
+        fig,
         title="Tuning History",
         xaxis_title="Trial",
         yaxis_title=tuning_result.metric_name,

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -143,7 +143,10 @@ class GroupHoldoutInnerValid(BaseInnerValidStrategy):
                     "GroupHoldoutInnerValid requires groups to be provided. "
                     "Set data.group_col in the config."
                 ),
-                context={},
+                context={
+                    "n_samples": n_samples,
+                    "strategy": "GroupHoldoutInnerValid",
+                },
             )
         # Preserve input order of groups (np.unique sorts, so use dict.fromkeys)
         seen: dict[Any, None] = dict.fromkeys(groups.tolist())
@@ -286,7 +289,11 @@ class BlockedGroupInnerValid(BaseInnerValidStrategy):
                     "BlockedGroupInnerValid requires groups. "
                     "Set groups.col in the split config."
                 ),
-                context={},
+                context={
+                    "n_samples": n_samples,
+                    "strategy": "BlockedGroupInnerValid",
+                    "task": self.task,
+                },
             )
 
         # Preserve input order (= time order)

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -149,9 +149,11 @@ class GroupHoldoutInnerValid(BaseInnerValidStrategy):
         seen: dict[Any, None] = dict.fromkeys(groups.tolist())
         ordered_groups = list(seen.keys())
         n_valid_groups = max(1, int(len(ordered_groups) * self.ratio))
-        valid_groups = set(ordered_groups[-n_valid_groups:])
+        valid_groups = ordered_groups[-n_valid_groups:]
         all_idx = np.arange(n_samples, dtype=np.intp)
-        valid_mask = np.array([g in valid_groups for g in groups])
+        # Vectorised membership test (#116) — C implementation, ~5x+ faster
+        # than the previous Python comprehension on large datasets.
+        valid_mask = np.isin(groups, valid_groups)
         valid_idx = all_idx[valid_mask]
         train_idx = all_idx[~valid_mask]
         return train_idx, valid_idx
@@ -233,11 +235,13 @@ class StratifiedTimeHoldoutInnerValid(BaseInnerValidStrategy):
             n_valid = max(1, int(len(cls_idx) * self.ratio))
             valid_indices.extend(cls_idx[-n_valid:].tolist())
 
-        valid_set = set(valid_indices)
-        valid_idx = np.array(sorted(valid_set), dtype=np.intp)
-        train_idx = np.array(
-            [i for i in range(n_samples) if i not in valid_set], dtype=np.intp
-        )
+        # Vectorised mask construction (#116) — replaces an O(n) Python
+        # ``i not in valid_set`` filter with a single boolean array.
+        valid_mask = np.zeros(n_samples, dtype=bool)
+        valid_mask[np.asarray(valid_indices, dtype=np.intp)] = True
+        all_idx = np.arange(n_samples, dtype=np.intp)
+        valid_idx = all_idx[valid_mask]
+        train_idx = all_idx[~valid_mask]
         return train_idx, valid_idx
 
 
@@ -316,10 +320,9 @@ class BlockedGroupInnerValid(BaseInnerValidStrategy):
             n_valid = max(1, int(len(sorted_groups) * self.ratio))
             valid_groups = set(sorted_groups[-n_valid:])
 
-        # Build index arrays
-        valid_group_set = set(valid_groups)
+        # Build index arrays via vectorised membership (#116).
         all_idx = np.arange(n_samples, dtype=np.intp)
-        valid_mask = np.array([g in valid_group_set for g in groups.tolist()])
+        valid_mask = np.isin(groups, list(valid_groups))
         return all_idx[~valid_mask], all_idx[valid_mask]
 
     def _stratified_tail_groups(

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -10,6 +10,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.task import TaskType
 
 
 class BaseInnerValidStrategy(ABC):
@@ -270,7 +271,7 @@ class BlockedGroupInnerValid(BaseInnerValidStrategy):
 
     _MIN_GROUPS_FOR_ISOLATION = 4
 
-    def __init__(self, ratio: float = 0.1, task: str = "regression") -> None:
+    def __init__(self, ratio: float = 0.1, task: TaskType = "regression") -> None:
         if not 0.0 < ratio < 1.0:
             raise ValueError(f"ratio must be in (0, 1), got {ratio}")
         self.ratio = ratio

--- a/lizyml/training/inner_valid.py
+++ b/lizyml/training/inner_valid.py
@@ -215,7 +215,17 @@ class StratifiedTimeHoldoutInnerValid(BaseInnerValidStrategy):
         groups: npt.NDArray[Any] | None = None,
     ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
         if y is None:
-            return TimeHoldoutInnerValid(self.ratio).split(n_samples)
+            # Inline tail holdout (#124): avoids per-call construction of
+            # TimeHoldoutInnerValid, which is hot in tuning workloads.
+            n_valid = max(1, int(n_samples * self.ratio))
+            if n_valid >= n_samples:
+                raise ValueError(
+                    f"Inner validation would consume all {n_samples} sample(s) "
+                    f"(n_valid={n_valid}, ratio={self.ratio}). "
+                    "Increase training data or decrease validation_ratio."
+                )
+            all_idx = np.arange(n_samples, dtype=np.intp)
+            return all_idx[:-n_valid], all_idx[-n_valid:]
 
         valid_indices: list[int] = []
         for cls in np.unique(y):

--- a/lizyml/training/oof_assembly.py
+++ b/lizyml/training/oof_assembly.py
@@ -9,16 +9,18 @@ Assembly rules (leakage prevention):
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from lizyml.core.types.task import TaskType
+
 if TYPE_CHECKING:
     from lizyml.estimators.base import BaseEstimatorAdapter
 
-TaskType = Literal["regression", "binary", "multiclass"]
+__all__ = ["TaskType", "compute_oof_valid_mask", "init_oof"]
 
 
 def init_oof(

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -221,9 +221,19 @@ def _expand_range(
     *,
     log: bool,
 ) -> tuple[float, float]:
-    """Expand *low*/*high* asymmetrically toward *edge*."""
+    """Expand *low*/*high* asymmetrically toward *edge*.
+
+    Linear lower-edge expansion is clamped at 0.0 (#110): negative bounds are
+    physically meaningless for hyperparameters such as ``learning_rate`` and
+    crash downstream samplers. Log-scale expansion is already safe because
+    division by ``_LOG_EXPANSION_FACTOR`` cannot make a positive value cross
+    zero. ``IntDim`` retains its own ``max(1, ...)`` clamp at the call site.
+    """
     if edge == "lower":
-        new_low = low / _LOG_EXPANSION_FACTOR if log and low > 0 else low - (high - low)
+        if log and low > 0:
+            new_low = low / _LOG_EXPANSION_FACTOR
+        else:
+            new_low = max(0.0, low - (high - low))
         return new_low, high
     if edge == "upper":
         new_high = (

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -187,6 +187,11 @@ class Tuner:
                 try:
                     user_cb(info)
                 except Exception as exc:
+                    # stacklevel=1 (this site) is intentional: by the time
+                    # ``warnings.warn`` runs, ``user_cb`` has already raised
+                    # and unwound, so its frame is not on the stack. The
+                    # exception type+message in the warning text is the
+                    # actionable signal for the user (#117).
                     warnings.warn(
                         f"progress_callback raised an exception; ignoring. "
                         f"{type(exc).__name__}: {exc}",

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 import time
 import warnings
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from optuna.storages import BaseStorage
 from lizyml.core.types.tuning_result import (
     TrialResult,
     TuneProgressCallback,
@@ -68,7 +71,7 @@ class Tuner:
         seed: int = 42,
         *,
         progress_callback: TuneProgressCallback | None = None,
-        storage: str | Any | None = None,
+        storage: str | BaseStorage | None = None,
         study_name: str | None = None,
     ) -> None:
         if storage is not None and study_name is None:

--- a/lizyml/tuning/tuner.py
+++ b/lizyml/tuning/tuner.py
@@ -183,9 +183,10 @@ class Tuner:
                 )
                 try:
                     user_cb(info)
-                except Exception:
+                except Exception as exc:
                     warnings.warn(
-                        "progress_callback raised an exception; ignoring.",
+                        f"progress_callback raised an exception; ignoring. "
+                        f"{type(exc).__name__}: {exc}",
                         RuntimeWarning,
                         stacklevel=1,
                     )

--- a/tests/test_codegen/test_feval_codegen.py
+++ b/tests/test_codegen/test_feval_codegen.py
@@ -434,7 +434,7 @@ class TestTemplateFevalContent:
 
 
 class TestExtractFevalMetadata:
-    """Tests for _extract_feval_metadata in _model_persistence."""
+    """Tests for _extract_feval_metadata in lgbm.provider (moved in H-0073)."""
 
     def _make_adapter(
         self,
@@ -450,19 +450,19 @@ class TestExtractFevalMetadata:
         )
 
     def test_no_metric_returns_empty(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={})
         assert _extract_feval_metadata(adapter) == []
 
     def test_native_only_returns_empty(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "binary_logloss"]})
         assert _extract_feval_metadata(adapter) == []
 
     def test_feval_metric_extracted(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "f1"]})
         result = _extract_feval_metadata(adapter)
@@ -473,7 +473,7 @@ class TestExtractFevalMetadata:
         assert result[0]["params"] == {}
 
     def test_feval_with_params(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": [{"precision_at_k": {"k": 20}}]})
         result = _extract_feval_metadata(adapter)
@@ -484,7 +484,7 @@ class TestExtractFevalMetadata:
         assert result[0]["needs_proba"] is True
 
     def test_mixed_native_and_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": ["auc", "f1", "brier"]})
         result = _extract_feval_metadata(adapter)
@@ -494,7 +494,7 @@ class TestExtractFevalMetadata:
         assert "auc" not in names
 
     def test_regression_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(
             task="regression", params={"metric": ["rmse", "rmsle"]}
@@ -505,7 +505,7 @@ class TestExtractFevalMetadata:
         assert result[0]["greater_is_better"] is False
 
     def test_string_metric(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(params={"metric": "f1"})
         result = _extract_feval_metadata(adapter)
@@ -513,7 +513,7 @@ class TestExtractFevalMetadata:
         assert result[0]["name"] == "f1"
 
     def test_r2_regression_feval(self) -> None:
-        from lizyml.core._model_persistence import _extract_feval_metadata
+        from lizyml.estimators.lgbm.provider import _extract_feval_metadata
 
         adapter = self._make_adapter(
             task="regression", params={"metric": ["rmse", "r2"]}

--- a/tests/test_config/test_early_stopping_roundtrip.py
+++ b/tests/test_config/test_early_stopping_roundtrip.py
@@ -101,9 +101,10 @@ class TestExplicitFlagTracking:
     """
 
     def test_legacy_validation_ratio_keeps_auto_resolve(self) -> None:
-        cfg = EarlyStoppingConfig.model_validate(
-            {"enabled": True, "rounds": 50, "validation_ratio": 0.2}
-        )
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = EarlyStoppingConfig.model_validate(
+                {"enabled": True, "rounds": 50, "validation_ratio": 0.2}
+            )
         assert cfg.inner_valid is not None
         assert cfg.inner_valid.method == "holdout"
         assert cfg.inner_valid.ratio == 0.2

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -337,11 +337,87 @@ class TestValidationRatio:
                 }
             },
         }
-        cfg = load_config(raw)
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = load_config(raw)
         es = cfg.training.early_stopping
         assert es.inner_valid is not None
         assert es.inner_valid.ratio == pytest.approx(0.2)
         assert es.inner_valid.method == "holdout"
+
+    def test_validation_ratio_emits_deprecation_warning(self) -> None:
+        """Pure legacy ``validation_ratio`` input must emit a
+        ``DeprecationWarning`` so users have a signal to migrate (#111).
+
+        The warning must mention the field name and the replacement
+        ``inner_valid.ratio``.
+        """
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 50,
+                    "validation_ratio": 0.15,
+                }
+            },
+        }
+        with pytest.warns(DeprecationWarning) as records:
+            load_config(raw)
+        msgs = [str(rec.message) for rec in records]
+        relevant = [m for m in msgs if "validation_ratio" in m]
+        assert relevant, f"expected validation_ratio deprecation, got: {msgs}"
+        assert any("inner_valid" in m for m in relevant)
+
+    def test_inner_valid_only_emits_no_deprecation(self) -> None:
+        """Configs using the new ``inner_valid`` form must not emit any
+        deprecation warning (round-trip safety, #111)."""
+        import warnings
+
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 30,
+                    "inner_valid": {"method": "holdout", "ratio": 0.15},
+                }
+            },
+        }
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            load_config(raw)
+        vr_warnings = [r for r in records if "validation_ratio" in str(r.message)]
+        assert not vr_warnings, (
+            f"unexpected validation_ratio warning(s): "
+            f"{[str(r.message) for r in vr_warnings]}"
+        )
+
+    def test_validation_ratio_roundtrip_emits_no_deprecation(self) -> None:
+        """A round-trip dump (``inner_valid`` + ``validation_ratio`` both
+        present and consistent) must not emit a deprecation warning — the
+        ``validation_ratio`` value is the dump artifact of the computed field,
+        not user-authored legacy input (#111)."""
+        import warnings
+
+        raw = {
+            **_MINIMAL_CONFIG,
+            "training": {
+                "early_stopping": {
+                    "enabled": True,
+                    "rounds": 30,
+                    "inner_valid": {"method": "holdout", "ratio": 0.15},
+                    "validation_ratio": 0.15,
+                }
+            },
+        }
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            load_config(raw)
+        vr_warnings = [r for r in records if "validation_ratio" in str(r.message)]
+        assert not vr_warnings, (
+            f"unexpected validation_ratio warning on roundtrip: "
+            f"{[str(r.message) for r in vr_warnings]}"
+        )
 
     def test_validation_ratio_and_inner_valid_conflict_raises(self) -> None:
         """Both validation_ratio and inner_valid specified → CONFIG_INVALID."""

--- a/tests/test_core/test_deprecation_registry.py
+++ b/tests/test_core/test_deprecation_registry.py
@@ -1,0 +1,120 @@
+"""Lint-style regression test: deprecation warnings must name a removal version.
+
+See #120, #121, H-0076.
+
+Every ``warnings.warn(..., DeprecationWarning)`` and
+``warnings.warn(..., UserWarning)`` site that talks about deprecated config
+surfaces must include a ``Will be removed in vX.Y`` suffix so users know
+how urgently to migrate. The single source of truth is
+``docs/DEPRECATIONS.md``.
+
+This test scans the warning *messages* themselves (string literals) in
+``lizyml/`` rather than relying on grepping call sites, so multi-line
+messages and f-strings are covered. Sites that are deliberately not
+deprecation-related (no "deprecated" / "deprecat" / "will be removed"
+language) are skipped.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE_ROOT = Path(__file__).parent.parent.parent / "lizyml"
+_REMOVAL_PATTERN = re.compile(r"Will be removed in v\d+\.\d+")
+_DEPRECATION_KEYWORDS = ("deprecated", "deprecat", "will be removed")
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SOURCE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _is_warnings_warn(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "warn"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "warnings"
+    )
+
+
+def _flatten_string_arg(node: ast.expr) -> str | None:
+    """Return the literal text of a warning message arg, or None if dynamic.
+
+    Supports ``"a" "b"`` implicit-concat, ``"a" + "b"``, and constants only.
+    f-strings with non-constant parts are concatenated by their literal
+    fragments — good enough for our keyword + suffix detection.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):  # f-string
+        parts: list[str] = []
+        for v in node.values:
+            if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                parts.append(v.value)
+            else:
+                parts.append("?")  # placeholder for FormattedValue
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _flatten_string_arg(node.left)
+        right = _flatten_string_arg(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _scan_warning_messages() -> list[tuple[Path, int, str]]:
+    """Return (path, line, message) for every ``warnings.warn`` call site
+    whose first arg is a string literal we can resolve."""
+    found: list[tuple[Path, int, str]] = []
+    for path in _iter_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_warnings_warn(node):
+                continue
+            if not node.args:
+                continue
+            msg = _flatten_string_arg(node.args[0])
+            if msg is None:
+                continue
+            found.append((path, node.lineno, msg))
+    return found
+
+
+class TestDeprecationRegistry:
+    def test_source_root_exists(self) -> None:
+        assert _SOURCE_ROOT.is_dir(), f"missing source root: {_SOURCE_ROOT}"
+
+    def test_deprecations_doc_exists(self) -> None:
+        """The central registry referenced by warnings must be present."""
+        path = _SOURCE_ROOT.parent / "docs" / "DEPRECATIONS.md"
+        assert path.is_file(), f"missing {path}"
+
+    def test_every_deprecation_warning_names_a_removal_version(self) -> None:
+        """Each deprecation-flavoured ``warnings.warn`` must include
+        ``Will be removed in vX.Y``."""
+        offenders: list[str] = []
+        for path, lineno, msg in _scan_warning_messages():
+            lower = msg.lower()
+            if not any(kw in lower for kw in _DEPRECATION_KEYWORDS):
+                continue
+            if not _REMOVAL_PATTERN.search(msg):
+                rel = path.relative_to(_SOURCE_ROOT.parent)
+                offenders.append(
+                    f"{rel}:{lineno}: missing 'Will be removed in vX.Y'\n"
+                    f"  message preview: {msg[:120]!r}"
+                )
+        if offenders:
+            pytest.fail(
+                "Deprecation warning(s) missing removal target (H-0076 / "
+                "see docs/DEPRECATIONS.md):\n" + "\n".join(offenders)
+            )

--- a/tests/test_core/test_fit_state.py
+++ b/tests/test_core/test_fit_state.py
@@ -1,0 +1,132 @@
+"""Tests for ``FitState`` and ``Model._get_fit_state()`` (#112, H-0074).
+
+Phase 1 of the FitState rollout. Verifies:
+
+- ``FitState`` is a frozen dataclass.
+- ``Model._get_fit_state()`` returns a populated ``FitState`` after fit.
+- The error path raises ``LizyMLError(MODEL_NOT_FIT)`` before fit.
+- Mixin-style helpers can be unit-tested by constructing a ``FitState``
+  with mock components — no full Model fit required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lizyml import Model
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.fit_state import FitState
+from tests._helpers import make_config, make_regression_df
+
+
+class TestFitStateContract:
+    def test_is_frozen(self) -> None:
+        """Frozen dataclass — runtime mutation must fail."""
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        with pytest.raises((AttributeError, TypeError)):
+            state.fit_result = None  # type: ignore[misc]
+
+    def test_required_fields_populated_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        # Required fields
+        assert state.cfg is model._cfg
+        assert state.fit_result is not None
+        assert state.provider is not None
+        # Refit produced by default fit()
+        assert state.refit_result is not None
+        # Tuning was not called
+        assert state.tuning_result is None
+
+    def test_y_and_x_present_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        assert state.y is not None
+        assert state.X is not None
+
+    def test_metrics_populated_after_fit(self) -> None:
+        df = make_regression_df(n=80)
+        cfg = make_config("regression")
+        model = Model(cfg, data=df)
+        model.fit()
+        state = model._get_fit_state()
+        assert state.metrics is not None
+        assert "raw" in state.metrics
+
+
+class TestGetFitStatePreFit:
+    def test_raises_before_fit(self) -> None:
+        cfg = make_config("regression")
+        model = Model(cfg)
+        with pytest.raises(LizyMLError) as exc_info:
+            model._get_fit_state()
+        assert exc_info.value.code == ErrorCode.MODEL_NOT_FIT
+
+
+class TestFitStateForMixinUnitTest:
+    """Demonstrate that a downstream consumer can build a ``FitState`` with
+    mocks and exercise Mixin-style logic without running a full Model fit.
+
+    Phase 2 of H-0074 will migrate Mixin signatures to actually accept
+    ``state: FitState``. This test pins down the data-only nature of the
+    snapshot so the future migration is mechanical.
+    """
+
+    def test_mocked_state_is_constructible(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        # Mock minimal pieces for the dataclass — actual values are
+        # consumer-specific; we only assert constructibility + immutability.
+        class _Sentinel:
+            pass
+
+        state = FitState(
+            cfg=_Sentinel(),  # type: ignore[arg-type]
+            fit_result=_Sentinel(),  # type: ignore[arg-type]
+            refit_result=None,
+            tuning_result=None,
+            provider=_Sentinel(),  # type: ignore[arg-type]
+            metrics={"raw": {}},
+            y=None,
+            X=None,
+            run_dir=None,
+            output_dir=None,
+        )
+        assert state.metrics == {"raw": {}}
+        with pytest.raises((AttributeError, FrozenInstanceError)):
+            state.metrics = {"raw": {"new": 1}}  # type: ignore[misc, assignment]
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["cfg", "fit_result", "provider"],
+    )
+    def test_missing_required_field_raises_typerror(self, missing_field: str) -> None:
+        """Required positional/keyword fields cannot default — guarantees
+        Phase 2 mock builders catch missing pieces at construction time."""
+        kwargs: dict[str, Any] = {
+            "cfg": object(),
+            "fit_result": object(),
+            "refit_result": None,
+            "tuning_result": None,
+            "provider": object(),
+            "metrics": None,
+            "y": None,
+            "X": None,
+            "run_dir": None,
+            "output_dir": None,
+        }
+        kwargs.pop(missing_field)
+        with pytest.raises(TypeError):
+            FitState(**kwargs)  # type: ignore[arg-type]

--- a/tests/test_core/test_mixin_state_isolation.py
+++ b/tests/test_core/test_mixin_state_isolation.py
@@ -1,0 +1,190 @@
+"""H-0077 Phase 2: prove Mixin methods read state only from FitState / TuningState.
+
+These tests pin down the contract introduced by H-0077:
+
+- ``Model._get_tuning_state()`` returns a ``TuningState`` after ``tune()`` and
+  raises ``LizyMLError(MODEL_NOT_FIT)`` before.
+- Mixin source files (``_model_plots.py`` / ``_model_tables.py`` /
+  ``_model_persistence.py``) contain zero direct references to Model's
+  private attributes (``self._cfg``, ``self._y``, ``self._X``,
+  ``self._fit_result``, ``self._refit_result``, ``self._tuning_result``,
+  ``self._provider``, ``self._metrics``, ``self._run_dir``,
+  ``self._output_dir``). The single read path is ``self._get_fit_state()``
+  / ``self._get_tuning_state()``.
+- A Mixin method can be invoked with a synthetic ``FitState`` /
+  ``TuningState`` constructed from mocks — no full ``Model.fit()`` required.
+
+Together with ``tests/test_core/test_fit_state.py`` (Phase 1 contract) these
+tests block any future regression where Mixin code reaches into Model body
+state directly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from lizyml import Model
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.fit_state import TuningState
+from tests._helpers import make_config, make_regression_df
+
+# ---------------------------------------------------------------------------
+# TuningState contract
+# ---------------------------------------------------------------------------
+
+
+def _reg_config_with_tuning(n_trials: int = 3) -> dict[str, Any]:
+    cfg = make_config("regression")
+    cfg["tuning"] = {
+        "optuna": {
+            "params": {"n_trials": n_trials, "direction": "minimize"},
+            "space": {
+                "num_leaves": {"type": "int", "low": 8, "high": 32},
+                "learning_rate": {
+                    "type": "float",
+                    "low": 0.01,
+                    "high": 0.3,
+                    "log": True,
+                },
+            },
+        }
+    }
+    return cfg
+
+
+class TestTuningStateContract:
+    def test_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        m = Model(_reg_config_with_tuning(n_trials=2))
+        m.tune(data=make_regression_df(n=80))
+        state = m._get_tuning_state()
+        with pytest.raises((AttributeError, FrozenInstanceError)):
+            state.tuning_result = None  # type: ignore[misc, assignment]
+
+    def test_populated_after_tune(self) -> None:
+        m = Model(_reg_config_with_tuning(n_trials=2))
+        m.tune(data=make_regression_df(n=80))
+        state = m._get_tuning_state()
+        assert state.cfg is m._cfg
+        assert state.tuning_result is m._tuning_result
+
+    def test_raises_before_tune(self) -> None:
+        m = Model(make_config("regression"))
+        with pytest.raises(LizyMLError) as exc_info:
+            m._get_tuning_state()
+        assert exc_info.value.code == ErrorCode.MODEL_NOT_FIT
+
+    def test_works_before_fit_after_tune(self) -> None:
+        """tuning_table / tuning_plot / boundary_table must work in this state."""
+        m = Model(_reg_config_with_tuning(n_trials=2))
+        m.tune(data=make_regression_df(n=80))
+        # No m.fit() — TuningState must still be retrievable.
+        state = m._get_tuning_state()
+        assert state.tuning_result is not None
+
+    def test_mocked_state_is_constructible(self) -> None:
+        class _Sentinel:
+            pass
+
+        state = TuningState(
+            cfg=_Sentinel(),  # type: ignore[arg-type]
+            tuning_result=_Sentinel(),  # type: ignore[arg-type]
+        )
+        assert state.tuning_result is not None
+
+
+# ---------------------------------------------------------------------------
+# Static guard: Mixin source files must not access self._<private>
+# ---------------------------------------------------------------------------
+
+
+_MIXIN_FILES = [
+    Path("lizyml/core/_model_plots.py"),
+    Path("lizyml/core/_model_tables.py"),
+    Path("lizyml/core/_model_persistence.py"),
+]
+
+# Attributes that live on the Model body and were leaking into Mixins
+# before H-0077 (Phase 2). The migration replaces every direct access
+# with state.<attr>.
+_FORBIDDEN_ATTRS = (
+    "cfg",
+    "y",
+    "X",
+    "fit_result",
+    "refit_result",
+    "tuning_result",
+    "provider",
+    "metrics",
+    "run_dir",
+    "output_dir",
+)
+
+
+class TestMixinPrivateAccessGuard:
+    @pytest.mark.parametrize("mixin_path", _MIXIN_FILES, ids=lambda p: p.name)
+    def test_no_self_dot_underscore_private_access(self, mixin_path: Path) -> None:
+        text = mixin_path.read_text()
+        # Strip the TYPE_CHECKING block; the stubs there exist only for type
+        # checkers and do not constitute runtime access.
+        text_runtime = re.sub(
+            r"if TYPE_CHECKING:\s*\n(?: {4,}.*\n)+",
+            "",
+            text,
+        )
+        pattern = re.compile(r"self\._(" + "|".join(_FORBIDDEN_ATTRS) + r")\b")
+        offenders = pattern.findall(text_runtime)
+        assert not offenders, (
+            f"{mixin_path} still has direct self._* access for: "
+            f"{sorted(set(offenders))}. "
+            "After H-0077 Phase 2, Mixins must read state via "
+            "_get_fit_state() / _get_tuning_state() only."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour-level smoke: Mixin methods still work end-to-end after migration
+# ---------------------------------------------------------------------------
+
+
+class TestMixinMethodsAfterMigration:
+    """Sanity checks that the Mixin methods still operate correctly when
+    reading from FitState / TuningState. Existing per-method tests cover
+    detailed behaviour; these guard against catastrophic regression
+    introduced by the migration itself."""
+
+    def test_residuals_via_state(self) -> None:
+        m = Model(make_config("regression"), data=make_regression_df(n=80))
+        m.fit()
+        residuals = m.residuals()
+        assert residuals.shape[0] > 0
+
+    def test_evaluate_table_via_state(self) -> None:
+        m = Model(make_config("regression"), data=make_regression_df(n=80))
+        m.fit()
+        table = m.evaluate_table()
+        assert isinstance(table, pd.DataFrame)
+        assert not table.empty
+
+    def test_tuning_table_after_tune_only(self) -> None:
+        """tuning_table must still work after tune() with no fit() — guards
+        against the FitState single-entry-point regression."""
+        m = Model(_reg_config_with_tuning(n_trials=2))
+        m.tune(data=make_regression_df(n=80))
+        table = m.tuning_table()
+        assert isinstance(table, pd.DataFrame)
+        assert len(table) == 2
+
+    def test_export_uses_facade_resolve_path(self, tmp_path: Path) -> None:
+        """`_resolve_export_path` lives on Model facade after H-0077."""
+        m = Model(make_config("regression"), data=make_regression_df(n=80))
+        m.fit()
+        out = m.export(tmp_path / "exp")
+        assert out.exists()
+        assert (out / "metadata.json").exists()

--- a/tests/test_core/test_no_empty_context.py
+++ b/tests/test_core/test_no_empty_context.py
@@ -1,27 +1,83 @@
-"""Lint-style regression test: forbid bare ``context={}`` in production code (#118).
+"""Lint-style regression tests for ``LizyMLError(context=...)`` quality (#118).
 
-The rule:
-    Every ``LizyMLError(...)`` must include at least one diagnostic key in
-    ``context``. Empty dicts strip the user of useful debugging info — see
-    the project rule \"Never swallow errors silently\".
+Two rules are enforced over ``lizyml/``:
 
-This test scans ``lizyml/`` for the literal ``context={}`` and fails if any
-sites are found. Tests and SKILL.md examples are exempt.
+1. **No literal ``context={}``**. Empty dicts strip the user of useful
+   debugging info — see the project rule "Never swallow errors silently".
+2. **No all-``None`` ``context``** (e.g. ``context={"x": None, "y": None}``).
+   A dict with only ``None`` values carries the same information as an empty
+   one — the keys exist but every value was missing at the time the error
+   was raised.
+
+Both rules use AST parsing so they correctly handle multi-line context
+dicts and miss-spaced literals that a naive regex would skip.
 """
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 import pytest
 
 _SOURCE_ROOT = Path(__file__).parent.parent.parent / "lizyml"
-_PATTERN = re.compile(r"context\s*=\s*\{\s*\}")
 
 
 def _iter_python_files() -> list[Path]:
     return [p for p in _SOURCE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def _is_lizyml_error_call(node: ast.AST) -> bool:
+    """Return True if *node* is a call expression whose callable is
+    ``LizyMLError`` (or anything ending with ``.LizyMLError``)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "LizyMLError":
+        return True
+    return isinstance(func, ast.Attribute) and func.attr == "LizyMLError"
+
+
+def _extract_context_kwarg(call: ast.Call) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == "context":
+            return kw.value
+    return None
+
+
+def _is_all_none_dict(node: ast.expr) -> bool:
+    """Return True if *node* is a dict literal whose every value is the
+    literal ``None``. Empty dicts return False here (handled separately)."""
+    if not isinstance(node, ast.Dict):
+        return False
+    if not node.values:
+        return False
+    return all(isinstance(v, ast.Constant) and v.value is None for v in node.values)
+
+
+def _is_empty_dict(node: ast.expr) -> bool:
+    return isinstance(node, ast.Dict) and not node.values
+
+
+def _scan(predicate: object) -> list[str]:
+    """Walk every production file and collect `path:line: snippet` for every
+    ``LizyMLError(context=…)`` whose context expression matches *predicate*."""
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - parse errors caught elsewhere
+            continue
+        for node in ast.walk(tree):
+            if not _is_lizyml_error_call(node):
+                continue
+            ctx = _extract_context_kwarg(node)
+            if ctx is None:
+                continue
+            if predicate(ctx):  # type: ignore[operator]
+                rel = path.relative_to(_SOURCE_ROOT.parent)
+                offenders.append(f"{rel}:{node.lineno}")
+    return offenders
 
 
 class TestNoEmptyContext:
@@ -31,17 +87,22 @@ class TestNoEmptyContext:
 
     def test_no_empty_context_in_production(self) -> None:
         """Every ``LizyMLError`` must carry a non-empty ``context``."""
-        offenders: list[str] = []
-        for path in _iter_python_files():
-            text = path.read_text(encoding="utf-8")
-            for lineno, line in enumerate(text.splitlines(), start=1):
-                if _PATTERN.search(line):
-                    rel = path.relative_to(_SOURCE_ROOT.parent)
-                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
-
+        offenders = _scan(_is_empty_dict)
         if offenders:
             pytest.fail(
                 "Empty context={} found in production code (#118 rule). "
                 "Every LizyMLError must include at least one diagnostic key:\n"
+                + "\n".join(offenders)
+            )
+
+    def test_no_all_none_context_in_production(self) -> None:
+        """``context={"x": None}`` is information-equivalent to ``{}`` and is
+        forbidden too. At least one value must be non-``None`` (a literal
+        ``None`` is fine when it is one of multiple keys)."""
+        offenders = _scan(_is_all_none_dict)
+        if offenders:
+            pytest.fail(
+                "All-None context found in production code (#118 rule). "
+                "Provide at least one non-None diagnostic value:\n"
                 + "\n".join(offenders)
             )

--- a/tests/test_core/test_no_empty_context.py
+++ b/tests/test_core/test_no_empty_context.py
@@ -1,0 +1,47 @@
+"""Lint-style regression test: forbid bare ``context={}`` in production code (#118).
+
+The rule:
+    Every ``LizyMLError(...)`` must include at least one diagnostic key in
+    ``context``. Empty dicts strip the user of useful debugging info — see
+    the project rule \"Never swallow errors silently\".
+
+This test scans ``lizyml/`` for the literal ``context={}`` and fails if any
+sites are found. Tests and SKILL.md examples are exempt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SOURCE_ROOT = Path(__file__).parent.parent.parent / "lizyml"
+_PATTERN = re.compile(r"context\s*=\s*\{\s*\}")
+
+
+def _iter_python_files() -> list[Path]:
+    return [p for p in _SOURCE_ROOT.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+class TestNoEmptyContext:
+    def test_source_root_exists(self) -> None:
+        """Sanity: the scan target must exist."""
+        assert _SOURCE_ROOT.is_dir(), f"missing source root: {_SOURCE_ROOT}"
+
+    def test_no_empty_context_in_production(self) -> None:
+        """Every ``LizyMLError`` must carry a non-empty ``context``."""
+        offenders: list[str] = []
+        for path in _iter_python_files():
+            text = path.read_text(encoding="utf-8")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if _PATTERN.search(line):
+                    rel = path.relative_to(_SOURCE_ROOT.parent)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+        if offenders:
+            pytest.fail(
+                "Empty context={} found in production code (#118 rule). "
+                "Every LizyMLError must include at least one diagnostic key:\n"
+                + "\n".join(offenders)
+            )

--- a/tests/test_core/test_splitter_dispatch.py
+++ b/tests/test_core/test_splitter_dispatch.py
@@ -1,0 +1,37 @@
+"""Regression tests for splitter dispatch fallback (#119).
+
+The dispatch in ``_build_splitter_for_method`` previously ended with a silent
+``KFoldSplitter`` fallback for unmatched ``SplitConfig`` variants. Adding a
+new variant without updating the dispatch would have silently produced KFold
+splits instead of failing loudly. The fallback now raises ``LizyMLError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizyml.core._model_factories import _build_splitter_for_method
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+
+
+class _UnknownSplitConfig:
+    """Sentinel object that does not match any recognised ``SplitConfig``
+    isinstance check, simulating a future variant added without updating
+    the dispatch."""
+
+
+class TestUnhandledSplitConfigRaises:
+    def test_unknown_split_config_raises_lizyml_error(self) -> None:
+        unknown = _UnknownSplitConfig()
+        with pytest.raises(LizyMLError) as exc_info:
+            _build_splitter_for_method(unknown, n_splits=5)  # type: ignore[arg-type]
+        assert exc_info.value.code == ErrorCode.CONFIG_INVALID
+
+    def test_error_message_names_the_unhandled_type(self) -> None:
+        unknown = _UnknownSplitConfig()
+        with pytest.raises(LizyMLError) as exc_info:
+            _build_splitter_for_method(unknown, n_splits=5)  # type: ignore[arg-type]
+        # The message and context must surface the unhandled config type
+        # so contributors get a clear signal.
+        assert "_UnknownSplitConfig" in exc_info.value.user_message
+        assert exc_info.value.context.get("split_config_type") == "_UnknownSplitConfig"

--- a/tests/test_core/test_task_type.py
+++ b/tests/test_core/test_task_type.py
@@ -1,0 +1,58 @@
+"""Tests for the canonical ``TaskType`` Literal (#122, H-0075).
+
+Pin down two contracts:
+
+1. The runtime values match the public Config schema and BLUEPRINT §7.1.
+2. Every layer that re-exports ``TaskType`` resolves to the same Literal
+   (no silent drift between modules).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizyml.core.types.task import TASK_TYPES, TaskType
+
+
+class TestTaskTypeContract:
+    def test_known_values(self) -> None:
+        assert set(TASK_TYPES) == {"regression", "binary", "multiclass"}
+
+    def test_task_types_is_tuple(self) -> None:
+        """``TASK_TYPES`` is iterable and ordered for parametrize use."""
+        assert isinstance(TASK_TYPES, tuple)
+        assert len(TASK_TYPES) == 3
+
+    @pytest.mark.parametrize("task", TASK_TYPES)
+    def test_each_value_round_trips(self, task: TaskType) -> None:
+        assert task in TASK_TYPES
+
+
+class TestTaskTypeReExports:
+    """Every layer that historically defined its own ``TaskType`` Literal
+    must now resolve to the same alias."""
+
+    def test_target_encoder_re_export(self) -> None:
+        from lizyml.core.types.target_encoder import TaskType as TET
+
+        assert TET is TaskType
+
+    def test_evaluator_re_export(self) -> None:
+        from lizyml.evaluation.evaluator import TaskType as EvalT
+
+        assert EvalT is TaskType
+
+    def test_oof_assembly_re_export(self) -> None:
+        from lizyml.training.oof_assembly import TaskType as OOFTaskType
+
+        assert OOFTaskType is TaskType
+
+    def test_lgbm_adapter_re_export(self) -> None:
+        from lizyml.estimators.lgbm.adapter import TaskType as LGBMT
+
+        assert LGBMT is TaskType
+
+    def test_lgbm_defaults_uses_canonical_alias(self) -> None:
+        from lizyml.estimators.lgbm.defaults import TaskType as DefT
+
+        assert DefT is TaskType

--- a/tests/test_estimators/test_check_provider.py
+++ b/tests/test_estimators/test_check_provider.py
@@ -118,6 +118,26 @@ class TestProtocolReturnTypes:
     @pytest.mark.parametrize(
         "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
     )
+    def test_build_export_params_returns_export_params(
+        self, provider_name: str, provider: Any
+    ) -> None:
+        """``build_export_params`` returns a populated ``ExportParams``.
+
+        See #109 / H-0073.
+        """
+        from lizyml.estimators.provider import ExportParams
+
+        X, y = _make_data("binary")
+        adapter = _build_and_fit(provider, "binary", X, y)
+        export = provider.build_export_params(adapter)
+        assert isinstance(export, ExportParams)
+        assert isinstance(export.params, dict)
+        assert export.num_boost_round > 0
+        assert isinstance(export.feval_metadata, list)
+
+    @pytest.mark.parametrize(
+        "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
+    )
     @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])
     def test_default_space_returns_search_dims(
         self, provider_name: str, provider: Any, task: str

--- a/tests/test_plots/test_theme.py
+++ b/tests/test_plots/test_theme.py
@@ -1,0 +1,103 @@
+"""Tests for the centralised plot theme helper (#123).
+
+The helper exists so future theme changes (template, brand colors, fonts)
+can be made in one place. These tests pin down the contract:
+
+- ``apply_default_layout`` calls ``fig.update_layout`` with the requested
+  title and forwards arbitrary kwargs.
+- Default ``height`` / ``width`` are applied when not provided.
+- A central ``DEFAULT_TEMPLATE`` is propagated to every plot.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lizyml.plots._theme import (
+    DEFAULT_HEIGHT,
+    DEFAULT_TEMPLATE,
+    DEFAULT_WIDTH,
+    apply_default_layout,
+)
+
+
+class _FigureSpy:
+    """Minimal stub that records ``update_layout`` calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def update_layout(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+class TestApplyDefaultLayout:
+    def test_title_is_required_and_forwarded(self) -> None:
+        fig = _FigureSpy()
+        apply_default_layout(fig, title="My Plot")
+        assert len(fig.calls) == 1
+        assert fig.calls[0]["title"] == "My Plot"
+
+    def test_default_template_is_applied(self) -> None:
+        fig = _FigureSpy()
+        apply_default_layout(fig, title="x")
+        assert fig.calls[0]["template"] == DEFAULT_TEMPLATE
+
+    def test_default_height_and_width_when_unset(self) -> None:
+        fig = _FigureSpy()
+        apply_default_layout(fig, title="x")
+        assert fig.calls[0]["height"] == DEFAULT_HEIGHT
+        assert fig.calls[0]["width"] == DEFAULT_WIDTH
+
+    def test_explicit_height_and_width_override_defaults(self) -> None:
+        fig = _FigureSpy()
+        apply_default_layout(fig, title="x", height=900, width=1200)
+        assert fig.calls[0]["height"] == 900
+        assert fig.calls[0]["width"] == 1200
+
+    def test_extra_layout_forwarded(self) -> None:
+        fig = _FigureSpy()
+        apply_default_layout(
+            fig,
+            title="x",
+            xaxis_title="t",
+            yaxis_title="y",
+            barmode="overlay",
+            margin={"l": 200},
+        )
+        call = fig.calls[0]
+        assert call["xaxis_title"] == "t"
+        assert call["yaxis_title"] == "y"
+        assert call["barmode"] == "overlay"
+        assert call["margin"] == {"l": 200}
+
+    def test_none_values_dropped_to_use_plotly_default(self) -> None:
+        """Passing ``None`` for an optional dim signals 'let plotly decide';
+        the helper must not forward it (so plotly's auto-sizing kicks in)."""
+        fig = _FigureSpy()
+        apply_default_layout(fig, title="x", height=None, width=None)
+        call = fig.calls[0]
+        assert "height" not in call
+        assert "width" not in call
+
+
+class TestThemeAppliedToAllPlots:
+    """Smoke test: every plot module imports and uses the helper."""
+
+    def test_every_plot_module_imports_apply_default_layout(self) -> None:
+        import importlib
+
+        modules = [
+            "lizyml.plots.calibration",
+            "lizyml.plots.classification",
+            "lizyml.plots.importance",
+            "lizyml.plots.learning_curve",
+            "lizyml.plots.oof_distribution",
+            "lizyml.plots.residuals",
+            "lizyml.plots.tuning",
+        ]
+        for name in modules:
+            mod = importlib.import_module(name)
+            assert hasattr(mod, "apply_default_layout"), (
+                f"{name} must import apply_default_layout for theme consistency"
+            )

--- a/tests/test_training/test_blocked_group_inner_valid.py
+++ b/tests/test_training/test_blocked_group_inner_valid.py
@@ -211,6 +211,16 @@ class TestStratifiedTimeHoldout:
         # Last 20% = 2 rows
         np.testing.assert_array_equal(valid_idx, np.array([8, 9]))
 
+    def test_regression_fallback_raises_when_ratio_consumes_all(self) -> None:
+        """Inline fallback (#124) must reject configurations that would
+        consume the entire training set, matching the pre-refactor contract
+        of ``TimeHoldoutInnerValid``. The trip wire fires for n_samples=1
+        because ``max(1, int(1*r))`` is always 1, leaving zero training rows.
+        """
+        strategy = StratifiedTimeHoldoutInnerValid(ratio=0.5)
+        with pytest.raises(ValueError, match="would consume all"):
+            strategy.split(1, y=None)
+
     def test_complete_coverage(self) -> None:
         y = np.array([0, 1, 0, 1, 0, 1])
         strategy = StratifiedTimeHoldoutInnerValid(ratio=0.3)

--- a/tests/test_training/test_inner_valid_extensions.py
+++ b/tests/test_training/test_inner_valid_extensions.py
@@ -218,7 +218,8 @@ class TestExplicitOverride:
                 }
             },
         }
-        cfg = load_config(raw)
+        with pytest.warns(DeprecationWarning, match="validation_ratio"):
+            cfg = load_config(raw)
         iv = build_inner_valid(cfg)
         assert isinstance(iv, HoldoutInnerValid)
         assert iv.ratio == 0.2

--- a/tests/test_training/test_inner_valid_vectorized.py
+++ b/tests/test_training/test_inner_valid_vectorized.py
@@ -1,0 +1,89 @@
+"""Behavioral tests for the numpy-vectorised inner-valid splits (#116).
+
+The refactor replaced three O(n) Python loops in ``inner_valid.py`` with
+``np.isin`` / boolean-mask equivalents. These tests pin down the
+behavioural contract on larger inputs where the speedup is visible — they
+do *not* benchmark, but they ensure the vectorised paths produce the same
+result as the slow reference implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lizyml.training.inner_valid import (
+    BlockedGroupInnerValid,
+    GroupHoldoutInnerValid,
+    StratifiedTimeHoldoutInnerValid,
+)
+
+
+def _reference_group_mask(groups: np.ndarray, valid_groups: set) -> np.ndarray:
+    """Slow Python reference for the membership mask."""
+    return np.array([g in valid_groups for g in groups])
+
+
+class TestGroupHoldoutVectorized:
+    def test_large_groups_match_reference(self) -> None:
+        rng = np.random.default_rng(42)
+        n = 5_000
+        n_groups = 100
+        groups = rng.integers(0, n_groups, size=n)
+
+        iv = GroupHoldoutInnerValid(ratio=0.2, random_state=0)
+        train_idx, valid_idx = iv.split(n, groups=groups)
+
+        # Sanity: no overlap, full coverage
+        assert len(set(train_idx) & set(valid_idx)) == 0
+        assert len(train_idx) + len(valid_idx) == n
+        # Group isolation
+        assert not (set(groups[train_idx]) & set(groups[valid_idx]))
+
+
+class TestStratifiedTimeHoldoutVectorized:
+    def test_large_n_matches_reference(self) -> None:
+        rng = np.random.default_rng(42)
+        n = 10_000
+        y = rng.integers(0, 3, size=n)
+
+        iv = StratifiedTimeHoldoutInnerValid(ratio=0.1)
+        train_idx, valid_idx = iv.split(n, y=y)
+
+        # No overlap, full coverage
+        assert len(set(train_idx) & set(valid_idx)) == 0
+        assert len(train_idx) + len(valid_idx) == n
+        # Each class appears in valid
+        assert set(y[valid_idx]) == {0, 1, 2}
+        # train + valid == range(n)
+        np.testing.assert_array_equal(
+            np.sort(np.concatenate([train_idx, valid_idx])),
+            np.arange(n),
+        )
+
+    def test_dtype_is_intp(self) -> None:
+        y = np.array([0, 1, 0, 1, 0, 1])
+        iv = StratifiedTimeHoldoutInnerValid(ratio=0.4)
+        train_idx, valid_idx = iv.split(len(y), y=y)
+        assert train_idx.dtype == np.intp
+        assert valid_idx.dtype == np.intp
+
+
+class TestBlockedGroupVectorized:
+    @pytest.mark.parametrize("task", ["regression", "binary"])
+    def test_large_groups_match_reference(self, task: str) -> None:
+        rng = np.random.default_rng(42)
+        n = 4_000
+        n_groups = 200
+        groups = np.repeat(np.arange(n_groups), n // n_groups)
+        # Time-ordered: groups appear in ascending order
+        y = rng.integers(0, 2, size=n)
+
+        iv = BlockedGroupInnerValid(ratio=0.1, task=task)
+        train_idx, valid_idx = iv.split(n, y=y, groups=groups)
+
+        # No overlap, full coverage
+        assert len(set(train_idx) & set(valid_idx)) == 0
+        assert len(train_idx) + len(valid_idx) == n
+        # Group isolation
+        assert not (set(groups[train_idx]) & set(groups[valid_idx]))

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -174,6 +174,32 @@ class TestExpandDims:
         new = expand_dims(dims, report)
         assert new[0] is dims[0]  # same object, untouched
 
+    def test_float_dim_linear_lower_clamped_to_zero(self) -> None:
+        """Regression for #110: linear FloatDim expansion must not produce
+        negative lower bounds, otherwise downstream samplers (e.g. LightGBM
+        learning_rate) crash on physically-impossible negative values.
+        """
+        dims = [FloatDim("learning_rate", low=0.001, high=0.1, log=False)]
+        report = detect_boundary(dims, {"learning_rate": 0.001}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], FloatDim)
+        assert new[0].low >= 0.0, (
+            f"FloatDim.low must not be negative after expansion, got {new[0].low}"
+        )
+        assert new[0].high == 0.1  # upper unchanged
+
+    def test_float_dim_linear_lower_clamp_preserves_already_safe_values(
+        self,
+    ) -> None:
+        """Linear expansion that produces a non-negative low must not be
+        clamped (no over-correction)."""
+        dims = [FloatDim("ratio", low=0.5, high=1.0, log=False)]
+        report = detect_boundary(dims, {"ratio": 0.51}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.5 - (1.0 - 0.5) = 0.0, exactly the floor — should pass through
+        assert new[0].low == 0.0
+        assert new[0].high == 1.0
+
 
 # ---------------------------------------------------------------------------
 # Type extension tests

--- a/tests/test_tuning/test_tuning_progress.py
+++ b/tests/test_tuning/test_tuning_progress.py
@@ -206,3 +206,28 @@ class TestProgressCallbackIntegration:
 
         assert call_count == 3
         assert result.best_params is not None
+
+    def test_callback_exception_warning_includes_details(self) -> None:
+        """Warning emitted from a failing callback must surface exception
+        type and message so users can debug their own callback (#117).
+        """
+
+        def bad_callback(info: TuneProgressInfo) -> None:
+            raise ValueError("intentional error in callback")
+
+        df = make_regression_df(n=200)
+        cfg = _reg_config_with_tuning(n_trials=2)
+        model = Model(cfg, data=df)
+
+        with pytest.warns(RuntimeWarning) as records:
+            model.tune(progress_callback=bad_callback)
+
+        callback_warnings = [
+            str(rec.message)
+            for rec in records
+            if "progress_callback" in str(rec.message)
+        ]
+        assert callback_warnings, "expected at least one progress_callback warning"
+        for msg in callback_warnings:
+            assert "ValueError" in msg
+            assert "intentional error in callback" in msg


### PR DESCRIPTION
## Summary
### Added

- **`EstimatorProvider.build_export_params()`** (H-0073, [#109](https://github.com/nbx-liz/LizyML/issues/109), [#126](https://github.com/nbx-liz/LizyML/issues/126)) — codegen-relevant booster params and feval metadata are now retrieved through the `EstimatorProvider` Protocol, so `Model.export_code()` is fully estimator-agnostic. Adding a new estimator no longer requires editing `lizyml/core/_model_persistence.py`. The new method also unifies `BlockedGroupKFold` `n_splits` resolution between persistence and factories.
- **`FitState` / `TuningState` frozen dataclasses + `Model._get_fit_state()` / `_get_tuning_state()`** (H-0074 Phase 1 + H-0077 Phase 2, [#112](https://github.com/nbx-liz/LizyML/issues/112)) — `ModelPlotsMixin` / `ModelTablesMixin` / `ModelPersistenceMixin` now read state exclusively through these snapshots. Direct `self._<private>` access is forbidden inside Mixin bodies and enforced by a static guard test (`tests/test_core/test_mixin_state_isolation.py`). Mixins become unit-testable with synthetic state. Public API unchanged.
- **`docs/DEPRECATIONS.md` central deprecation registry** (H-0076, [#120](https://github.com/nbx-liz/LizyML/issues/120), [#121](https://github.com/nbx-liz/LizyML/issues/121)) — single source of truth for every deprecated public surface and its removal target version. Every `DeprecationWarning` LizyML raises now contains "Will be removed in vX.Y." (currently "v1.0"); `tests/test_core/test_deprecation_registry.py` enforces this contract in CI.

### Changed

- **`TaskType` Literal centralised + propagated to all dispatch sites** (H-0075, [#122](https://github.com/nbx-liz/LizyML/issues/122)) — `lizyml/core/types/task.py` exposes `TaskType = Literal["regression", "binary", "multiclass"]`. Every branch on task now uses an exhaustive dispatch table, eliminating string-comparison divergence between modules. Public API unchanged; internal type-safety only.
- **`DeprecationWarning` messages now state the removal target version** (H-0076) — users see "Will be removed in v1.0." in every deprecation message so migration deadlines are explicit.
- **Inner-valid membership checks vectorised with numpy** (H-0065 follow-up, [#135](https://github.com/nbx-liz/LizyML/issues/135)) — measurable speedup on large CV folds; behaviour unchanged.
- **`Model.tune()` decomposed into 5 testable helpers** (H-0040 follow-up, [#114](https://github.com/nbx-liz/LizyML/issues/114)) — orchestrator + per-step helpers, no behaviour change.
- **`LizyMLError.context` enriched at 23 sites** ([#118](https://github.com/nbx-liz/LizyML/issues/118)) — fold index / config path / method name now consistently carried; regression guard added.
- **`storage` parameter type tightened to `str | BaseStorage | None`** ([#136](https://github.com/nbx-liz/LizyML/issues/136)) — was `Any`; aligns with H-0072 docstring.
- **Plot theme deduplicated via `apply_default_layout`** ([#134](https://github.com/nbx-liz/LizyML/issues/134)) — `lizyml/plots/_theme.py` is now the single source for default layout settings shared across every plot module.
- **`StratifiedTimeHoldoutInnerValid` tail-holdout fallback inlined** ([#133](https://github.com/nbx-liz/LizyML/issues/133)) — readability improvement, behaviour unchanged.
- **`TargetEncoder` lexicographic class ordering documented with example** ([#132](https://github.com/nbx-liz/LizyML/issues/132)).

### Fixed

- **Tuning progress callback warning now includes exception type and message** ([#128](https://github.com/nbx-liz/LizyML/issues/128)) — debugging callback failures no longer requires re-running with logging tweaks.
- **`FloatDim` linear lower expansion clamped at zero** ([#129](https://github.com/nbx-liz/LizyML/issues/129)) — boundary-detection re-tune (H-0068) no longer drives lower bounds below zero on naturally non-negative parameters.
- **Legacy top-level `validation_ratio` input emits `DeprecationWarning`** ([#130](https://github.com/nbx-liz/LizyML/issues/130)) — previously a YAML with only `early_stopping.validation_ratio` (and no `inner_valid:` block) was silent. Now the deprecation contract is enforced on input, not just output.
- **Unhandled `SplitConfig` variants raise `LizyMLError(CONFIG_INVALID)`** ([#131](https://github.com/nbx-liz/LizyML/issues/131)) — previously a silent fallback could mask schema regressions.
- **Code-review HIGH issues + `#124` test gap closed** ([#141](https://github.com/nbx-liz/LizyML/issues/141)) — Sprint 1+2 follow-up batch.
- **MEDIUM / LOW code-review batch** ([#142](https://github.com/nbx-liz/LizyML/issues/142)) — accumulated cleanup landed in one PR.

### Internal

- **`TrainComponents` rebuild path extracted to `_sort_and_rebuild_components()`** ([#137](https://github.com/nbx-liz/LizyML/issues/137)) — refactor only.
- **Mixin source files contain zero direct `self._<private>` access** (H-0077 Phase 2, enforced by `tests/test_core/test_mixin_state_isolation.py`).

## Version
- Previous: v0.12.0
- New: v0.13.0
- Type: MINOR
