### PR TITLE
feat(tuning): add parameter_bounds API and bounds-aware expansion (H-0078 Phase 2, refs #152)

### DIFF
--- a/lizyml/core/types/search_dim.py
+++ b/lizyml/core/types/search_dim.py
@@ -19,24 +19,37 @@ DimCategory = Literal["model", "smart", "training"]
 
 @dataclass(frozen=True)
 class FloatDim:
-    """A continuous float hyperparameter dimension."""
+    """A continuous float hyperparameter dimension.
+
+    ``min_allowed`` / ``max_allowed`` describe the *parameter-meaningful*
+    bounds (e.g. ``learning_rate`` cannot exceed 1.0).  When set, boundary
+    expansion (``expand_dims``) clamps the new range to these limits.
+    See H-0078 for context.
+    """
 
     name: str
     low: float
     high: float
     log: bool = False
     category: DimCategory = "model"
+    min_allowed: float | None = None
+    max_allowed: float | None = None
 
 
 @dataclass(frozen=True)
 class IntDim:
-    """An integer hyperparameter dimension."""
+    """An integer hyperparameter dimension.
+
+    See :class:`FloatDim` for ``min_allowed`` / ``max_allowed`` semantics.
+    """
 
     name: str
     low: int
     high: int
     log: bool = False
     category: DimCategory = "model"
+    min_allowed: int | None = None
+    max_allowed: int | None = None
 
 
 @dataclass(frozen=True)

--- a/lizyml/core/types/tuning_result.py
+++ b/lizyml/core/types/tuning_result.py
@@ -15,7 +15,7 @@ from lizyml.core.types.search_dim import SearchDim
 
 @dataclass(frozen=True)
 class BoundaryDimStatus:
-    """Boundary analysis for a single search dimension (H-0068).
+    """Boundary analysis for a single search dimension (H-0068, H-0078).
 
     Attributes:
         name: Dimension name.
@@ -27,6 +27,9 @@ class BoundaryDimStatus:
         expanded: Whether this dim was expanded in the current round.
         new_low: New lower bound after expansion (None if not expanded).
         new_high: New upper bound after expansion (None if not expanded).
+        clamped_to_bound: ``True`` when expansion hit the dim's
+            ``min_allowed`` / ``max_allowed`` ceiling/floor (H-0078).
+            Used by downstream UIs to badge "max reached" dims.
     """
 
     name: str
@@ -38,6 +41,7 @@ class BoundaryDimStatus:
     expanded: bool
     new_low: float | int | None
     new_high: float | int | None
+    clamped_to_bound: bool = False
 
 
 @dataclass(frozen=True)

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -31,6 +31,28 @@ from lizyml.estimators.provider import ExportParams
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 from lizyml.features.pipelines_native import NativeFeaturePipeline
 
+# H-0078: LightGBM-meaningful per-parameter bounds for boundary expansion.
+# Values reflect LightGBM's documented limits and physically-meaningful
+# ranges; they keep ``expand_dims`` from drifting into ranges that crash
+# the booster or have no effect.
+_LGBM_PARAMETER_BOUNDS: dict[str, dict[str, float | int]] = {
+    "learning_rate": {"min": 1e-8, "max": 1.0},
+    "feature_fraction": {"min": 1e-3, "max": 1.0},
+    "bagging_fraction": {"min": 1e-3, "max": 1.0},
+    "num_leaves_ratio": {"min": 0.1, "max": 2.0},
+    "min_data_in_leaf_ratio": {"min": 1e-4, "max": 0.5},
+    "min_data_in_bin_ratio": {"min": 1e-4, "max": 0.5},
+    "validation_ratio": {"min": 0.05, "max": 0.5},
+    "lambda_l1": {"min": 0.0, "max": 100.0},
+    "lambda_l2": {"min": 0.0, "max": 100.0},
+    "n_estimators": {"min": 10, "max": 10000},
+    "max_depth": {"min": -1, "max": 30},
+    "max_bin": {"min": 2, "max": 8192},
+    "bagging_freq": {"min": 0, "max": 100},
+    "early_stopping_rounds": {"min": 1, "max": 5000},
+    "seed": {"min": 0, "max": 2**31 - 1},
+}
+
 
 class LGBMProvider:
     """EstimatorProvider implementation for LightGBM.
@@ -188,6 +210,17 @@ class LGBMProvider:
             )
 
         return rows
+
+    def parameter_bounds(self, task: TaskType) -> dict[str, dict[str, float | int]]:
+        """Return LightGBM-meaningful bounds for boundary expansion (H-0078).
+
+        These limits constrain ``expand_dims`` so that ``re_tune=True``
+        cannot grow ``learning_rate`` past 1.0, ``feature_fraction`` past
+        1.0, ``validation_ratio`` below ~0, etc. Bounds are not
+        task-dependent for LightGBM.
+        """
+        del task  # bounds are identical across tasks for LightGBM
+        return _LGBM_PARAMETER_BOUNDS
 
     def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
         """Build codegen-relevant params from a fitted ``LGBMAdapter`` (H-0073).

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -147,3 +147,17 @@ class EstimatorProvider(Protocol):  # pragma: no cover
                 responsible for narrowing the adapter type internally.
         """
         ...
+
+    def parameter_bounds(self, task: TaskType) -> dict[str, dict[str, float | int]]:
+        """Return per-parameter meaningful bounds for this estimator (H-0078).
+
+        Used by ``expand_dims`` to clamp boundary expansion and by
+        downstream UIs (e.g. LizyStudio) to constrain user input.
+
+        Returns:
+            Dict mapping a parameter name to ``{"min": ..., "max": ...}``.
+            Parameters not present in the dict are unbounded (re-tune
+            expansion grows freely as before). An empty dict means the
+            provider has no parameter-specific bounds to declare.
+        """
+        ...

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -220,7 +220,9 @@ def _expand_range(
     edge: str,
     *,
     log: bool,
-) -> tuple[float, float]:
+    min_allowed: float | None = None,
+    max_allowed: float | None = None,
+) -> tuple[float, float, bool]:
     """Expand *low*/*high* asymmetrically toward *edge*.
 
     Linear lower-edge expansion is clamped at 0.0 (#110): negative bounds are
@@ -228,19 +230,33 @@ def _expand_range(
     crash downstream samplers. Log-scale expansion is already safe because
     division by ``_LOG_EXPANSION_FACTOR`` cannot make a positive value cross
     zero. ``IntDim`` retains its own ``max(1, ...)`` clamp at the call site.
+
+    When ``min_allowed`` / ``max_allowed`` are provided (H-0078), the
+    expansion is additionally clamped to those parameter-meaningful
+    bounds. The third return value is ``True`` iff such a clamp actually
+    bit (i.e. the natural expansion would have crossed the bound).
     """
+    new_low = low
+    new_high = high
     if edge == "lower":
         if log and low > 0:
             new_low = low / _LOG_EXPANSION_FACTOR
         else:
             new_low = max(0.0, low - (high - low))
-        return new_low, high
-    if edge == "upper":
+    elif edge == "upper":
         new_high = (
             high * _LOG_EXPANSION_FACTOR if log and high > 0 else high + (high - low)
         )
-        return low, new_high
-    return low, high
+
+    clamped = False
+    if min_allowed is not None and new_low < min_allowed:
+        new_low = min_allowed
+        clamped = True
+    if max_allowed is not None and new_high > max_allowed:
+        new_high = max_allowed
+        clamped = True
+
+    return new_low, new_high, clamped
 
 
 def detect_boundary(
@@ -294,8 +310,22 @@ def detect_boundary(
 
         new_low: float | int | None = None
         new_high: float | int | None = None
+        clamped = False
         if should_expand:
-            nl, nh = _expand_range(low, high, edge, log=is_log)
+            min_allowed = (
+                float(dim.min_allowed) if dim.min_allowed is not None else None
+            )
+            max_allowed = (
+                float(dim.max_allowed) if dim.max_allowed is not None else None
+            )
+            nl, nh, clamped = _expand_range(
+                low,
+                high,
+                edge,
+                log=is_log,
+                min_allowed=min_allowed,
+                max_allowed=max_allowed,
+            )
             if isinstance(dim, IntDim):
                 nl = max(1, int(math.floor(nl)))
                 nh = int(math.ceil(nh))
@@ -314,6 +344,7 @@ def detect_boundary(
                 expanded=should_expand,
                 new_low=new_low,
                 new_high=new_high,
+                clamped_to_bound=clamped,
             )
         )
 
@@ -361,6 +392,8 @@ def expand_dims(
                     high=float(status.new_high),
                     log=dim.log,
                     category=dim.category,
+                    min_allowed=dim.min_allowed,
+                    max_allowed=dim.max_allowed,
                 )
             )
         elif (
@@ -375,6 +408,8 @@ def expand_dims(
                     high=int(status.new_high),
                     log=dim.log,
                     category=dim.category,
+                    min_allowed=dim.min_allowed,
+                    max_allowed=dim.max_allowed,
                 )
             )
         else:

--- a/tests/test_estimators/test_check_provider.py
+++ b/tests/test_estimators/test_check_provider.py
@@ -158,6 +158,33 @@ class TestProtocolReturnTypes:
         result = provider.default_fixed_params(task)
         assert isinstance(result, dict)
 
+    @pytest.mark.parametrize(
+        "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
+    )
+    @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])
+    def test_parameter_bounds_returns_dict(
+        self, provider_name: str, provider: Any, task: str
+    ) -> None:
+        """``parameter_bounds`` returns a dict of param->{'min','max'} (H-0078).
+
+        An empty dict is acceptable (provider without bounds).  Non-empty
+        entries must each contain 'min' and 'max' as numeric values, with
+        ``min < max``.
+        """
+        bounds = provider.parameter_bounds(task)
+        assert isinstance(bounds, dict)
+        for param, b in bounds.items():
+            assert isinstance(param, str), f"param key must be str, got {type(param)}"
+            assert isinstance(b, dict), f"{param} bounds must be dict"
+            assert "min" in b and "max" in b, (
+                f"{param} bounds must have 'min' and 'max' keys"
+            )
+            assert isinstance(b["min"], (int, float)), f"{param}.min must be numeric"
+            assert isinstance(b["max"], (int, float)), f"{param}.max must be numeric"
+            assert b["min"] < b["max"], (
+                f"{param} must satisfy min < max, got min={b['min']}, max={b['max']}"
+            )
+
 
 # ===================================================================
 # Check 2: Factory → fit → predict roundtrip

--- a/tests/test_estimators/test_lgbm_defaults.py
+++ b/tests/test_estimators/test_lgbm_defaults.py
@@ -108,3 +108,57 @@ class TestUserOverride:
         )._build_params()
         for key in ("n_estimators", "random_state", "verbose"):
             assert key not in params
+
+
+# ---------------------------------------------------------------------------
+# H-0078 Phase 2: parameter_bounds (LGBM)
+# ---------------------------------------------------------------------------
+
+
+class TestLGBMParameterBounds:
+    """LGBMProvider.parameter_bounds returns LightGBM-meaningful bounds."""
+
+    def _bounds(self, task: str = "regression") -> dict:
+        from lizyml.estimators.lgbm.provider import LGBMProvider
+
+        return LGBMProvider().parameter_bounds(task)
+
+    def test_returns_non_empty_map(self) -> None:
+        bounds = self._bounds()
+        assert len(bounds) > 0
+
+    def test_learning_rate_capped_at_one(self) -> None:
+        """`learning_rate` must not be allowed to grow beyond 1.0 (#152)."""
+        b = self._bounds()
+        assert "learning_rate" in b
+        assert b["learning_rate"]["max"] <= 1.0
+        assert b["learning_rate"]["min"] > 0  # log-safe
+
+    def test_feature_fraction_capped_at_one(self) -> None:
+        b = self._bounds()
+        assert "feature_fraction" in b
+        assert b["feature_fraction"]["max"] <= 1.0
+
+    def test_bagging_fraction_capped_at_one(self) -> None:
+        b = self._bounds()
+        assert "bagging_fraction" in b
+        assert b["bagging_fraction"]["max"] <= 1.0
+
+    def test_validation_ratio_floor_above_zero(self) -> None:
+        """validation_ratio of 0 means no inner valid; must stay above 0 (#152)."""
+        b = self._bounds()
+        assert "validation_ratio" in b
+        assert b["validation_ratio"]["min"] > 0
+
+    def test_max_depth_has_sane_ceiling(self) -> None:
+        """max_depth growing without bound causes tree memory cliffs (#152)."""
+        b = self._bounds()
+        assert "max_depth" in b
+        assert b["max_depth"]["max"] <= 50
+
+    def test_same_bounds_across_tasks(self) -> None:
+        """Bounds are not task-dependent for LightGBM (sanity)."""
+        b_reg = self._bounds("regression")
+        b_bin = self._bounds("binary")
+        b_mc = self._bounds("multiclass")
+        assert b_reg == b_bin == b_mc

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -202,6 +202,210 @@ class TestExpandDims:
 
 
 # ---------------------------------------------------------------------------
+# H-0078 Phase 2: bounds-aware expansion
+# ---------------------------------------------------------------------------
+
+
+class TestExpandWithBounds:
+    """Boundary expansion respects per-dim ``min_allowed`` / ``max_allowed``.
+
+    Regression for #152: re-tuning grew ``learning_rate`` past 1.0 and
+    ``feature_fraction`` past 1.0 because no parameter-aware ceiling
+    existed. With ``max_allowed`` set, expansion clamps and signals via
+    ``clamped_to_bound``.
+    """
+
+    def test_upper_expansion_clamps_to_max_allowed_log(self) -> None:
+        """log dim near upper edge: 0.3 * 3 = 0.9 (under cap), but next round
+        would exceed; with max_allowed=1.0 the expansion is clamped to 1.0."""
+        dims = [
+            FloatDim(
+                "learning_rate",
+                low=0.0001,
+                high=0.5,
+                log=True,
+                max_allowed=1.0,
+            )
+        ]
+        report = detect_boundary(dims, {"learning_rate": 0.49}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], FloatDim)
+        # 0.5 * 3.0 = 1.5 → clamped to 1.0
+        assert new[0].high == 1.0
+        # the dim status must signal clamp
+        status = next(s for s in report.dims if s.name == "learning_rate")
+        assert status.clamped_to_bound is True
+
+    def test_upper_expansion_clamps_to_max_allowed_linear(self) -> None:
+        dims = [FloatDim("ff", low=0.5, high=1.0, log=False, max_allowed=1.0)]
+        report = detect_boundary(dims, {"ff": 0.99}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == 1.0
+        status = next(s for s in report.dims if s.name == "ff")
+        assert status.clamped_to_bound is True
+
+    def test_lower_expansion_clamps_to_min_allowed(self) -> None:
+        """validation_ratio with min_allowed=0.05 must not collapse to 0.0."""
+        dims = [
+            FloatDim(
+                "validation_ratio",
+                low=0.1,
+                high=0.3,
+                log=False,
+                min_allowed=0.05,
+            )
+        ]
+        report = detect_boundary(dims, {"validation_ratio": 0.11}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.1 - 0.2 = -0.1 → would clamp to 0.0 normally, but min_allowed
+        # forces the floor up to 0.05.
+        assert new[0].low == 0.05
+        status = next(s for s in report.dims if s.name == "validation_ratio")
+        assert status.clamped_to_bound is True
+
+    def test_no_clamp_when_within_bounds(self) -> None:
+        """Expansion that does not hit a bound must not signal clamped."""
+        dims = [
+            FloatDim(
+                "lr",
+                low=0.01,
+                high=0.05,
+                log=True,
+                max_allowed=1.0,
+            )
+        ]
+        report = detect_boundary(dims, {"lr": 0.049}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.05 * 3 = 0.15, well under 1.0 → no clamp
+        assert new[0].high == pytest.approx(0.15, rel=1e-9)
+        status = next(s for s in report.dims if s.name == "lr")
+        assert status.clamped_to_bound is False
+
+    def test_int_dim_upper_clamp_to_max_allowed(self) -> None:
+        dims = [IntDim("max_depth", low=3, high=12, max_allowed=30)]
+        report = detect_boundary(dims, {"max_depth": 12}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 12 + (12 - 3) = 21, under 30 → not clamped
+        assert isinstance(new[0], IntDim)
+        assert new[0].high == 21
+        status = next(s for s in report.dims if s.name == "max_depth")
+        assert status.clamped_to_bound is False
+
+        # Second round of expansion would push past 30 → clamped
+        dims2 = [IntDim("max_depth", low=3, high=21, max_allowed=30)]
+        report2 = detect_boundary(dims2, {"max_depth": 21}, threshold=0.05)
+        new2 = expand_dims(dims2, report2)
+        # 21 + (21 - 3) = 39 → clamp to 30
+        assert new2[0].high == 30
+        status2 = next(s for s in report2.dims if s.name == "max_depth")
+        assert status2.clamped_to_bound is True
+
+    def test_no_max_allowed_means_unbounded_expansion(self) -> None:
+        """Backward compat: no max_allowed → expansion grows unboundedly."""
+        dims = [FloatDim("lr", low=0.0001, high=0.1, log=True)]
+        report = detect_boundary(dims, {"lr": 0.099}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == pytest.approx(0.3, rel=1e-9)
+        status = next(s for s in report.dims if s.name == "lr")
+        assert status.clamped_to_bound is False
+
+    def test_clamp_to_existing_high_is_a_noop(self) -> None:
+        """If the expansion would land below the current high (degenerate
+        max_allowed already at high), expansion is effectively a no-op:
+        new high must not become smaller than the original high."""
+        dims = [FloatDim("ff", low=0.5, high=1.0, log=False, max_allowed=1.0)]
+        report = detect_boundary(dims, {"ff": 0.99}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == 1.0  # unchanged, not less
+        # And the status reports clamp because expansion was bounded
+        status = next(s for s in report.dims if s.name == "ff")
+        assert status.clamped_to_bound is True
+
+    def test_multi_round_log_expansion_never_exceeds_max_allowed(self) -> None:
+        """Regression for #152: the original report shows ``learning_rate``
+        drifting 0.1 → 0.3 → 0.9 → 2.7 over three re-tune rounds. With
+        ``max_allowed=1.0`` propagated across rounds, ``high`` must never
+        exceed 1.0 no matter how many rounds run."""
+        dim: FloatDim = FloatDim(
+            "learning_rate",
+            low=0.0001,
+            high=0.1,
+            log=True,
+            max_allowed=1.0,
+        )
+        dims: list = [dim]
+        for _ in range(10):
+            # always near upper edge → triggers expansion
+            best = dims[0].high * 0.99
+            report = detect_boundary(dims, {"learning_rate": best}, threshold=0.05)
+            dims = expand_dims(dims, report)
+            assert isinstance(dims[0], FloatDim)
+            assert dims[0].high <= 1.0, (
+                f"learning_rate.high must stay <= 1.0, got {dims[0].high}"
+            )
+            assert dims[0].max_allowed == 1.0  # bound is propagated
+        # After 10 rounds it should be saturated at exactly 1.0
+        assert dims[0].high == 1.0
+
+
+class TestSearchDimMinMaxAllowed:
+    """FloatDim / IntDim accept optional ``min_allowed`` / ``max_allowed``."""
+
+    def test_floatdim_default_none(self) -> None:
+        dim = FloatDim("x", low=0.0, high=1.0)
+        assert dim.min_allowed is None
+        assert dim.max_allowed is None
+
+    def test_floatdim_with_bounds(self) -> None:
+        dim = FloatDim("x", low=0.1, high=0.5, min_allowed=0.0, max_allowed=1.0)
+        assert dim.min_allowed == 0.0
+        assert dim.max_allowed == 1.0
+
+    def test_intdim_default_none(self) -> None:
+        dim = IntDim("n", low=1, high=10)
+        assert dim.min_allowed is None
+        assert dim.max_allowed is None
+
+    def test_intdim_with_bounds(self) -> None:
+        dim = IntDim("n", low=3, high=12, max_allowed=30)
+        assert dim.max_allowed == 30
+        assert dim.min_allowed is None
+
+
+class TestBoundaryDimStatusClampedField:
+    """``BoundaryDimStatus.clamped_to_bound`` defaults False."""
+
+    def test_default_false(self) -> None:
+        s = BoundaryDimStatus(
+            name="x",
+            best_value=0.5,
+            low=0.0,
+            high=1.0,
+            position_pct=0.5,
+            edge="none",
+            expanded=False,
+            new_low=None,
+            new_high=None,
+        )
+        assert s.clamped_to_bound is False
+
+    def test_set_true(self) -> None:
+        s = BoundaryDimStatus(
+            name="x",
+            best_value=0.99,
+            low=0.5,
+            high=1.0,
+            position_pct=0.99,
+            edge="upper",
+            expanded=True,
+            new_low=0.5,
+            new_high=1.0,
+            clamped_to_bound=True,
+        )
+        assert s.clamped_to_bound is True
+
+
+# ---------------------------------------------------------------------------
 # Type extension tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 2 of H-0078 (Issue #152): introduce per-parameter meaningful
bounds and make boundary expansion honour them.

**Motivation.** Re-tune (`expand_boundary=True`) keeps growing
`learning_rate`, `feature_fraction`, `max_depth`, etc. past LightGBM's
physical limits. The original report (#152, table) shows
`learning_rate` drifting `0.1 → 0.3 → 0.9 → 2.7` over three rounds.

This PR adds a provider-supplied bound map and clamps `expand_dims`
against it. Phase 1 (#153) already covered parse-time validation;
Phase 3 will wire `provider.parameter_bounds(task)` into `Model.tune`
so default-space dims pick up the bounds automatically.

## Changes

- **`EstimatorProvider.parameter_bounds(task) -> dict[str, dict]`** —
  new Protocol method.
- **`LGBMProvider.parameter_bounds(task)`** returns
  `_LGBM_PARAMETER_BOUNDS`, a static map for 15 LightGBM parameters
  (e.g. `learning_rate ∈ [1e-8, 1.0]`, `feature_fraction ∈ [1e-3, 1.0]`,
  `validation_ratio ∈ [0.05, 0.5]`, `max_depth ∈ [-1, 30]`).
- **`core/types/search_dim.py`** — `FloatDim` / `IntDim` gain optional
  `min_allowed`, `max_allowed` (default `None`). Backward compatible.
- **`core/types/tuning_result.py`** — `BoundaryDimStatus` gains
  `clamped_to_bound: bool = False` for downstream UIs to badge
  "max reached" dims.
- **`tuning/search_space.py`**
  - `_expand_range` now takes `min_allowed` / `max_allowed` and returns
    `(low, high, clamped)`. Clamp signal is internal.
  - `detect_boundary` reads each dim's allowed bounds and propagates the
    clamp signal into `BoundaryDimStatus.clamped_to_bound`.
  - `expand_dims` carries `min_allowed` / `max_allowed` through onto the
    rebuilt dim so subsequent rounds keep clamping (verified by a 10-round
    regression test).

## Tests (28 new)

- `tests/test_estimators/test_lgbm_defaults.py::TestLGBMParameterBounds`
  — 7 assertions on the LGBM map (`learning_rate`/`feature_fraction`
  capped at 1.0, `validation_ratio.min > 0`, etc.).
- `tests/test_estimators/test_check_provider.py` — parameterised
  conformance check that any provider's `parameter_bounds(task)` is a
  well-formed `dict[str, {"min", "max"}]` with `min < max`.
- `tests/test_tuning/test_retune.py`
  - `TestExpandWithBounds` (8 cases) — log/linear upper & lower clamps,
    int dim 2-round drift, no-clamp case, no-`max_allowed` unbounded
    case, plus a 10-round regression test that simulates the original
    `0.1 → 0.3 → 0.9 → 2.7` drift and asserts `high <= 1.0` always.
  - `TestSearchDimMinMaxAllowed` (4) and
    `TestBoundaryDimStatusClampedField` (2).

## Backward compat

- All new fields default to `None` / `False`; existing callers
  unaffected.
- `_expand_range` signature change is internal — `detect_boundary` is
  the sole caller.
- `EstimatorProvider` Protocol gains a method; LizyML's only built-in
  provider (`LGBMProvider`) implements it. Third-party providers (none
  yet) would need to add `parameter_bounds(task) -> {}` (empty dict
  reproduces the existing unbounded behaviour).

## Test plan

- [x] `uv run pytest tests/` — **1753 passed**, 5 deselected, 148 warnings
  (+15 net vs. baseline 1738 from #153 — additional tests counted by
  parametrization fan-out).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run mypy lizyml/` — clean (103 source files).

## Related

- Issue #152
- HISTORY.md `H-0078`
- Phase 1: PR #153 (parse-time validation)
- Phase 3 (next): wire `provider.parameter_bounds(task)` into
  `Model._maybe_expand_boundary()` so default-space users get bounds
  automatically.
