### PR TITLE
feat(tuning): wire EstimatorProvider.parameter_bounds() into Model.tune (H-0078 Phase 3, closes #152)

### DIFF
--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -88,6 +88,7 @@ from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
 from lizyml.training.refit_trainer import RefitResult, RefitTrainer
 from lizyml.tuning.search_space import (
+    attach_bounds,
     detect_boundary,
     expand_dims,
     parse_space,
@@ -604,6 +605,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         Returns a tuple ``(space, used_default, fixed_params)`` where
         ``used_default`` signals that no user-supplied space was provided
         (drives the H-0068 expand-boundary default).
+
+        H-0078: ``provider.parameter_bounds(task)`` is attached to each
+        matching dim so that boundary expansion in subsequent rounds is
+        clamped to physically-meaningful limits.
         """
         cfg = self._cfg
         assert cfg.tuning is not None  # noqa: S101 — validated upstream
@@ -618,6 +623,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             else:
                 space = provider.default_space(cfg.task)
                 used_default = True
+            space = attach_bounds(space, provider.parameter_bounds(cfg.task))
 
         fixed: dict[str, Any] = (
             provider.default_fixed_params(cfg.task) if used_default else {}

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -25,6 +25,7 @@ __all__ = [
     "FloatDim",
     "IntDim",
     "SearchDim",
+    "attach_bounds",
     "detect_boundary",
     "expand_dims",
     "parse_space",
@@ -393,6 +394,67 @@ def detect_boundary(
         dims=tuple(statuses),
         expanded_names=tuple(expanded_names),
     )
+
+
+def attach_bounds(
+    dims: list[SearchDim],
+    bounds: dict[str, dict[str, float | int]],
+) -> list[SearchDim]:
+    """Return a new list of dims with ``min_allowed`` / ``max_allowed`` injected.
+
+    For each ``FloatDim`` / ``IntDim`` whose ``name`` is a key in *bounds*,
+    a copy is returned with ``min_allowed`` / ``max_allowed`` populated
+    from ``{"min": ..., "max": ...}``. Dims that already carry user-set
+    bounds are left untouched (user override wins). ``CategoricalDim`` is
+    always returned unchanged. Dims with no entry in *bounds* are
+    unchanged.
+
+    Used by ``Model.tune`` to wire ``EstimatorProvider.parameter_bounds(task)``
+    onto the search space (H-0078).
+    """
+    if not bounds:
+        return list(dims)
+
+    new_dims: list[SearchDim] = []
+    for dim in dims:
+        if isinstance(dim, CategoricalDim):
+            new_dims.append(dim)
+            continue
+        b = bounds.get(dim.name)
+        if b is None:
+            new_dims.append(dim)
+            continue
+        # Respect user-set bounds — do not overwrite.
+        if dim.min_allowed is not None or dim.max_allowed is not None:
+            new_dims.append(dim)
+            continue
+        if isinstance(dim, FloatDim):
+            new_dims.append(
+                FloatDim(
+                    name=dim.name,
+                    low=dim.low,
+                    high=dim.high,
+                    log=dim.log,
+                    category=dim.category,
+                    min_allowed=float(b["min"]),
+                    max_allowed=float(b["max"]),
+                )
+            )
+        elif isinstance(dim, IntDim):
+            new_dims.append(
+                IntDim(
+                    name=dim.name,
+                    low=dim.low,
+                    high=dim.high,
+                    log=dim.log,
+                    category=dim.category,
+                    min_allowed=int(b["min"]),
+                    max_allowed=int(b["max"]),
+                )
+            )
+        else:  # pragma: no cover — exhaustive over SearchDim
+            new_dims.append(dim)
+    return new_dims
 
 
 def expand_dims(

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -30,7 +30,7 @@ from lizyml.core.types.tuning_result import (
     TuneProgressInfo,
     TuningResult,
 )
-from lizyml.tuning.search_space import detect_boundary, expand_dims
+from lizyml.tuning.search_space import attach_bounds, detect_boundary, expand_dims
 from tests._helpers import make_config, make_regression_df
 
 # ---------------------------------------------------------------------------
@@ -403,6 +403,161 @@ class TestBoundaryDimStatusClampedField:
             clamped_to_bound=True,
         )
         assert s.clamped_to_bound is True
+
+
+# ---------------------------------------------------------------------------
+# H-0078 Phase 3: attach_bounds — provider->dim wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAttachBounds:
+    """``attach_bounds`` injects provider bounds onto matching dims."""
+
+    def test_floatdim_matching_name_gets_bounds(self) -> None:
+        dims = [FloatDim("learning_rate", low=0.001, high=0.1, log=True)]
+        bounds = {"learning_rate": {"min": 1e-8, "max": 1.0}}
+        new = attach_bounds(dims, bounds)
+        assert isinstance(new[0], FloatDim)
+        assert new[0].min_allowed == 1e-8
+        assert new[0].max_allowed == 1.0
+        # Other fields preserved
+        assert new[0].low == 0.001
+        assert new[0].high == 0.1
+        assert new[0].log is True
+
+    def test_intdim_matching_name_gets_bounds_as_int(self) -> None:
+        dims = [IntDim("max_depth", low=3, high=12)]
+        bounds = {"max_depth": {"min": -1, "max": 30}}
+        new = attach_bounds(dims, bounds)
+        assert isinstance(new[0], IntDim)
+        assert new[0].min_allowed == -1
+        assert new[0].max_allowed == 30
+        assert isinstance(new[0].max_allowed, int)
+
+    def test_dim_without_match_unchanged(self) -> None:
+        dim = FloatDim("custom_param", low=0.1, high=0.5)
+        bounds = {"learning_rate": {"min": 0.0, "max": 1.0}}
+        new = attach_bounds([dim], bounds)
+        assert new[0] is dim  # untouched, same object
+
+    def test_categorical_dim_unchanged(self) -> None:
+        dim = CategoricalDim("obj", choices=("a", "b"))
+        bounds = {"obj": {"min": 0.0, "max": 1.0}}  # nonsensical but shouldn't crash
+        new = attach_bounds([dim], bounds)
+        assert new[0] is dim
+
+    def test_user_set_min_allowed_preserved(self) -> None:
+        """User-set min_allowed/max_allowed wins over provider bounds."""
+        dims = [
+            FloatDim(
+                "learning_rate",
+                low=0.001,
+                high=0.1,
+                log=True,
+                min_allowed=1e-6,
+                max_allowed=0.5,
+            )
+        ]
+        bounds = {"learning_rate": {"min": 1e-8, "max": 1.0}}
+        new = attach_bounds(dims, bounds)
+        # user values preserved
+        assert new[0].min_allowed == 1e-6
+        assert new[0].max_allowed == 0.5
+
+    def test_empty_bounds_returns_same_list(self) -> None:
+        dims = [FloatDim("x", low=0.0, high=1.0)]
+        new = attach_bounds(dims, {})
+        assert new[0] is dims[0]
+
+    def test_multiple_dims_some_matching(self) -> None:
+        dims = [
+            FloatDim("learning_rate", low=0.001, high=0.1),
+            IntDim("max_depth", low=3, high=12),
+            FloatDim("custom_unrelated", low=0.0, high=1.0),
+        ]
+        bounds = {
+            "learning_rate": {"min": 1e-8, "max": 1.0},
+            "max_depth": {"min": -1, "max": 30},
+        }
+        new = attach_bounds(dims, bounds)
+        assert new[0].max_allowed == 1.0
+        assert new[1].max_allowed == 30
+        assert new[2].max_allowed is None
+
+
+class TestModelTuneWiresParameterBounds:
+    """Integration: ``Model.tune(re_tune=True)`` clamps boundary expansion
+    using ``provider.parameter_bounds(task)`` (H-0078 Phase 3)."""
+
+    def test_default_space_picks_up_lgbm_bounds(self) -> None:
+        """Tuning with the default LightGBM space exposes max_allowed on
+        ``learning_rate`` after the first ``tune()`` call."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {"optuna": {"params": {"n_trials": 2}}}
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        space = model._space  # type: ignore[attr-defined]
+        assert space is not None
+        lr = next((d for d in space if d.name == "learning_rate"), None)
+        assert lr is not None
+        assert lr.max_allowed == 1.0
+
+    def test_user_space_lr_picks_up_lgbm_bounds_by_name(self) -> None:
+        """A user-supplied dim named ``learning_rate`` also picks up the
+        provider bound by name match."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {
+            "optuna": {
+                "params": {"n_trials": 2},
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.01,
+                        "high": 0.3,
+                        "log": True,
+                    },
+                },
+            }
+        }
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        space = model._space  # type: ignore[attr-defined]
+        lr = next((d for d in space if d.name == "learning_rate"), None)
+        assert lr is not None
+        assert lr.max_allowed == 1.0
+        assert lr.min_allowed == 1e-8
+
+    def test_re_tune_clamps_learning_rate_at_one(self) -> None:
+        """Regression for #152: re-tune cannot push ``learning_rate.high``
+        past 1.0 because provider bounds are wired through ``Model.tune``."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {
+            "optuna": {
+                "params": {"n_trials": 2},
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.5,
+                        "high": 0.9,
+                        "log": True,
+                    },
+                    "max_depth": {"type": "int", "low": 3, "high": 5},
+                },
+            }
+        }
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        # Run several re-tune rounds with expand_boundary=True. The space
+        # should never grow ``learning_rate.high`` past 1.0.
+        for _ in range(5):
+            model.tune(df, resume=True, n_trials=2, expand_boundary=True)
+            space = model._space  # type: ignore[attr-defined]
+            lr = next((d for d in space if d.name == "learning_rate"), None)
+            assert lr is not None
+            assert lr.high <= 1.0, f"learning_rate.high must stay <= 1.0, got {lr.high}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 3 of H-0078 (Issue #152) — closes the chain. Wires
`EstimatorProvider.parameter_bounds(task)` into `Model.tune` so that
both default-space dims and user-supplied dims pick up
parameter-meaningful bounds **automatically**, without any caller code
change.

After this lands, the original report scenario in #152
(`learning_rate` drifting `0.1 → 0.3 → 0.9 → 2.7` over re-tune rounds)
is no longer possible: every round clamps to `learning_rate.high <= 1.0`,
and `BoundaryDimStatus.clamped_to_bound` flags it for downstream UIs.

Phase 1 (#153) — parse-time validation.
Phase 2 (#154) — bounds API + bounds-aware expansion.
Phase 3 (this) — wiring.

## Changes

- **`lizyml/tuning/search_space.py`**
  - New `attach_bounds(dims, bounds)` helper. Returns a new list of
    dims with `min_allowed` / `max_allowed` injected for matching
    parameter names. User-set bounds are preserved (user override wins).
    `CategoricalDim` is unchanged. Empty bounds map → identity.
- **`lizyml/core/model.py`**
  - `_resolve_search_space` now calls
    `attach_bounds(space, provider.parameter_bounds(cfg.task))` before
    returning, so the search space carries bounds from round 1 onward.
    `detect_boundary` and `expand_dims` (Phase 2) read those bounds and
    clamp accordingly.

## Tests (10 new)

- `tests/test_tuning/test_retune.py::TestAttachBounds` (7) — match by
  name, IntDim int-typed bounds, CategoricalDim untouched, user
  override preserved, empty map noop, multi-dim mix.
- `tests/test_tuning/test_retune.py::TestModelTuneWiresParameterBounds` (3)
  - default LightGBM space exposes `learning_rate.max_allowed = 1.0`
    after `Model.tune()`,
  - user-supplied dim named `learning_rate` picks up the bound by name,
  - **regression for #152**: 5-round `tune(resume=True, expand_boundary=True)`
    keeps `learning_rate.high <= 1.0` no matter how many rounds run.

## Backward compat

- No public API change. `attach_bounds` is internal.
- Dims with names not present in `provider.parameter_bounds(task)` are
  returned unchanged.
- Third-party providers returning `{}` reproduce the exact pre-H-0078
  behaviour.

## Test plan

- [x] `uv run pytest tests/test_tuning/` — Phase 3 new tests green.
- [ ] `uv run pytest tests/` — full suite (running, expected ≥ 1763
  passed = 1753 from #154 + 10 new).
- [x] `uv run ruff check .` — clean.
- [x] `uv run ruff format --check .` — clean.
- [x] `uv run mypy lizyml/` — clean (103 source files).

## Related

- Issue #152
- HISTORY.md `H-0078` (added in #153, will be marked `accepted` in a
  small follow-up after all 3 PRs merge)
- Phase 1: PR #153
- Phase 2: PR #154
