### PR TITLE
release: v0.14.0 — LizyML 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.14.0] - 2026-05-10
+
+### Added
+
+- **`EstimatorProvider.parameter_bounds(task)`** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — new Protocol method returning per-parameter meaningful bounds (`{"min": ..., "max": ...}`) for boundary expansion. `LGBMProvider.parameter_bounds(task)` ships a static map for 15 LightGBM parameters (e.g. `learning_rate ∈ [1e-8, 1.0]`, `feature_fraction ∈ [1e-3, 1.0]`, `validation_ratio ∈ [0.05, 0.5]`, `max_depth ∈ [-1, 30]`). Used by `Model.tune` and downstream UIs (LizyStudio) to constrain user input. Third-party providers may return `{}` for unbounded behaviour.
+- **`SearchDim.min_allowed` / `max_allowed`** (H-0078) — optional bounds on `FloatDim` / `IntDim` (default `None`). Boundary expansion clamps to these limits when set.
+- **`BoundaryDimStatus.clamped_to_bound: bool`** (H-0078) — flags dims whose expansion hit the parameter-meaningful bound, so downstream UIs can badge "max reached" dims. Defaults `False`.
+- **`attach_bounds(dims, bounds)` helper in `lizyml.tuning.search_space`** (H-0078) — injects `min_allowed` / `max_allowed` onto matching dims by name. Called from `Model._resolve_search_space` so default-space and user-supplied dims both pick up provider bounds automatically.
+
+### Changed
+
+- **`parse_space()` rejects degenerate / inverted ranges and log-with-non-positive-low** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — `low >= high` and `log=True ∧ low <= 0` now raise `LizyMLError(CONFIG_INVALID)` at parse time instead of letting Optuna raise a generic error mid-trial. Strictly better failure mode (earlier and clearer).
+- **`expand_dims` propagates `min_allowed` / `max_allowed`** (H-0078) — re-tune over multiple rounds preserves provider-supplied bounds, preventing the original `learning_rate` drift (`0.1 → 0.3 → 0.9 → 2.7`) reported in #152. 5- and 10-round regression tests guard the contract.
+
+### Internal
+
+- **`_expand_range` is bounds-aware** (H-0078) — keyword-only `min_allowed` / `max_allowed` arguments + 3-tuple return `(low, high, clamped)`. Internal signature change; only `detect_boundary` is a caller.
+
 ## [0.13.0] - 2026-05-10
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6343,4 +6343,143 @@ H-0074 Phase 1 で `FitState` frozen dataclass と `Model._get_fit_state()` を�
 - Result: accepted
 - Notes: Phase 1 (H-0074) で予告した Phase 2 の実装。tuning 系メソッドの fit-前-tune-後 ケースを `TuningState` 別経路で扱うことで `FitState` の "fit 後 snapshot" 不変条件を維持。
 
+---
+
+## H-0078: 探索空間の検証強化と `EstimatorProvider.parameter_bounds()` 導入
+
+- **ステータス**: Proposed
+- **起票日**: 2026-05-10
+- **スコープ**: Public API (`EstimatorProvider`), Internal Types (`SearchDim`, `BoundaryDimStatus`), `tuning/search_space.py`, `core/model.py`
+- **関連**: [Issue #152](https://github.com/nbx-liz/issues/152) (severity: high), LizyStudio Issue #460（下流 UI）
+
+### 目的
+
+Re-tune (`expand_boundary=True`) を繰り返した際、`expand_dims` がパラメータ別の意味境界を超えて探索範囲を拡大してしまう。`learning_rate.high` が 1.0 を超え、`feature_fraction.high` が 1.0 を超え、`validation_ratio.low` が 0.0 にまで縮退する。さらに `parse_space` は `low >= high` や `log=True ∧ low <= 0` のような不正値を受け入れ、Optuna の trial 時にようやく汚いエラーで失敗する。
+
+これらは LizyStudio や CLI 利用者を含む全ての Tuning 利用者に影響する。本 Proposal では以下の 3 階層で対応する。
+
+1. **Parse-time validation**: `parse_space` が `low<high`・`log+positive` を即時拒否（早期失敗）。
+2. **Provider-supplied bounds**: `EstimatorProvider.parameter_bounds(task)` でパラメータ別の意味境界を表現できる API を新設。LightGBM 用は `LGBMProvider` が知る。
+3. **Bounded expansion**: `_expand_range` を `min_allowed` / `max_allowed` 認識にし、`Model.tune` が provider→dim に bounds を注入する。`BoundaryDimStatus.clamped_to_bound` で UI が badge できる。
+
+### 変更内容
+
+#### Phase 1 — `parse_space` 検証強化
+
+`lizyml/tuning/search_space.py::parse_space()` に以下のチェックを追加。
+
+- `"float"` / `"int"`: `low < high` が満たされない場合 `LizyMLError(CONFIG_INVALID, ...)` を raise。
+- `log=True`: `low > 0` が満たされない場合 `LizyMLError(CONFIG_INVALID, ...)` を raise（log distribution は正の下限を要求）。
+
+エラー文言には `param`, `low`, `high`, `log` を context に含める。
+
+#### Phase 2 — `parameter_bounds` API + bounds-aware `_expand_range`
+
+1. **`EstimatorProvider.parameter_bounds(task)` 追加**
+
+   ```python
+   def parameter_bounds(self, task: TaskType) -> dict[str, dict[str, float | int]]:
+       """Return per-parameter meaningful bounds. Empty dict = unbounded."""
+       ...
+   ```
+
+   ベースの Protocol で宣言。デフォルト実装はないため、各 Provider が実装する（未対応 estimator は `{}` を返してよい）。
+
+2. **`LGBMProvider.parameter_bounds(task)` 実装**
+
+   LightGBM 既知の意味境界を返す（Issue #152 の表を出発点に LightGBM docs と integration test で確定）:
+
+   ```python
+   {
+       "learning_rate":          {"min": 1e-8, "max": 1.0},
+       "feature_fraction":       {"min": 1e-3, "max": 1.0},
+       "bagging_fraction":       {"min": 1e-3, "max": 1.0},
+       "num_leaves_ratio":       {"min": 0.1,  "max": 2.0},
+       "min_data_in_leaf_ratio": {"min": 1e-4, "max": 0.5},
+       "min_data_in_bin_ratio":  {"min": 1e-4, "max": 0.5},
+       "validation_ratio":       {"min": 0.05, "max": 0.5},
+       "lambda_l1":              {"min": 0.0,  "max": 100.0},
+       "lambda_l2":              {"min": 0.0,  "max": 100.0},
+       "n_estimators":           {"min": 10,   "max": 10000},
+       "max_depth":              {"min": -1,   "max": 30},
+       "max_bin":                {"min": 2,    "max": 8192},
+       "bagging_freq":           {"min": 0,    "max": 100},
+       "early_stopping_rounds":  {"min": 1,    "max": 5000},
+       "seed":                   {"min": 0,    "max": 2**31 - 1},
+   }
+   ```
+
+3. **`SearchDim` (FloatDim/IntDim) に optional フィールド追加**
+
+   `min_allowed: float | int | None = None`, `max_allowed: float | int | None = None`。`@dataclass(frozen=True)` の不変条件と後方互換性を維持。
+
+4. **`_expand_range` を bounds-aware に拡張**
+
+   引数に `min_allowed` / `max_allowed` を追加し、計算された `new_low` / `new_high` を境界でクランプ。両側がぶつかった場合は元値のまま返す（無限ループ防止のため `expanded=False` を上位で再判定）。
+
+5. **`BoundaryDimStatus.clamped_to_bound: bool` フィールド追加**
+
+   `expand_dims` 経由で expansion が境界に当たった場合 True。下流 UI が "max reached" badge を出すためのフラグ。デフォルト False で後方互換。
+
+#### Phase 3 — `Model.tune` 配線
+
+`Model._maybe_expand_boundary()` で `provider.parameter_bounds(cfg.task)` を取得し、`detect_boundary` 呼び出し前に各 dim へ bounds を注入する（または `detect_boundary` の signature を bounds-aware にする）。`expand_boundary=False` 時は既存挙動と同一（bounds は無視される）。
+
+`expand_dims` も bounds 認識にし、`new_low/new_high` のクランプ + `clamped_to_bound` セットを行う。
+
+### 影響範囲
+
+- **変更ファイル**:
+  - `lizyml/tuning/search_space.py`（`parse_space` 検証 / `_expand_range` bounds 対応 / `detect_boundary` `expand_dims` への bounds 配線）
+  - `lizyml/core/types/search_dim.py`（`min_allowed` / `max_allowed` 追加）
+  - `lizyml/core/types/tuning_result.py`（`BoundaryDimStatus.clamped_to_bound` 追加）
+  - `lizyml/estimators/provider.py`（Protocol に `parameter_bounds` 追加）
+  - `lizyml/estimators/lgbm/provider.py`（実装追加）
+  - `lizyml/core/model.py`（`_maybe_expand_boundary` で bounds 注入）
+  - テスト: `tests/test_search_space/test_parse_space_validation.py`（新規）、`tests/test_search_space/test_expand_dims_clamp.py`（新規）、`tests/test_estimators/test_lgbm_provider.py`（追記）、`tests/test_core/test_model_tune_uses_bounds.py`（新規）
+- **無変更**: Persistence 形式、Calibration、Plots/Tables 出力 shape、Codegen export、既存 happy-path tuning 挙動。
+
+### 互換性
+
+- **`parse_space`**: 不正値を受け入れていたコードは新たに `CONFIG_INVALID` で fail-fast。これは "later & messier" → "earlier & clearer" への振る舞い変更で、**実害のあるユーザーコードは存在しない**（Optuna が trial で raise していたため）。format_version 影響なし。
+- **`SearchDim`**: 新 field は optional でデフォルト None。既存呼び出しは無変更で動作。
+- **`BoundaryDimStatus`**: 新 field は default False で後方互換。golden test の dim status 比較は更新が必要。
+- **`EstimatorProvider`**: Protocol に method 追加。LizyML 内蔵 Provider (LGBM) は実装する。サードパーティ Provider が存在する場合は実装が必要だが現時点で該当なし。
+- **`_expand_range`**: 新引数 `min_allowed` / `max_allowed` は keyword-only / optional。
+- format_version 変更不要。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| `_expand_range` 内で param 名から bounds を直接 lookup | search_space.py が estimator-specific 知識を持つことになり、5-layer DAG (provider 経由のみ) の境界違反 |
+| `default_space` に bounds をハードコード | `default_space` を使わずユーザーが `tuning.search_space` を指定した場合に bounds が効かない（Issue #152 のシナリオを完全には解決できない） |
+| `parse_space` の検証緩和（warning のみ） | Optuna が後で raise するため、結局 fail。早期失敗で UX 改善が目的 |
+| 単一 PR で全 Phase | レビュー負荷増・rollback 単位が粗い。3 Phase に分割し、各 Phase 単体で価値が出る形にする |
+| Provider 不要（dim に bounds を直接書く） | `default_space` 以外（ユーザー定義空間）でも bounds が効くようにするには、param 名 → bounds の mapping が必要。estimator ごとの mapping を保持する責務は Provider が自然 |
+
+### 受け入れ基準
+
+- [ ] `parse_space` が `low >= high` を `LizyMLError(CONFIG_INVALID)` で拒否（テストあり）。
+- [ ] `parse_space` が `log=True ∧ low <= 0` を `LizyMLError(CONFIG_INVALID)` で拒否（テストあり）。
+- [ ] `EstimatorProvider.parameter_bounds(task)` が Protocol に追加されている。
+- [ ] `LGBMProvider.parameter_bounds(task)` が LightGBM 固有 map を返す（テストあり）。
+- [ ] `SearchDim`（FloatDim/IntDim）が optional `min_allowed` / `max_allowed` を持つ。
+- [ ] `_expand_range` が bounds でクランプし、`BoundaryDimStatus.clamped_to_bound` を立てる（テストあり）。
+- [ ] `Model.tune(re_tune=...)` が provider→dim に bounds を注入する（統合テストあり）。
+- [ ] 既存 1709 テスト全件 pass。
+- [ ] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy lizyml/` がクリーン。
+
+### Migration
+
+- ユーザーには影響なし（公開 API 完全互換、新 field は optional）。
+- サードパーティ Provider 実装者には `parameter_bounds(task) -> dict` の追加実装を求める。空 dict を返せば既存挙動と同一（unbounded expansion）。
+- LizyStudio 側はこの Phase 完了後 `provider.parameter_bounds(...)` を介して UI の bound 制限を取得する流れに切り替える（別 Issue 管理）。
+
+### Decision
+
+- Date: TBD
+- Result: pending
+- Notes: 3 Phase 分割で順次 PR を提出する。各 Phase 完了時にこのエントリを更新。
+
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6347,10 +6347,11 @@ H-0074 Phase 1 で `FitState` frozen dataclass と `Model._get_fit_state()` を�
 
 ## H-0078: 探索空間の検証強化と `EstimatorProvider.parameter_bounds()` 導入
 
-- **ステータス**: Proposed
+- **ステータス**: Accepted
 - **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
 - **スコープ**: Public API (`EstimatorProvider`), Internal Types (`SearchDim`, `BoundaryDimStatus`), `tuning/search_space.py`, `core/model.py`
-- **関連**: [Issue #152](https://github.com/nbx-liz/issues/152) (severity: high), LizyStudio Issue #460（下流 UI）
+- **関連**: [Issue #152](https://github.com/nbx-liz/issues/152) (severity: high), LizyStudio Issue #460（下流 UI）, PR [#153](https://github.com/nbx-liz/LizyML/pull/153) / [#154](https://github.com/nbx-liz/LizyML/pull/154) / [#156](https://github.com/nbx-liz/LizyML/pull/156)
 
 ### 目的
 
@@ -6478,8 +6479,13 @@ Re-tune (`expand_boundary=True`) を繰り返した際、`expand_dims` がパラ
 
 ### Decision
 
-- Date: TBD
-- Result: pending
-- Notes: 3 Phase 分割で順次 PR を提出する。各 Phase 完了時にこのエントリを更新。
+- Date: 2026-05-10
+- Result: accepted
+- Notes:
+  - **Phase 1 (PR #153)**: `parse_space` が `low >= high` と `log + low <= 0` を `LizyMLError(CONFIG_INVALID)` で拒否（+8 tests）。
+  - **Phase 2 (PR #154)**: `EstimatorProvider.parameter_bounds(task)` Protocol method を追加し、`LGBMProvider` が 15 params の bounds を返す。`SearchDim`（FloatDim/IntDim）に optional `min_allowed`/`max_allowed` を追加。`_expand_range` が bounds でクランプし `BoundaryDimStatus.clamped_to_bound` を立てる（+25 tests）。
+  - **Phase 3 (PR #156)**: `attach_bounds(dims, bounds)` ヘルパーを追加し、`Model._resolve_search_space` が `provider.parameter_bounds(cfg.task)` を search space に注入。default-space と user-supplied space の両方が bounds を自動取得（+10 tests）。Issue #152 の 5 ラウンド regression test 込み。
+  - 後方互換性は完全維持。サードパーティ Provider は `parameter_bounds(task) -> {}` で従来挙動を再現可能。
+  - リリース: v0.14.0 で配布。
 
 

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -88,6 +88,7 @@ from lizyml.training.cv_trainer import CVTrainer
 from lizyml.training.inner_valid import BaseInnerValidStrategy
 from lizyml.training.refit_trainer import RefitResult, RefitTrainer
 from lizyml.tuning.search_space import (
+    attach_bounds,
     detect_boundary,
     expand_dims,
     parse_space,
@@ -604,6 +605,10 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         Returns a tuple ``(space, used_default, fixed_params)`` where
         ``used_default`` signals that no user-supplied space was provided
         (drives the H-0068 expand-boundary default).
+
+        H-0078: ``provider.parameter_bounds(task)`` is attached to each
+        matching dim so that boundary expansion in subsequent rounds is
+        clamped to physically-meaningful limits.
         """
         cfg = self._cfg
         assert cfg.tuning is not None  # noqa: S101 — validated upstream
@@ -618,6 +623,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             else:
                 space = provider.default_space(cfg.task)
                 used_default = True
+            space = attach_bounds(space, provider.parameter_bounds(cfg.task))
 
         fixed: dict[str, Any] = (
             provider.default_fixed_params(cfg.task) if used_default else {}

--- a/lizyml/core/types/search_dim.py
+++ b/lizyml/core/types/search_dim.py
@@ -19,24 +19,37 @@ DimCategory = Literal["model", "smart", "training"]
 
 @dataclass(frozen=True)
 class FloatDim:
-    """A continuous float hyperparameter dimension."""
+    """A continuous float hyperparameter dimension.
+
+    ``min_allowed`` / ``max_allowed`` describe the *parameter-meaningful*
+    bounds (e.g. ``learning_rate`` cannot exceed 1.0).  When set, boundary
+    expansion (``expand_dims``) clamps the new range to these limits.
+    See H-0078 for context.
+    """
 
     name: str
     low: float
     high: float
     log: bool = False
     category: DimCategory = "model"
+    min_allowed: float | None = None
+    max_allowed: float | None = None
 
 
 @dataclass(frozen=True)
 class IntDim:
-    """An integer hyperparameter dimension."""
+    """An integer hyperparameter dimension.
+
+    See :class:`FloatDim` for ``min_allowed`` / ``max_allowed`` semantics.
+    """
 
     name: str
     low: int
     high: int
     log: bool = False
     category: DimCategory = "model"
+    min_allowed: int | None = None
+    max_allowed: int | None = None
 
 
 @dataclass(frozen=True)

--- a/lizyml/core/types/tuning_result.py
+++ b/lizyml/core/types/tuning_result.py
@@ -15,7 +15,7 @@ from lizyml.core.types.search_dim import SearchDim
 
 @dataclass(frozen=True)
 class BoundaryDimStatus:
-    """Boundary analysis for a single search dimension (H-0068).
+    """Boundary analysis for a single search dimension (H-0068, H-0078).
 
     Attributes:
         name: Dimension name.
@@ -27,6 +27,9 @@ class BoundaryDimStatus:
         expanded: Whether this dim was expanded in the current round.
         new_low: New lower bound after expansion (None if not expanded).
         new_high: New upper bound after expansion (None if not expanded).
+        clamped_to_bound: ``True`` when expansion hit the dim's
+            ``min_allowed`` / ``max_allowed`` ceiling/floor (H-0078).
+            Used by downstream UIs to badge "max reached" dims.
     """
 
     name: str
@@ -38,6 +41,7 @@ class BoundaryDimStatus:
     expanded: bool
     new_low: float | int | None
     new_high: float | int | None
+    clamped_to_bound: bool = False
 
 
 @dataclass(frozen=True)

--- a/lizyml/estimators/lgbm/provider.py
+++ b/lizyml/estimators/lgbm/provider.py
@@ -31,6 +31,28 @@ from lizyml.estimators.provider import ExportParams
 from lizyml.features.pipeline_base import BaseFeaturePipeline
 from lizyml.features.pipelines_native import NativeFeaturePipeline
 
+# H-0078: LightGBM-meaningful per-parameter bounds for boundary expansion.
+# Values reflect LightGBM's documented limits and physically-meaningful
+# ranges; they keep ``expand_dims`` from drifting into ranges that crash
+# the booster or have no effect.
+_LGBM_PARAMETER_BOUNDS: dict[str, dict[str, float | int]] = {
+    "learning_rate": {"min": 1e-8, "max": 1.0},
+    "feature_fraction": {"min": 1e-3, "max": 1.0},
+    "bagging_fraction": {"min": 1e-3, "max": 1.0},
+    "num_leaves_ratio": {"min": 0.1, "max": 2.0},
+    "min_data_in_leaf_ratio": {"min": 1e-4, "max": 0.5},
+    "min_data_in_bin_ratio": {"min": 1e-4, "max": 0.5},
+    "validation_ratio": {"min": 0.05, "max": 0.5},
+    "lambda_l1": {"min": 0.0, "max": 100.0},
+    "lambda_l2": {"min": 0.0, "max": 100.0},
+    "n_estimators": {"min": 10, "max": 10000},
+    "max_depth": {"min": -1, "max": 30},
+    "max_bin": {"min": 2, "max": 8192},
+    "bagging_freq": {"min": 0, "max": 100},
+    "early_stopping_rounds": {"min": 1, "max": 5000},
+    "seed": {"min": 0, "max": 2**31 - 1},
+}
+
 
 class LGBMProvider:
     """EstimatorProvider implementation for LightGBM.
@@ -188,6 +210,17 @@ class LGBMProvider:
             )
 
         return rows
+
+    def parameter_bounds(self, task: TaskType) -> dict[str, dict[str, float | int]]:
+        """Return LightGBM-meaningful bounds for boundary expansion (H-0078).
+
+        These limits constrain ``expand_dims`` so that ``re_tune=True``
+        cannot grow ``learning_rate`` past 1.0, ``feature_fraction`` past
+        1.0, ``validation_ratio`` below ~0, etc. Bounds are not
+        task-dependent for LightGBM.
+        """
+        del task  # bounds are identical across tasks for LightGBM
+        return _LGBM_PARAMETER_BOUNDS
 
     def build_export_params(self, adapter: BaseEstimatorAdapter) -> ExportParams:
         """Build codegen-relevant params from a fitted ``LGBMAdapter`` (H-0073).

--- a/lizyml/estimators/provider.py
+++ b/lizyml/estimators/provider.py
@@ -147,3 +147,17 @@ class EstimatorProvider(Protocol):  # pragma: no cover
                 responsible for narrowing the adapter type internally.
         """
         ...
+
+    def parameter_bounds(self, task: TaskType) -> dict[str, dict[str, float | int]]:
+        """Return per-parameter meaningful bounds for this estimator (H-0078).
+
+        Used by ``expand_dims`` to clamp boundary expansion and by
+        downstream UIs (e.g. LizyStudio) to constrain user input.
+
+        Returns:
+            Dict mapping a parameter name to ``{"min": ..., "max": ...}``.
+            Parameters not present in the dict are unbounded (re-tune
+            expansion grows freely as before). An empty dict means the
+            provider has no parameter-specific bounds to declare.
+        """
+        ...

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -25,6 +25,7 @@ __all__ = [
     "FloatDim",
     "IntDim",
     "SearchDim",
+    "attach_bounds",
     "detect_boundary",
     "expand_dims",
     "parse_space",
@@ -393,6 +394,67 @@ def detect_boundary(
         dims=tuple(statuses),
         expanded_names=tuple(expanded_names),
     )
+
+
+def attach_bounds(
+    dims: list[SearchDim],
+    bounds: dict[str, dict[str, float | int]],
+) -> list[SearchDim]:
+    """Return a new list of dims with ``min_allowed`` / ``max_allowed`` injected.
+
+    For each ``FloatDim`` / ``IntDim`` whose ``name`` is a key in *bounds*,
+    a copy is returned with ``min_allowed`` / ``max_allowed`` populated
+    from ``{"min": ..., "max": ...}``. Dims that already carry user-set
+    bounds are left untouched (user override wins). ``CategoricalDim`` is
+    always returned unchanged. Dims with no entry in *bounds* are
+    unchanged.
+
+    Used by ``Model.tune`` to wire ``EstimatorProvider.parameter_bounds(task)``
+    onto the search space (H-0078).
+    """
+    if not bounds:
+        return list(dims)
+
+    new_dims: list[SearchDim] = []
+    for dim in dims:
+        if isinstance(dim, CategoricalDim):
+            new_dims.append(dim)
+            continue
+        b = bounds.get(dim.name)
+        if b is None:
+            new_dims.append(dim)
+            continue
+        # Respect user-set bounds — do not overwrite.
+        if dim.min_allowed is not None or dim.max_allowed is not None:
+            new_dims.append(dim)
+            continue
+        if isinstance(dim, FloatDim):
+            new_dims.append(
+                FloatDim(
+                    name=dim.name,
+                    low=dim.low,
+                    high=dim.high,
+                    log=dim.log,
+                    category=dim.category,
+                    min_allowed=float(b["min"]),
+                    max_allowed=float(b["max"]),
+                )
+            )
+        elif isinstance(dim, IntDim):
+            new_dims.append(
+                IntDim(
+                    name=dim.name,
+                    low=dim.low,
+                    high=dim.high,
+                    log=dim.log,
+                    category=dim.category,
+                    min_allowed=int(b["min"]),
+                    max_allowed=int(b["max"]),
+                )
+            )
+        else:  # pragma: no cover — exhaustive over SearchDim
+            new_dims.append(dim)
+    return new_dims
 
 
 def expand_dims(

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -36,6 +36,39 @@ __all__ = [
 _ALLOWED_CHOICE_TYPES = (type(None), bool, int, float, str)
 
 
+def _validate_numeric_range(
+    name: str,
+    low: float,
+    high: float,
+    *,
+    log: bool,
+) -> None:
+    """Validate ``low < high`` and (when ``log`` is True) ``low > 0``.
+
+    Optuna only raises these errors at trial-time with generic messages.
+    Catching them at parse time gives users a clear, configuration-level
+    diagnostic with the offending bounds in ``context``.
+    """
+    if low >= high:
+        raise LizyMLError(
+            code=ErrorCode.CONFIG_INVALID,
+            user_message=(
+                f"Search dim '{name}' has low >= high (low={low}, high={high}). "
+                f"Min must be strictly less than Max."
+            ),
+            context={"param": name, "low": low, "high": high, "log": log},
+        )
+    if log and low <= 0:
+        raise LizyMLError(
+            code=ErrorCode.CONFIG_INVALID,
+            user_message=(
+                f"Search dim '{name}' uses log distribution but low={low} <= 0. "
+                f"Log requires a strictly positive lower bound."
+            ),
+            context={"param": name, "low": low, "high": high, "log": log},
+        )
+
+
 def _validate_categorical_choices(name: str, choices: list[Any]) -> None:
     """Validate that every element in *choices* is a scalar type.
 
@@ -84,22 +117,30 @@ def parse_space(space: dict[str, Any]) -> list[SearchDim]:
         dim_type: str = spec.get("type", "")
         category: DimCategory = spec.get("category", "model")
         if dim_type == "float":
+            low_f = float(spec["low"])
+            high_f = float(spec["high"])
+            log_f = bool(spec.get("log", False))
+            _validate_numeric_range(name, low_f, high_f, log=log_f)
             dims.append(
                 FloatDim(
                     name=name,
-                    low=float(spec["low"]),
-                    high=float(spec["high"]),
-                    log=bool(spec.get("log", False)),
+                    low=low_f,
+                    high=high_f,
+                    log=log_f,
                     category=category,
                 )
             )
         elif dim_type == "int":
+            low_i = int(spec["low"])
+            high_i = int(spec["high"])
+            log_i = bool(spec.get("log", False))
+            _validate_numeric_range(name, low_i, high_i, log=log_i)
             dims.append(
                 IntDim(
                     name=name,
-                    low=int(spec["low"]),
-                    high=int(spec["high"]),
-                    log=bool(spec.get("log", False)),
+                    low=low_i,
+                    high=high_i,
+                    log=log_i,
                     category=category,
                 )
             )

--- a/lizyml/tuning/search_space.py
+++ b/lizyml/tuning/search_space.py
@@ -261,7 +261,9 @@ def _expand_range(
     edge: str,
     *,
     log: bool,
-) -> tuple[float, float]:
+    min_allowed: float | None = None,
+    max_allowed: float | None = None,
+) -> tuple[float, float, bool]:
     """Expand *low*/*high* asymmetrically toward *edge*.
 
     Linear lower-edge expansion is clamped at 0.0 (#110): negative bounds are
@@ -269,19 +271,33 @@ def _expand_range(
     crash downstream samplers. Log-scale expansion is already safe because
     division by ``_LOG_EXPANSION_FACTOR`` cannot make a positive value cross
     zero. ``IntDim`` retains its own ``max(1, ...)`` clamp at the call site.
+
+    When ``min_allowed`` / ``max_allowed`` are provided (H-0078), the
+    expansion is additionally clamped to those parameter-meaningful
+    bounds. The third return value is ``True`` iff such a clamp actually
+    bit (i.e. the natural expansion would have crossed the bound).
     """
+    new_low = low
+    new_high = high
     if edge == "lower":
         if log and low > 0:
             new_low = low / _LOG_EXPANSION_FACTOR
         else:
             new_low = max(0.0, low - (high - low))
-        return new_low, high
-    if edge == "upper":
+    elif edge == "upper":
         new_high = (
             high * _LOG_EXPANSION_FACTOR if log and high > 0 else high + (high - low)
         )
-        return low, new_high
-    return low, high
+
+    clamped = False
+    if min_allowed is not None and new_low < min_allowed:
+        new_low = min_allowed
+        clamped = True
+    if max_allowed is not None and new_high > max_allowed:
+        new_high = max_allowed
+        clamped = True
+
+    return new_low, new_high, clamped
 
 
 def detect_boundary(
@@ -335,8 +351,22 @@ def detect_boundary(
 
         new_low: float | int | None = None
         new_high: float | int | None = None
+        clamped = False
         if should_expand:
-            nl, nh = _expand_range(low, high, edge, log=is_log)
+            min_allowed = (
+                float(dim.min_allowed) if dim.min_allowed is not None else None
+            )
+            max_allowed = (
+                float(dim.max_allowed) if dim.max_allowed is not None else None
+            )
+            nl, nh, clamped = _expand_range(
+                low,
+                high,
+                edge,
+                log=is_log,
+                min_allowed=min_allowed,
+                max_allowed=max_allowed,
+            )
             if isinstance(dim, IntDim):
                 nl = max(1, int(math.floor(nl)))
                 nh = int(math.ceil(nh))
@@ -355,6 +385,7 @@ def detect_boundary(
                 expanded=should_expand,
                 new_low=new_low,
                 new_high=new_high,
+                clamped_to_bound=clamped,
             )
         )
 
@@ -402,6 +433,8 @@ def expand_dims(
                     high=float(status.new_high),
                     log=dim.log,
                     category=dim.category,
+                    min_allowed=dim.min_allowed,
+                    max_allowed=dim.max_allowed,
                 )
             )
         elif (
@@ -416,6 +449,8 @@ def expand_dims(
                     high=int(status.new_high),
                     log=dim.log,
                     category=dim.category,
+                    min_allowed=dim.min_allowed,
+                    max_allowed=dim.max_allowed,
                 )
             )
         else:

--- a/tests/test_estimators/test_check_provider.py
+++ b/tests/test_estimators/test_check_provider.py
@@ -158,6 +158,33 @@ class TestProtocolReturnTypes:
         result = provider.default_fixed_params(task)
         assert isinstance(result, dict)
 
+    @pytest.mark.parametrize(
+        "provider_name,provider", PROVIDERS, ids=[p[0] for p in PROVIDERS]
+    )
+    @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])
+    def test_parameter_bounds_returns_dict(
+        self, provider_name: str, provider: Any, task: str
+    ) -> None:
+        """``parameter_bounds`` returns a dict of param->{'min','max'} (H-0078).
+
+        An empty dict is acceptable (provider without bounds).  Non-empty
+        entries must each contain 'min' and 'max' as numeric values, with
+        ``min < max``.
+        """
+        bounds = provider.parameter_bounds(task)
+        assert isinstance(bounds, dict)
+        for param, b in bounds.items():
+            assert isinstance(param, str), f"param key must be str, got {type(param)}"
+            assert isinstance(b, dict), f"{param} bounds must be dict"
+            assert "min" in b and "max" in b, (
+                f"{param} bounds must have 'min' and 'max' keys"
+            )
+            assert isinstance(b["min"], (int, float)), f"{param}.min must be numeric"
+            assert isinstance(b["max"], (int, float)), f"{param}.max must be numeric"
+            assert b["min"] < b["max"], (
+                f"{param} must satisfy min < max, got min={b['min']}, max={b['max']}"
+            )
+
 
 # ===================================================================
 # Check 2: Factory → fit → predict roundtrip

--- a/tests/test_estimators/test_lgbm_defaults.py
+++ b/tests/test_estimators/test_lgbm_defaults.py
@@ -108,3 +108,57 @@ class TestUserOverride:
         )._build_params()
         for key in ("n_estimators", "random_state", "verbose"):
             assert key not in params
+
+
+# ---------------------------------------------------------------------------
+# H-0078 Phase 2: parameter_bounds (LGBM)
+# ---------------------------------------------------------------------------
+
+
+class TestLGBMParameterBounds:
+    """LGBMProvider.parameter_bounds returns LightGBM-meaningful bounds."""
+
+    def _bounds(self, task: str = "regression") -> dict:
+        from lizyml.estimators.lgbm.provider import LGBMProvider
+
+        return LGBMProvider().parameter_bounds(task)
+
+    def test_returns_non_empty_map(self) -> None:
+        bounds = self._bounds()
+        assert len(bounds) > 0
+
+    def test_learning_rate_capped_at_one(self) -> None:
+        """`learning_rate` must not be allowed to grow beyond 1.0 (#152)."""
+        b = self._bounds()
+        assert "learning_rate" in b
+        assert b["learning_rate"]["max"] <= 1.0
+        assert b["learning_rate"]["min"] > 0  # log-safe
+
+    def test_feature_fraction_capped_at_one(self) -> None:
+        b = self._bounds()
+        assert "feature_fraction" in b
+        assert b["feature_fraction"]["max"] <= 1.0
+
+    def test_bagging_fraction_capped_at_one(self) -> None:
+        b = self._bounds()
+        assert "bagging_fraction" in b
+        assert b["bagging_fraction"]["max"] <= 1.0
+
+    def test_validation_ratio_floor_above_zero(self) -> None:
+        """validation_ratio of 0 means no inner valid; must stay above 0 (#152)."""
+        b = self._bounds()
+        assert "validation_ratio" in b
+        assert b["validation_ratio"]["min"] > 0
+
+    def test_max_depth_has_sane_ceiling(self) -> None:
+        """max_depth growing without bound causes tree memory cliffs (#152)."""
+        b = self._bounds()
+        assert "max_depth" in b
+        assert b["max_depth"]["max"] <= 50
+
+    def test_same_bounds_across_tasks(self) -> None:
+        """Bounds are not task-dependent for LightGBM (sanity)."""
+        b_reg = self._bounds("regression")
+        b_bin = self._bounds("binary")
+        b_mc = self._bounds("multiclass")
+        assert b_reg == b_bin == b_mc

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -30,7 +30,7 @@ from lizyml.core.types.tuning_result import (
     TuneProgressInfo,
     TuningResult,
 )
-from lizyml.tuning.search_space import detect_boundary, expand_dims
+from lizyml.tuning.search_space import attach_bounds, detect_boundary, expand_dims
 from tests._helpers import make_config, make_regression_df
 
 # ---------------------------------------------------------------------------
@@ -403,6 +403,161 @@ class TestBoundaryDimStatusClampedField:
             clamped_to_bound=True,
         )
         assert s.clamped_to_bound is True
+
+
+# ---------------------------------------------------------------------------
+# H-0078 Phase 3: attach_bounds — provider->dim wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAttachBounds:
+    """``attach_bounds`` injects provider bounds onto matching dims."""
+
+    def test_floatdim_matching_name_gets_bounds(self) -> None:
+        dims = [FloatDim("learning_rate", low=0.001, high=0.1, log=True)]
+        bounds = {"learning_rate": {"min": 1e-8, "max": 1.0}}
+        new = attach_bounds(dims, bounds)
+        assert isinstance(new[0], FloatDim)
+        assert new[0].min_allowed == 1e-8
+        assert new[0].max_allowed == 1.0
+        # Other fields preserved
+        assert new[0].low == 0.001
+        assert new[0].high == 0.1
+        assert new[0].log is True
+
+    def test_intdim_matching_name_gets_bounds_as_int(self) -> None:
+        dims = [IntDim("max_depth", low=3, high=12)]
+        bounds = {"max_depth": {"min": -1, "max": 30}}
+        new = attach_bounds(dims, bounds)
+        assert isinstance(new[0], IntDim)
+        assert new[0].min_allowed == -1
+        assert new[0].max_allowed == 30
+        assert isinstance(new[0].max_allowed, int)
+
+    def test_dim_without_match_unchanged(self) -> None:
+        dim = FloatDim("custom_param", low=0.1, high=0.5)
+        bounds = {"learning_rate": {"min": 0.0, "max": 1.0}}
+        new = attach_bounds([dim], bounds)
+        assert new[0] is dim  # untouched, same object
+
+    def test_categorical_dim_unchanged(self) -> None:
+        dim = CategoricalDim("obj", choices=("a", "b"))
+        bounds = {"obj": {"min": 0.0, "max": 1.0}}  # nonsensical but shouldn't crash
+        new = attach_bounds([dim], bounds)
+        assert new[0] is dim
+
+    def test_user_set_min_allowed_preserved(self) -> None:
+        """User-set min_allowed/max_allowed wins over provider bounds."""
+        dims = [
+            FloatDim(
+                "learning_rate",
+                low=0.001,
+                high=0.1,
+                log=True,
+                min_allowed=1e-6,
+                max_allowed=0.5,
+            )
+        ]
+        bounds = {"learning_rate": {"min": 1e-8, "max": 1.0}}
+        new = attach_bounds(dims, bounds)
+        # user values preserved
+        assert new[0].min_allowed == 1e-6
+        assert new[0].max_allowed == 0.5
+
+    def test_empty_bounds_returns_same_list(self) -> None:
+        dims = [FloatDim("x", low=0.0, high=1.0)]
+        new = attach_bounds(dims, {})
+        assert new[0] is dims[0]
+
+    def test_multiple_dims_some_matching(self) -> None:
+        dims = [
+            FloatDim("learning_rate", low=0.001, high=0.1),
+            IntDim("max_depth", low=3, high=12),
+            FloatDim("custom_unrelated", low=0.0, high=1.0),
+        ]
+        bounds = {
+            "learning_rate": {"min": 1e-8, "max": 1.0},
+            "max_depth": {"min": -1, "max": 30},
+        }
+        new = attach_bounds(dims, bounds)
+        assert new[0].max_allowed == 1.0
+        assert new[1].max_allowed == 30
+        assert new[2].max_allowed is None
+
+
+class TestModelTuneWiresParameterBounds:
+    """Integration: ``Model.tune(re_tune=True)`` clamps boundary expansion
+    using ``provider.parameter_bounds(task)`` (H-0078 Phase 3)."""
+
+    def test_default_space_picks_up_lgbm_bounds(self) -> None:
+        """Tuning with the default LightGBM space exposes max_allowed on
+        ``learning_rate`` after the first ``tune()`` call."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {"optuna": {"params": {"n_trials": 2}}}
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        space = model._space  # type: ignore[attr-defined]
+        assert space is not None
+        lr = next((d for d in space if d.name == "learning_rate"), None)
+        assert lr is not None
+        assert lr.max_allowed == 1.0
+
+    def test_user_space_lr_picks_up_lgbm_bounds_by_name(self) -> None:
+        """A user-supplied dim named ``learning_rate`` also picks up the
+        provider bound by name match."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {
+            "optuna": {
+                "params": {"n_trials": 2},
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.01,
+                        "high": 0.3,
+                        "log": True,
+                    },
+                },
+            }
+        }
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        space = model._space  # type: ignore[attr-defined]
+        lr = next((d for d in space if d.name == "learning_rate"), None)
+        assert lr is not None
+        assert lr.max_allowed == 1.0
+        assert lr.min_allowed == 1e-8
+
+    def test_re_tune_clamps_learning_rate_at_one(self) -> None:
+        """Regression for #152: re-tune cannot push ``learning_rate.high``
+        past 1.0 because provider bounds are wired through ``Model.tune``."""
+        cfg = make_config("regression")
+        cfg["tuning"] = {
+            "optuna": {
+                "params": {"n_trials": 2},
+                "space": {
+                    "learning_rate": {
+                        "type": "float",
+                        "low": 0.5,
+                        "high": 0.9,
+                        "log": True,
+                    },
+                    "max_depth": {"type": "int", "low": 3, "high": 5},
+                },
+            }
+        }
+        df = make_regression_df()
+        model = Model(cfg)
+        model.tune(df)
+        # Run several re-tune rounds with expand_boundary=True. The space
+        # should never grow ``learning_rate.high`` past 1.0.
+        for _ in range(5):
+            model.tune(df, resume=True, n_trials=2, expand_boundary=True)
+            space = model._space  # type: ignore[attr-defined]
+            lr = next((d for d in space if d.name == "learning_rate"), None)
+            assert lr is not None
+            assert lr.high <= 1.0, f"learning_rate.high must stay <= 1.0, got {lr.high}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tuning/test_retune.py
+++ b/tests/test_tuning/test_retune.py
@@ -202,6 +202,210 @@ class TestExpandDims:
 
 
 # ---------------------------------------------------------------------------
+# H-0078 Phase 2: bounds-aware expansion
+# ---------------------------------------------------------------------------
+
+
+class TestExpandWithBounds:
+    """Boundary expansion respects per-dim ``min_allowed`` / ``max_allowed``.
+
+    Regression for #152: re-tuning grew ``learning_rate`` past 1.0 and
+    ``feature_fraction`` past 1.0 because no parameter-aware ceiling
+    existed. With ``max_allowed`` set, expansion clamps and signals via
+    ``clamped_to_bound``.
+    """
+
+    def test_upper_expansion_clamps_to_max_allowed_log(self) -> None:
+        """log dim near upper edge: 0.3 * 3 = 0.9 (under cap), but next round
+        would exceed; with max_allowed=1.0 the expansion is clamped to 1.0."""
+        dims = [
+            FloatDim(
+                "learning_rate",
+                low=0.0001,
+                high=0.5,
+                log=True,
+                max_allowed=1.0,
+            )
+        ]
+        report = detect_boundary(dims, {"learning_rate": 0.49}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert isinstance(new[0], FloatDim)
+        # 0.5 * 3.0 = 1.5 → clamped to 1.0
+        assert new[0].high == 1.0
+        # the dim status must signal clamp
+        status = next(s for s in report.dims if s.name == "learning_rate")
+        assert status.clamped_to_bound is True
+
+    def test_upper_expansion_clamps_to_max_allowed_linear(self) -> None:
+        dims = [FloatDim("ff", low=0.5, high=1.0, log=False, max_allowed=1.0)]
+        report = detect_boundary(dims, {"ff": 0.99}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == 1.0
+        status = next(s for s in report.dims if s.name == "ff")
+        assert status.clamped_to_bound is True
+
+    def test_lower_expansion_clamps_to_min_allowed(self) -> None:
+        """validation_ratio with min_allowed=0.05 must not collapse to 0.0."""
+        dims = [
+            FloatDim(
+                "validation_ratio",
+                low=0.1,
+                high=0.3,
+                log=False,
+                min_allowed=0.05,
+            )
+        ]
+        report = detect_boundary(dims, {"validation_ratio": 0.11}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.1 - 0.2 = -0.1 → would clamp to 0.0 normally, but min_allowed
+        # forces the floor up to 0.05.
+        assert new[0].low == 0.05
+        status = next(s for s in report.dims if s.name == "validation_ratio")
+        assert status.clamped_to_bound is True
+
+    def test_no_clamp_when_within_bounds(self) -> None:
+        """Expansion that does not hit a bound must not signal clamped."""
+        dims = [
+            FloatDim(
+                "lr",
+                low=0.01,
+                high=0.05,
+                log=True,
+                max_allowed=1.0,
+            )
+        ]
+        report = detect_boundary(dims, {"lr": 0.049}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 0.05 * 3 = 0.15, well under 1.0 → no clamp
+        assert new[0].high == pytest.approx(0.15, rel=1e-9)
+        status = next(s for s in report.dims if s.name == "lr")
+        assert status.clamped_to_bound is False
+
+    def test_int_dim_upper_clamp_to_max_allowed(self) -> None:
+        dims = [IntDim("max_depth", low=3, high=12, max_allowed=30)]
+        report = detect_boundary(dims, {"max_depth": 12}, threshold=0.05)
+        new = expand_dims(dims, report)
+        # 12 + (12 - 3) = 21, under 30 → not clamped
+        assert isinstance(new[0], IntDim)
+        assert new[0].high == 21
+        status = next(s for s in report.dims if s.name == "max_depth")
+        assert status.clamped_to_bound is False
+
+        # Second round of expansion would push past 30 → clamped
+        dims2 = [IntDim("max_depth", low=3, high=21, max_allowed=30)]
+        report2 = detect_boundary(dims2, {"max_depth": 21}, threshold=0.05)
+        new2 = expand_dims(dims2, report2)
+        # 21 + (21 - 3) = 39 → clamp to 30
+        assert new2[0].high == 30
+        status2 = next(s for s in report2.dims if s.name == "max_depth")
+        assert status2.clamped_to_bound is True
+
+    def test_no_max_allowed_means_unbounded_expansion(self) -> None:
+        """Backward compat: no max_allowed → expansion grows unboundedly."""
+        dims = [FloatDim("lr", low=0.0001, high=0.1, log=True)]
+        report = detect_boundary(dims, {"lr": 0.099}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == pytest.approx(0.3, rel=1e-9)
+        status = next(s for s in report.dims if s.name == "lr")
+        assert status.clamped_to_bound is False
+
+    def test_clamp_to_existing_high_is_a_noop(self) -> None:
+        """If the expansion would land below the current high (degenerate
+        max_allowed already at high), expansion is effectively a no-op:
+        new high must not become smaller than the original high."""
+        dims = [FloatDim("ff", low=0.5, high=1.0, log=False, max_allowed=1.0)]
+        report = detect_boundary(dims, {"ff": 0.99}, threshold=0.05)
+        new = expand_dims(dims, report)
+        assert new[0].high == 1.0  # unchanged, not less
+        # And the status reports clamp because expansion was bounded
+        status = next(s for s in report.dims if s.name == "ff")
+        assert status.clamped_to_bound is True
+
+    def test_multi_round_log_expansion_never_exceeds_max_allowed(self) -> None:
+        """Regression for #152: the original report shows ``learning_rate``
+        drifting 0.1 → 0.3 → 0.9 → 2.7 over three re-tune rounds. With
+        ``max_allowed=1.0`` propagated across rounds, ``high`` must never
+        exceed 1.0 no matter how many rounds run."""
+        dim: FloatDim = FloatDim(
+            "learning_rate",
+            low=0.0001,
+            high=0.1,
+            log=True,
+            max_allowed=1.0,
+        )
+        dims: list = [dim]
+        for _ in range(10):
+            # always near upper edge → triggers expansion
+            best = dims[0].high * 0.99
+            report = detect_boundary(dims, {"learning_rate": best}, threshold=0.05)
+            dims = expand_dims(dims, report)
+            assert isinstance(dims[0], FloatDim)
+            assert dims[0].high <= 1.0, (
+                f"learning_rate.high must stay <= 1.0, got {dims[0].high}"
+            )
+            assert dims[0].max_allowed == 1.0  # bound is propagated
+        # After 10 rounds it should be saturated at exactly 1.0
+        assert dims[0].high == 1.0
+
+
+class TestSearchDimMinMaxAllowed:
+    """FloatDim / IntDim accept optional ``min_allowed`` / ``max_allowed``."""
+
+    def test_floatdim_default_none(self) -> None:
+        dim = FloatDim("x", low=0.0, high=1.0)
+        assert dim.min_allowed is None
+        assert dim.max_allowed is None
+
+    def test_floatdim_with_bounds(self) -> None:
+        dim = FloatDim("x", low=0.1, high=0.5, min_allowed=0.0, max_allowed=1.0)
+        assert dim.min_allowed == 0.0
+        assert dim.max_allowed == 1.0
+
+    def test_intdim_default_none(self) -> None:
+        dim = IntDim("n", low=1, high=10)
+        assert dim.min_allowed is None
+        assert dim.max_allowed is None
+
+    def test_intdim_with_bounds(self) -> None:
+        dim = IntDim("n", low=3, high=12, max_allowed=30)
+        assert dim.max_allowed == 30
+        assert dim.min_allowed is None
+
+
+class TestBoundaryDimStatusClampedField:
+    """``BoundaryDimStatus.clamped_to_bound`` defaults False."""
+
+    def test_default_false(self) -> None:
+        s = BoundaryDimStatus(
+            name="x",
+            best_value=0.5,
+            low=0.0,
+            high=1.0,
+            position_pct=0.5,
+            edge="none",
+            expanded=False,
+            new_low=None,
+            new_high=None,
+        )
+        assert s.clamped_to_bound is False
+
+    def test_set_true(self) -> None:
+        s = BoundaryDimStatus(
+            name="x",
+            best_value=0.99,
+            low=0.5,
+            high=1.0,
+            position_pct=0.99,
+            edge="upper",
+            expanded=True,
+            new_low=0.5,
+            new_high=1.0,
+            clamped_to_bound=True,
+        )
+        assert s.clamped_to_bound is True
+
+
+# ---------------------------------------------------------------------------
 # Type extension tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tuning/test_tuning.py
+++ b/tests/test_tuning/test_tuning.py
@@ -171,6 +171,81 @@ class TestParseSpace:
         dims = parse_space({})
         assert dims == []
 
+    # --- H-0078 Phase 1: range / log validation ---------------------------
+
+    def test_float_low_equal_high_raises(self) -> None:
+        """A float dim with low == high is degenerate and must be rejected."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"lr": {"type": "float", "low": 0.1, "high": 0.1}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "lr" in err.user_message
+        assert err.context.get("param") == "lr"
+
+    def test_float_low_greater_than_high_raises(self) -> None:
+        """An inverted float range must be rejected at parse time, not by Optuna."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"lr": {"type": "float", "low": 0.5, "high": 0.1}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "lr" in err.user_message
+        # context must capture both bounds for diagnosability
+        assert err.context.get("low") == 0.5
+        assert err.context.get("high") == 0.1
+
+    def test_int_low_equal_high_raises(self) -> None:
+        """An int dim with low == high is degenerate and must be rejected."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"n": {"type": "int", "low": 8, "high": 8}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "n" in err.user_message
+
+    def test_int_low_greater_than_high_raises(self) -> None:
+        """An inverted int range must be rejected at parse time."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"n": {"type": "int", "low": 64, "high": 16}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert err.context.get("param") == "n"
+
+    def test_float_log_with_zero_low_raises(self) -> None:
+        """Log distribution requires strictly positive lower bound."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"lr": {"type": "float", "low": 0.0, "high": 0.1, "log": True}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "log" in err.user_message.lower()
+        assert err.context.get("param") == "lr"
+        assert err.context.get("log") is True
+
+    def test_float_log_with_negative_low_raises(self) -> None:
+        """Log distribution must reject negative low even when low<high holds."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space(
+                {"lr": {"type": "float", "low": -0.01, "high": 0.1, "log": True}}
+            )
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "lr" in err.user_message
+
+    def test_int_log_with_zero_low_raises(self) -> None:
+        """Log on int dim with low<=0 must also be rejected."""
+        with pytest.raises(LizyMLError) as exc_info:
+            parse_space({"n": {"type": "int", "low": 0, "high": 100, "log": True}})
+        err = exc_info.value
+        assert err.code == ErrorCode.CONFIG_INVALID
+        assert "n" in err.user_message
+
+    def test_float_log_with_positive_low_ok(self) -> None:
+        """Sanity: a valid log-scale dim still parses without error."""
+        dims = parse_space(
+            {"lr": {"type": "float", "low": 0.001, "high": 0.1, "log": True}}
+        )
+        assert len(dims) == 1
+        assert isinstance(dims[0], FloatDim)
+        assert dims[0].log is True
+
 
 class TestSuggestParams:
     def test_float_suggestion(self) -> None:


### PR DESCRIPTION
## Summary
### Added

- **`EstimatorProvider.parameter_bounds(task)`** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — new Protocol method returning per-parameter meaningful bounds (`{"min": ..., "max": ...}`) for boundary expansion. `LGBMProvider.parameter_bounds(task)` ships a static map for 15 LightGBM parameters (e.g. `learning_rate ∈ [1e-8, 1.0]`, `feature_fraction ∈ [1e-3, 1.0]`, `validation_ratio ∈ [0.05, 0.5]`, `max_depth ∈ [-1, 30]`). Used by `Model.tune` and downstream UIs (LizyStudio) to constrain user input. Third-party providers may return `{}` for unbounded behaviour.
- **`SearchDim.min_allowed` / `max_allowed`** (H-0078) — optional bounds on `FloatDim` / `IntDim` (default `None`). Boundary expansion clamps to these limits when set.
- **`BoundaryDimStatus.clamped_to_bound: bool`** (H-0078) — flags dims whose expansion hit the parameter-meaningful bound, so downstream UIs can badge "max reached" dims. Defaults `False`.
- **`attach_bounds(dims, bounds)` helper in `lizyml.tuning.search_space`** (H-0078) — injects `min_allowed` / `max_allowed` onto matching dims by name. Called from `Model._resolve_search_space` so default-space and user-supplied dims both pick up provider bounds automatically.

### Changed

- **`parse_space()` rejects degenerate / inverted ranges and log-with-non-positive-low** (H-0078, [#152](https://github.com/nbx-liz/LizyML/issues/152)) — `low >= high` and `log=True ∧ low <= 0` now raise `LizyMLError(CONFIG_INVALID)` at parse time instead of letting Optuna raise a generic error mid-trial. Strictly better failure mode (earlier and clearer).
- **`expand_dims` propagates `min_allowed` / `max_allowed`** (H-0078) — re-tune over multiple rounds preserves provider-supplied bounds, preventing the original `learning_rate` drift (`0.1 → 0.3 → 0.9 → 2.7`) reported in #152. 5- and 10-round regression tests guard the contract.

### Internal

- **`_expand_range` is bounds-aware** (H-0078) — keyword-only `min_allowed` / `max_allowed` arguments + 3-tuple return `(low, high, clamped)`. Internal signature change; only `detect_boundary` is a caller.

## Version
- Previous: v0.13.0
- New: v0.14.0
- Type: MINOR
