### PR TITLE
docs: mark H-0078 accepted and add v0.14.0 CHANGELOG entry [docs-only]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.14.0] - 2026-05-10
+
+### Added
+
+- **`EstimatorProvider.parameter_bounds(task)`** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — new Protocol method returning per-parameter meaningful bounds (`{"min": ..., "max": ...}`) for boundary expansion. `LGBMProvider.parameter_bounds(task)` ships a static map for 15 LightGBM parameters (e.g. `learning_rate ∈ [1e-8, 1.0]`, `feature_fraction ∈ [1e-3, 1.0]`, `validation_ratio ∈ [0.05, 0.5]`, `max_depth ∈ [-1, 30]`). Used by `Model.tune` and downstream UIs (LizyStudio) to constrain user input. Third-party providers may return `{}` for unbounded behaviour.
+- **`SearchDim.min_allowed` / `max_allowed`** (H-0078) — optional bounds on `FloatDim` / `IntDim` (default `None`). Boundary expansion clamps to these limits when set.
+- **`BoundaryDimStatus.clamped_to_bound: bool`** (H-0078) — flags dims whose expansion hit the parameter-meaningful bound, so downstream UIs can badge "max reached" dims. Defaults `False`.
+- **`attach_bounds(dims, bounds)` helper in `lizyml.tuning.search_space`** (H-0078) — injects `min_allowed` / `max_allowed` onto matching dims by name. Called from `Model._resolve_search_space` so default-space and user-supplied dims both pick up provider bounds automatically.
+
+### Changed
+
+- **`parse_space()` rejects degenerate / inverted ranges and log-with-non-positive-low** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — `low >= high` and `log=True ∧ low <= 0` now raise `LizyMLError(CONFIG_INVALID)` at parse time instead of letting Optuna raise a generic error mid-trial. Strictly better failure mode (earlier and clearer).
+- **`expand_dims` propagates `min_allowed` / `max_allowed`** (H-0078) — re-tune over multiple rounds preserves provider-supplied bounds, preventing the original `learning_rate` drift (`0.1 → 0.3 → 0.9 → 2.7`) reported in #152. 5- and 10-round regression tests guard the contract.
+
+### Internal
+
+- **`_expand_range` is bounds-aware** (H-0078) — keyword-only `min_allowed` / `max_allowed` arguments + 3-tuple return `(low, high, clamped)`. Internal signature change; only `detect_boundary` is a caller.
+
 ## [0.13.0] - 2026-05-10
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6347,10 +6347,11 @@ H-0074 Phase 1 で `FitState` frozen dataclass と `Model._get_fit_state()` を�
 
 ## H-0078: 探索空間の検証強化と `EstimatorProvider.parameter_bounds()` 導入
 
-- **ステータス**: Proposed
+- **ステータス**: Accepted
 - **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
 - **スコープ**: Public API (`EstimatorProvider`), Internal Types (`SearchDim`, `BoundaryDimStatus`), `tuning/search_space.py`, `core/model.py`
-- **関連**: [Issue #152](https://github.com/nbx-liz/issues/152) (severity: high), LizyStudio Issue #460（下流 UI）
+- **関連**: [Issue #152](https://github.com/nbx-liz/issues/152) (severity: high), LizyStudio Issue #460（下流 UI）, PR [#153](https://github.com/nbx-liz/LizyML/pull/153) / [#154](https://github.com/nbx-liz/LizyML/pull/154) / [#156](https://github.com/nbx-liz/LizyML/pull/156)
 
 ### 目的
 
@@ -6478,8 +6479,13 @@ Re-tune (`expand_boundary=True`) を繰り返した際、`expand_dims` がパラ
 
 ### Decision
 
-- Date: TBD
-- Result: pending
-- Notes: 3 Phase 分割で順次 PR を提出する。各 Phase 完了時にこのエントリを更新。
+- Date: 2026-05-10
+- Result: accepted
+- Notes:
+  - **Phase 1 (PR #153)**: `parse_space` が `low >= high` と `log + low <= 0` を `LizyMLError(CONFIG_INVALID)` で拒否（+8 tests）。
+  - **Phase 2 (PR #154)**: `EstimatorProvider.parameter_bounds(task)` Protocol method を追加し、`LGBMProvider` が 15 params の bounds を返す。`SearchDim`（FloatDim/IntDim）に optional `min_allowed`/`max_allowed` を追加。`_expand_range` が bounds でクランプし `BoundaryDimStatus.clamped_to_bound` を立てる（+25 tests）。
+  - **Phase 3 (PR #156)**: `attach_bounds(dims, bounds)` ヘルパーを追加し、`Model._resolve_search_space` が `provider.parameter_bounds(cfg.task)` を search space に注入。default-space と user-supplied space の両方が bounds を自動取得（+10 tests）。Issue #152 の 5 ラウンド regression test 込み。
+  - 後方互換性は完全維持。サードパーティ Provider は `parameter_bounds(task) -> {}` で従来挙動を再現可能。
+  - リリース: v0.14.0 で配布。
 
 


### PR DESCRIPTION
## Summary

Documentation-only prep for the v0.14.0 release.

- **HISTORY.md** — H-0078 status `Proposed` → `Accepted`; Decision
  block filled in with the 3-phase summary and PR links (#153, #154,
  #156).
- **CHANGELOG.md** — new `[0.14.0] - 2026-05-10` entry covering the
  H-0078 surface area:
  - **Added**: `EstimatorProvider.parameter_bounds(task)` API +
    `LGBMProvider` bound map, `SearchDim.{min,max}_allowed`,
    `BoundaryDimStatus.clamped_to_bound`, `attach_bounds()` helper.
  - **Changed**: `parse_space()` rejects degenerate / inverted /
    log-with-non-positive-low ranges; `expand_dims` propagates bounds
    across re-tune rounds.
  - **Internal**: `_expand_range` bounds-aware signature.

No code change.

## Test plan

- [x] CHANGELOG follows Keep-a-Changelog structure (matches v0.13.0
  shape).
- [x] HISTORY.md `H-0078` Decision block points to merged PRs #153,
  #154, #156.
- [x] `[docs-only]` change — full pytest suite already verified across
  PR #156 (1764 passed). No new code touched here.

## Related

- Issue #152 (closed)
- HISTORY.md `H-0078`
- This PR is followed immediately by a `release: v0.14.0` PR
  (`develop` → `main`, merge commit) per the project's release
  workflow.
