### PR TITLE
fix(estimators): respect user/Optuna-supplied objective when task-compatible (H-0079 Phase 1, refs #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed (potentially breaking)
+
+- **`LGBMConfig.params["objective"]` is now respected when task-compatible** (H-0079 Phase 1, [#159](https://github.com/nbx-liz/LizyML/issues/159)) — pre-0.15 `LGBMAdapter._build_params()` silently stripped any user/Optuna-supplied `objective` and force-set `_TASK_OBJECTIVE[task]`, so `default_space("regression")` trials sampling `"fair"` actually trained with `"huber"`. From this release: same-task values flow through to `lgb.train` (e.g. `objective="fair"` for regression now actually uses Fair loss); cross-task values raise `LizyMLError(CONFIG_INVALID)` instead of being silently demoted. Users who relied on the silent strip to suppress accidental cross-task injection see no behaviour change at the contract level (still rejected), but **same-task non-default objectives may produce different metrics than pre-0.15 runs**. Re-running tune over `default_space` may yield a different `best_params` because `"fair"` is now genuinely evaluated.
+- **`LGBMAdapter._build_params()` enforces an objective invariant assertion** (H-0079 L5) — at the end of `_build_params()`, an `assert` validates that any user-supplied `objective` survives the build. Active in dev / test / CI; suppressed under `python -O`. Fail-fast guard against future regressions to the silent-strip pattern.
+
+### Added
+
+- **`TASK_COMPATIBLE_OBJECTIVES` whitelist in `lizyml.estimators.lgbm.defaults`** (H-0079 Phase 1) — public mapping `dict[str, frozenset[str]]` enumerating the canonical LightGBM objective names valid per task (regression: 9, binary: 3, multiclass: 2). Used by `_build_params()` for cross-task validation and exposed for downstream integrations until the Provider-level API ships in Phase 2.
+
 ## [0.14.0] - 2026-05-10
 
 ### Added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6488,4 +6488,144 @@ Re-tune (`expand_boundary=True`) を繰り返した際、`expand_dims` がパラ
   - 後方互換性は完全維持。サードパーティ Provider は `parameter_bounds(task) -> {}` で従来挙動を再現可能。
   - リリース: v0.14.0 で配布。
 
+## H-0079: silent objective override 修正と `EstimatorProvider.objective_choices()` / `metric_choices()` 導入
+
+- **ステータス**: Proposed
+- **起票日**: 2026-05-10
+- **スコープ**: Public API (`EstimatorProvider`), `lizyml/estimators/lgbm/adapter.py`, `lizyml/estimators/lgbm/defaults.py`, `lizyml/estimators/lgbm/metric_bridge.py`, `lizyml/estimators/lgbm/provider.py`, `lizyml/tuning/search_space.py` (`default_space` signature)
+- **関連**: [Issue #159](https://github.com/nbx-liz/LizyML/issues/159), H-0078（同型の Provider 拡張パターン）, LizyStudio Issue #461（下流 UI consumer）
+
+### 目的
+
+LGBM Provider 層に存在する次の 2 つの問題を解消する。
+
+1. **Bug — silent objective override**: `LGBMAdapter._build_params()` が user / Optuna trial 由来の `objective` を **無条件に strip** し、`_TASK_OBJECTIVE[task]` で再代入する。`default_space("regression")` の `CategoricalDim("objective", ("huber", "fair"))` で `"fair"` をサンプルした trial も実際は `"huber"` で学習され、`tuning_table` の `objective` 列が嘘になる。`metric` 側は H-0061 で同型の strip を解除済だが、`objective` は同型バグとして残置されていた（コミット `ba152b0`「fix(estimators): objective/metric stripped from user params (task-locked)」、2026-03-15）。
+2. **API gap — private choice lists**: LizyStudio など下流 UI が "valid objective / metric per task" を提示する際、`_OBJECTIVE_CHOICES`（`defaults.py`）/ `_LGBM_NATIVE_METRICS` / `_FEVAL_METRICS`（`metric_bridge.py`）すべてが private。Provider レベルの公開 API が無いため、下流は (a) リストを再実装（drift risk）または (b) private symbol を import（layer 違反）の二択になる。さらに `_OBJECTIVE_CHOICES` は LightGBM が受理する `objective` enum の一部しか登録していない（regression: 9 → 2、binary: 3 → 1、multiclass: 2 → 2）。
+
+H-0078 の `parameter_bounds(task)` と同型の Provider 拡張で両方を一度に解く。
+
+### 対応方針
+
+H-0078 と同じ 3-Phase 構成。Phase 単位で独立 PR 化し、各 Phase のみで価値が出る形にする。
+
+#### Phase 1 — silent override 修正 + invariant guards
+
+`LGBMAdapter._build_params()` の `user_params.pop("objective", None)` を **task-compatibility check** に置換する。
+
+- 同 task 互換の値 → `params["objective"]` に上書き（lgb.train まで届く）。
+- task 非互換の値（例: `task="binary"` で `objective="regression"`）→ `LizyMLError(CONFIG_INVALID)` を raise。既存の cross-task 注入防御テスト（`tests/test_code_review_fixes.py`）の意図は維持される。
+- 末尾に **invariant assertion** を追加し、user 指定値が strip / 上書きされた場合に dev / test 環境で fail-fast（L5 in-code guard）。
+
+`TASK_COMPATIBLE_OBJECTIVES: dict[TaskType, frozenset[str]]` を `defaults.py` に追加し、LightGBM 公式 enum の canonical 名のみ登録する（regression 9 / binary 3 / multiclass 2）。
+
+#### Phase 2 — Provider choice APIs
+
+`EstimatorProvider` Protocol に 2 つの method を追加する。
+
+```python
+class EstimatorProvider(Protocol):
+    ...
+    def objective_choices(self, task: TaskType) -> tuple[str, ...]:
+        """Canonical objective names valid for *task*. No aliases."""
+        ...
+
+    def metric_choices(self, task: TaskType) -> dict[Literal["native", "feval"], tuple[str, ...]]:
+        """Per-task valid metrics, split by source.
+
+        - ``"native"``: LightGBM-evaluated metrics.
+        - ``"feval"``:  LizyML custom metrics, wired as feval callables.
+
+        Canonical names only, deterministic order, no duplicates across keys.
+        """
+        ...
+```
+
+`LGBMProvider` で実装。`default_space()` は optional `provider` 引数を受け取り、`provider.objective_choices(task)` から `CategoricalDim("objective", ...)` を構築する（既存 callers は無変更で動作）。
+
+#### Phase 3 — 内部統合 + drift guards + docs
+
+- `defaults.py:_OBJECTIVE_CHOICES` を削除し、`default_space` は `LGBMProvider().objective_choices()` を経由する。
+- `metric_bridge._LGBM_NATIVE_METRICS` / `_FEVAL_METRICS` は private cache として残すが、authoritative source は Provider と明記。alias 受理（`l1`, `l2`, `mae`, `mse` 等）は metric_bridge 側に残し、`metric_choices()` の戻り値は canonical のみ。
+- `MetricRegistry` の登録メトリクスが `metric_choices(task)["native"] ∪ metric_choices(task)["feval"]` で完全に被覆されることを drift test で担保（L4）。
+- `docs/config-reference.md` に task 別 valid objectives 表を追加（L7）。
+
+### Regression prevention（7 layers）
+
+Issue #159 で要求された全 7 層を Phase に分散して実装する。
+
+| Layer | 内容 | 対応 Phase |
+|---|---|---|
+| L1 | parametric end-to-end identity test（14 task×objective ペア） | Phase 1 |
+| L2 | tune-sampled-objective が refit booster に届く identity guard | Phase 1 |
+| L3 | provider drift smoke-fit（`objective_choices` / `metric_choices` の各値で実際に学習が通ること） | Phase 2 |
+| L4 | `MetricRegistry` ↔ `metric_choices` 被覆 drift test | Phase 3 |
+| L5 | `_build_params()` 末尾の invariant assertion | Phase 1 |
+| L6 | CHANGELOG（Changed (potentially breaking)）+ DEPRECATIONS 行 | Phase 1 |
+| L7 | `docs/config-reference.md` に task 別 valid objectives 表 | Phase 3 |
+
+### 影響範囲
+
+- **変更ファイル**:
+  - Phase 1: `lizyml/estimators/lgbm/adapter.py`、`lizyml/estimators/lgbm/defaults.py`（`TASK_COMPATIBLE_OBJECTIVES` 追加）、`tests/test_estimators/test_lgbm_objective_identity.py`（新規）、`tests/test_tuning/test_tune_fit_identity.py`（追記）、`tests/test_estimators/test_lgbm_defaults.py`（修正：バグ前提アサート差し替え）、`CHANGELOG.md`、`docs/DEPRECATIONS.md`、`HISTORY.md`。
+  - Phase 2: `lizyml/estimators/provider.py`（Protocol 追加）、`lizyml/estimators/lgbm/provider.py`（実装）、`lizyml/estimators/lgbm/defaults.py`（`default_space` signature）、`tests/test_estimators/test_provider_choice_apis.py`（新規）、`tests/test_estimators/test_provider_protocol_drift.py`（新規）、`HISTORY.md`、`CHANGELOG.md`。
+  - Phase 3: `lizyml/estimators/lgbm/defaults.py`（`_OBJECTIVE_CHOICES` 削除）、`lizyml/estimators/lgbm/metric_bridge.py`（authoritative source コメント）、`tests/test_estimators/test_metric_choices_registry_coverage.py`（新規）、`docs/config-reference.md`、`HISTORY.md`、`CHANGELOG.md`。
+- **無変更**: Persistence 形式、Calibration、Plots/Tables 出力 shape、Codegen export、CV / Splitter、Calibration の cross-fit 仕様。
+
+### 互換性
+
+- **`objective` の挙動変更**（Phase 1）: 同 task 互換値はこれまで silent に無視されていたが、今後は反映される。**過去の tune 結果を re-tune / refit すると metric が変動する可能性**がある（特に regression default_space の `objective="fair"` を引いていた trial）。CHANGELOG の "Changed (potentially breaking)" に明記し、DEPRECATIONS 行で言及する。
+- **`EstimatorProvider` の Protocol 拡張**（Phase 2）: method 2 件を追加。LizyML 内蔵 Provider（LGBM）は実装する。サードパーティ Provider が存在する場合は実装が必要だが現時点で該当なし（H-0078 と同じ判断）。
+- **`default_space()` signature**（Phase 2）: optional `provider` 引数を追加。既存 callers は無変更で動作。
+- **format_version 変更不要**: 保存物の意味は変わらない（trained booster 自体は今も `_TASK_OBJECTIVE[task]` で学習されているため、export / persistence で書かれる値は修正前後で一致）。Re-tune / re-fit 後にのみ booster の objective が変わる。
+
+### 代替案と不採用理由
+
+| 代替案 | 不採用理由 |
+|---|---|
+| `_TASK_OBJECTIVE` を継続し、user 指定値を完全無視（現状維持） | tune の `tuning_table` が嘘を表示し続ける問題が解決しない。`default_space` が `objective` を tunable に出している以上、サンプル値が反映されないのは仕様矛盾 |
+| 互換性のため warning のみで `_TASK_OBJECTIVE` を上書きしない | `tuning_table` と実際の booster が乖離し続ける（現状の bug と同じ）。サイレントが致命的なので fail-fast へ倒す |
+| Issue #159 を 1 PR で bundle | レビュー範囲が大きく、Phase 1 の bug fix が API 追加と同時にしか出せなくなる。H-0078 の 3-PR 構成が機能した実績があるため踏襲 |
+| `objective_choices` を `frozenset` で返す | 順序保証が無く、UI 側で安定した表示順を担保できない。`tuple[str, ...]` で順序固定 |
+| `metric_choices` を flat な `tuple` にする | 下流 UI が "native vs feval" を区別できず、計算速度の違い（feval は callable 経由で遅い）を伝えられない。`dict[Literal, tuple]` で source を明示 |
+| custom `fobj`（callable objective）対応を同梱 | 別問題（`ObjectiveRegistry` 設計が必要）。Out of scope として後続 Issue に回す |
+| `_TASK_METRIC` の objective 連動（例: `objective="tweedie"` なら metric も tweedie 系へ） | 別問題。UX 改善で hard bug ではないため Out of scope |
+
+### 受け入れ基準
+
+- [ ] **Phase 1**:
+  - [ ] `LGBMAdapter._build_params()` が同 task 互換の `objective` を pass-through し、cross-task 値を `LizyMLError(CONFIG_INVALID)` で reject する。
+  - [ ] L1: 14 (task × objective) ペアの parametric end-to-end identity test が green（user 指定 `objective` が booster の `params["objective"]` に bit-for-bit 一致する）。
+  - [ ] L2: tune-sampled-objective が refit booster に届く identity guard が green。
+  - [ ] L5: `_build_params()` 末尾の invariant assertion が存在する。
+  - [ ] L6: CHANGELOG「Changed (potentially breaking)」+ DEPRECATIONS 行。
+  - [ ] 既存 1709 テスト全件 pass。
+- [ ] **Phase 2**:
+  - [ ] `EstimatorProvider.objective_choices(task) -> tuple[str, ...]` が Protocol に追加されている。
+  - [ ] `EstimatorProvider.metric_choices(task) -> dict[Literal["native","feval"], tuple[str, ...]]` が Protocol に追加されている。
+  - [ ] `LGBMProvider.objective_choices(task)` が canonical 9 / 3 / 2 を返す。
+  - [ ] `LGBMProvider.metric_choices(task)` が canonical 名のみ・重複無し・順序固定で返す。
+  - [ ] `default_space(task, provider=None)` が `provider.objective_choices(task)` を経由する。
+  - [ ] L3: provider drift smoke-fit（全 objective / 全 native metric で smoke fit が通る）。
+- [ ] **Phase 3**:
+  - [ ] `_OBJECTIVE_CHOICES`（defaults.py）が削除されている。
+  - [ ] L4: MetricRegistry ↔ `metric_choices` 被覆 drift test が green。
+  - [ ] L7: `docs/config-reference.md` に task 別 valid objectives 表が追加されている。
+- [ ] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy lizyml/` / `uv run pytest` が全 Phase でクリーン。
+
+### Migration
+
+- ユーザー向け：
+  - `LGBMConfig.params={"objective": ...}` を明示指定していたコードは、これまで silent に無視されていた値が今後は反映される。同 task 互換であれば動作上のデグレは無いが、metric が変わる可能性に注意。
+  - `default_space("regression")` の tune 結果は、`"fair"` を引いた trial が今後は実際に `fair` で学習されるため、過去の tuning_table の score と乖離する可能性がある（過去の tuning_table は嘘だった）。
+- サードパーティ Provider 実装者：Phase 2 で `objective_choices` / `metric_choices` の追加実装を求める。空の `tuple` / `{"native": (), "feval": ()}` を返せば「choice 提供なし」として扱われる（`default_space` 側はサンプル候補が無くなるので tune 不可、明示的なエラーにする）。
+
+### Decision
+
+- Date: 2026-05-10
+- Result: accepted (Phase 1)
+- Notes:
+  - **Phase 1 (PR pending)**: `LGBMAdapter._build_params()` の `user_params.pop("objective", None)` を `_check_objective_compatible()` 経由の task-compat check に置換。`TASK_COMPATIBLE_OBJECTIVES`（regression 9 / binary 3 / multiclass 2）を `defaults.py` に追加。L1 parametric identity test（14 ペア + 7 cross-task reject）、L2 tune-sampled-objective identity test（regression）、L5 in-code invariant assertion を実装（+24 tests）。CHANGELOG「Changed (potentially breaking)」と DEPRECATIONS の行を追加。
+  - 既存 1709 → 1794 テスト全件 pass。
+  - **Phase 2 / Phase 3 は別 PR で続報**。Decision rows を順次追記する。
+
 

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -18,6 +18,7 @@ a removal-version suffix matching the pattern `Will be removed in v\d+\.\d+`.
 | `purged_time_series.embargo_pct` | `embargo` (int, observation count) | **v1.0** | H-0021 |
 | `purged_time_series.gap` | `embargo` | **v1.0** | H-0021 |
 | `lizyml.core._model_factories.build_calibration_splitter` | (removed; outer split is reused) | **v1.0** | H-0058 |
+| `LGBMConfig.params["objective"]` silently stripped (cross-task) | Raise `LizyMLError(CONFIG_INVALID)` at fit time | **already enforced** | H-0079 (2026-05) |
 
 ## Migration notes
 
@@ -79,6 +80,33 @@ split:
   purge_gap: 5
   embargo: 10        # explicit observation count, not a fraction
 ```
+
+### `LGBMConfig.params["objective"]` cross-task injection (H-0079)
+
+Pre-0.15 the `LGBMAdapter._build_params()` body popped `objective` from
+the user-supplied params unconditionally and re-set
+`_TASK_OBJECTIVE[task]`. Cross-task values like
+`task="binary", params={"objective": "regression"}` were silently
+dropped — same defensive intent, but no signal to the user.
+
+From v0.15 the same defensive contract is enforced explicitly:
+
+```python
+# Before (v0.14 and earlier): silently dropped
+LGBMConfig(task="binary", params={"objective": "regression"})  # trained with "binary"
+
+# After (v0.15+): raises CONFIG_INVALID at fit / _build_params
+LGBMConfig(task="binary", params={"objective": "regression"})
+# LizyMLError: objective 'regression' is not compatible with task 'binary'.
+# Valid: ['binary', 'cross_entropy', 'cross_entropy_lambda'].
+```
+
+For same-task values (e.g. `task="regression"`, `objective="fair"`) the
+silent strip was a **bug** rather than a deprecated contract:
+`default_space("regression")` already exposed `objective` as a tunable,
+yet the sampled value was discarded. v0.15 honours those values, so
+`tune` may now report a different `best_params`/`best_score` for
+identical config + data.
 
 ### `build_calibration_splitter()` (removed)
 

--- a/lizyml/estimators/lgbm/adapter.py
+++ b/lizyml/estimators/lgbm/adapter.py
@@ -15,8 +15,33 @@ from lizyml.estimators.lgbm.defaults import (
     _COMMON_DEFAULTS,
     _TASK_METRIC,
     _TASK_OBJECTIVE,
+    TASK_COMPATIBLE_OBJECTIVES,
 )
 from lizyml.estimators.lgbm.metric_bridge import resolve_metrics
+
+
+def _check_objective_compatible(task: str, objective: str) -> None:
+    """Raise CONFIG_INVALID when *objective* is not valid for *task* (H-0079).
+
+    Cross-task injection (e.g. ``objective='regression'`` for binary task)
+    used to be silently stripped pre-H-0079 — same defensive intent, but
+    explicit failure instead of a silent override that misled tuning_table.
+    """
+    valid = TASK_COMPATIBLE_OBJECTIVES.get(task, frozenset())
+    if objective not in valid:
+        raise LizyMLError(
+            code=ErrorCode.CONFIG_INVALID,
+            user_message=(
+                f"objective '{objective}' is not compatible with task "
+                f"'{task}'. Valid objectives: {sorted(valid)}."
+            ),
+            context={
+                "task": task,
+                "objective": objective,
+                "valid_objectives": sorted(valid),
+            },
+        )
+
 
 try:
     import lightgbm as lgb
@@ -374,8 +399,14 @@ class LGBMAdapter(BaseEstimatorAdapter):
             user_params.setdefault("seed", user_params.pop("random_state"))
         if "verbose" in user_params:
             user_params.setdefault("verbosity", user_params.pop("verbose"))
-        # Strip task-locked keys — objective is always set from task
-        user_params.pop("objective", None)
+        # H-0079: respect user/Optuna-supplied objective when task-compatible.
+        # Pre-H-0079 this value was silently stripped, so default_space
+        # tune trials sampling e.g. "fair" actually trained with the task
+        # default. Reject cross-task injections explicitly with CONFIG_INVALID.
+        user_objective = user_params.pop("objective", None)
+        if user_objective is not None:
+            _check_objective_compatible(self.task, user_objective)
+            params["objective"] = user_objective
         # Allow user-specified metric; fall back to task default if absent/empty
         # Accepts str, list[str], or list[str | dict] (H-0065 MetricEntry).
         user_metric = user_params.pop("metric", None)
@@ -394,6 +425,20 @@ class LGBMAdapter(BaseEstimatorAdapter):
                 )
                 params["metric"] = native if native else "None"
         params.update(user_params)
+
+        # H-0079 L5: invariant guard — if a user objective was supplied and
+        # task-compatible, it must survive _build_params(). Catches future
+        # regressions to the silent-strip pattern even if someone refactors
+        # the body. Disabled under `python -O` (production), active in
+        # dev / test / CI.
+        assert (  # noqa: S101 — defensive contract guard, see H-0079
+            user_objective is None or params["objective"] == user_objective
+        ), (
+            f"H-0079 invariant violated: user-supplied objective="
+            f"'{user_objective}' did not survive _build_params() "
+            f"(got '{params.get('objective')}'). Likely regression to "
+            f"the silent-strip pattern."
+        )
 
         return params, num_boost_round, feval_list, feval_display_names
 

--- a/lizyml/estimators/lgbm/defaults.py
+++ b/lizyml/estimators/lgbm/defaults.py
@@ -14,6 +14,38 @@ _TASK_OBJECTIVE: dict[str, str] = {
     "multiclass": "multiclass",
 }
 
+# H-0079: Per-task whitelist of LightGBM objective names accepted by
+# ``LGBMAdapter._build_params``. Canonical names only (no aliases). Source:
+# https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective
+TASK_COMPATIBLE_OBJECTIVES: dict[str, frozenset[str]] = {
+    "regression": frozenset(
+        [
+            "regression",
+            "regression_l1",
+            "huber",
+            "fair",
+            "poisson",
+            "quantile",
+            "mape",
+            "gamma",
+            "tweedie",
+        ]
+    ),
+    "binary": frozenset(
+        [
+            "binary",
+            "cross_entropy",
+            "cross_entropy_lambda",
+        ]
+    ),
+    "multiclass": frozenset(
+        [
+            "multiclass",
+            "multiclassova",
+        ]
+    ),
+}
+
 # Maps task → eval_metric list
 _TASK_METRIC: dict[str, list[str]] = {
     "regression": ["huber", "mae", "mape"],

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -336,18 +336,28 @@ class TestFitResultImmutability:
 
 
 class TestObjectiveOverwriteProtection:
-    """Task-locked objective must not be overridable by user params."""
+    """Cross-task objective injection must be rejected.
+
+    Pre-H-0079 this was enforced by silent strip + force re-set to the
+    task default. From H-0079 onwards the same defensive contract is
+    preserved but the mechanism is an explicit ``CONFIG_INVALID`` raise,
+    so users no longer get a silently-different model.
+    """
 
     def test_objective_locked_after_user_params(self) -> None:
-        """Even if user passes objective='regression', binary task keeps 'binary'."""
+        """User-supplied objective='regression' for binary task must raise."""
+        import pytest
+
+        from lizyml.core.exceptions import LizyMLError
         from lizyml.estimators.lgbm import LGBMAdapter
 
         adapter = LGBMAdapter(
             task="binary",
             params={"objective": "regression"},
         )
-        params, *_ = adapter._build_params()
-        assert params["objective"] == "binary"
+        with pytest.raises(LizyMLError) as excinfo:
+            adapter._build_params()
+        assert excinfo.value.code.name == "CONFIG_INVALID"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_estimators/test_lgbm_objective_identity.py
+++ b/tests/test_estimators/test_lgbm_objective_identity.py
@@ -1,0 +1,148 @@
+"""H-0079 Phase 1 — Parametric end-to-end identity guard for LGBM objective.
+
+Layer 1 of the 7-layer regression prevention: for every (task, objective)
+pair in TASK_COMPATIBLE_OBJECTIVES, a small fit must produce a booster
+whose internal ``params["objective"]`` matches the requested value
+bit-for-bit. Guards against:
+
+- silent strip in ``_build_params()`` (the original H-0079 bug)
+- reintroduction of forced ``_TASK_OBJECTIVE`` override
+- alias collapsing (e.g. ``"mse" -> "regression"``) at the wrong layer
+
+A single failure here means user/Optuna-supplied ``objective`` did not
+reach ``lgb.train``, which is the exact regression mode of the original
+bug — `tuning_table` reports one value while the booster trains with
+another.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizyml.config.schema import LizyMLConfig
+from lizyml.core.model import Model
+from tests._helpers import make_binary_df, make_config, make_multiclass_df
+
+
+def _make_positive_regression_df(n: int = 80, seed: int = 0) -> pd.DataFrame:
+    """Regression DataFrame with strictly positive targets.
+
+    Required for ``gamma`` (target > 0), ``poisson`` / ``tweedie`` (target
+    >= 0), and ``mape`` (target != 0). Negative-tolerant objectives
+    (``regression``, ``regression_l1``, ``huber``, ``fair``, ``quantile``)
+    still fit happily on positive data.
+    """
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame(
+        {
+            "feat_a": rng.uniform(0, 10, n),
+            "feat_b": rng.uniform(0, 5, n),
+        }
+    )
+    df["target"] = df["feat_a"] * 0.5 + df["feat_b"] + rng.uniform(0.1, 1.0, n)
+    return df
+
+
+_TASK_DATA_FACTORY = {
+    "regression": lambda: _make_positive_regression_df(n=80, seed=0),
+    "binary": lambda: make_binary_df(n=80, seed=0),
+    "multiclass": lambda: make_multiclass_df(n=120, seed=0),
+}
+
+
+_TASK_OBJECTIVE_PAIRS = [
+    # regression: 9 canonical LightGBM objectives
+    ("regression", "regression"),
+    ("regression", "regression_l1"),
+    ("regression", "huber"),
+    ("regression", "fair"),
+    ("regression", "poisson"),
+    ("regression", "quantile"),
+    ("regression", "mape"),
+    ("regression", "gamma"),
+    ("regression", "tweedie"),
+    # binary: 3 canonical LightGBM objectives
+    ("binary", "binary"),
+    ("binary", "cross_entropy"),
+    ("binary", "cross_entropy_lambda"),
+    # multiclass: 2 canonical LightGBM objectives
+    ("multiclass", "multiclass"),
+    ("multiclass", "multiclassova"),
+]
+
+
+class TestUserObjectiveReachesBooster:
+    """L1: user-supplied ``objective`` must survive ``_build_params()``."""
+
+    @pytest.mark.parametrize(("task", "objective"), _TASK_OBJECTIVE_PAIRS)
+    def test_user_objective_reaches_booster(self, task: str, objective: str) -> None:
+        """Every (task, objective) pair in TASK_COMPATIBLE_OBJECTIVES must
+        produce a booster whose ``params["objective"]`` matches input."""
+        df = _TASK_DATA_FACTORY[task]()
+        # Avoid metric/objective coupling regressions — keep metric default.
+        cfg_dict = make_config(
+            task,
+            n_estimators=10,
+            n_splits=2,
+            objective=objective,
+        )
+        cfg = LizyMLConfig(**cfg_dict)
+        m = Model(cfg)
+        m.fit(data=df)
+
+        # Inspect the refit booster (post-fit, full-data).
+        refit_booster = m._refit_result.model.get_native_model()  # type: ignore[union-attr]
+        actual = refit_booster.params["objective"]
+        assert actual == objective, (
+            f"Requested objective='{objective}' for task='{task}' was not "
+            f"honoured by the refit booster (got '{actual}'). "
+            f"_build_params() may be stripping or overriding objective."
+        )
+
+        # Also inspect a per-fold booster (CV path uses the same code path
+        # but a separate adapter instance).
+        fold_booster = m.fit_result.models[0].get_native_model()  # type: ignore[union-attr]
+        actual_fold = fold_booster.params["objective"]
+        assert actual_fold == objective, (
+            f"Requested objective='{objective}' for task='{task}' was not "
+            f"honoured by the per-fold booster (got '{actual_fold}')."
+        )
+
+
+class TestCrossTaskObjectiveRejected:
+    """Cross-task injection still raises (existing defense, contract preserved)."""
+
+    @pytest.mark.parametrize(
+        ("task", "bad_objective"),
+        [
+            ("regression", "binary"),
+            ("regression", "multiclass"),
+            ("binary", "regression"),
+            ("binary", "huber"),
+            ("binary", "multiclass"),
+            ("multiclass", "regression"),
+            ("multiclass", "binary"),
+        ],
+    )
+    def test_cross_task_objective_raises(self, task: str, bad_objective: str) -> None:
+        """Objective from another task must raise ``CONFIG_INVALID``."""
+        from lizyml.core.exceptions import LizyMLError
+
+        df = _TASK_DATA_FACTORY[task]()
+        cfg_dict = make_config(
+            task,
+            n_estimators=10,
+            n_splits=2,
+            objective=bad_objective,
+        )
+        cfg = LizyMLConfig(**cfg_dict)
+        m = Model(cfg)
+        with pytest.raises(LizyMLError) as excinfo:
+            m.fit(data=df)
+        assert excinfo.value.code.name == "CONFIG_INVALID"
+        # Context must include enough info for users to diagnose
+        ctx = excinfo.value.context
+        assert ctx.get("task") == task
+        assert ctx.get("objective") == bad_objective

--- a/tests/test_estimators/test_param_behavioral_effect.py
+++ b/tests/test_estimators/test_param_behavioral_effect.py
@@ -110,10 +110,15 @@ class TestBoosterParamPropagation:
         assert params[param_name] == param_value
 
     def test_objective_locked_to_task(self) -> None:
-        # User cannot override objective
+        # H-0079: cross-task objective injection now raises CONFIG_INVALID
+        # (was silently stripped pre-H-0079 — same defensive intent, but
+        # explicit failure instead of silent override).
+        from lizyml.core.exceptions import LizyMLError
+
         adapter = LGBMAdapter(task="binary", params={"objective": "regression"})
-        params, *_ = adapter._build_params()
-        assert params["objective"] == "binary"
+        with pytest.raises(LizyMLError) as excinfo:
+            adapter._build_params()
+        assert excinfo.value.code.name == "CONFIG_INVALID"
 
     def test_verbosity_forced_negative(self) -> None:
         adapter = LGBMAdapter(task="regression")

--- a/tests/test_tuning/test_tune_fit_identity.py
+++ b/tests/test_tuning/test_tune_fit_identity.py
@@ -142,3 +142,48 @@ class TestTuneFitIdentity:
             f"for metric '{metric_name}'. "
             f"Tune and fit code paths may diverge."
         )
+
+
+# ===================================================================
+# Phase 4: H-0079 — tune-sampled objective reaches refit booster
+# ===================================================================
+
+
+class TestTuneSampledObjectiveIdentity:
+    """L2 of H-0079: when tune samples ``objective`` from default_space,
+    the refit booster must train with the **sampled** value, not the
+    task-locked default.
+
+    Pre-H-0079 the score-equality test (``TestTuneFitIdentity``) passed
+    even with the silent strip, because both tune trial and refit threw
+    away the sampled objective the same way. This test plugs the gap
+    by inspecting the booster's actual ``params["objective"]`` after
+    fit, independent of any score comparison.
+    """
+
+    def test_tune_sampled_objective_matches_refit_booster_regression(self) -> None:
+        """Refit booster's objective must equal ``best_params["objective"]``."""
+        df = make_regression_df(n=300, seed=0)
+        cfg_dict = make_config(
+            "regression", n_estimators=30, n_splits=2, tuning_n_trials=5, seed=42
+        )
+        cfg = LizyMLConfig(**cfg_dict)
+
+        m = Model(cfg)
+        tune_result = m.tune(data=df)
+
+        # default_space("regression") samples objective ∈ {"huber", "fair"}.
+        best_objective = tune_result.best_params.get("objective")
+        assert best_objective is not None, (
+            "tune.best_params must include 'objective' when default_space "
+            "is used (regression)."
+        )
+
+        m.fit(data=df)
+        refit_booster = m._refit_result.model.get_native_model()  # type: ignore[union-attr]
+        actual = refit_booster.params["objective"]
+        assert actual == best_objective, (
+            f"Tune sampled objective='{best_objective}' but refit booster "
+            f"trained with '{actual}'. _build_params() may be stripping "
+            f"the sampled value (H-0079 silent override)."
+        )


### PR DESCRIPTION
## Summary

Phase 1 of [#159](https://github.com/nbx-liz/LizyML/issues/159) (H-0079).
Fixes the silent objective override bug introduced in 2026-03-15 (commit
ba152b0) and shipped in every release v0.2.0 → v0.14.0.

Pre-H-0079 `LGBMAdapter._build_params()` unconditionally popped any
user/Optuna-supplied `objective` and force-set `_TASK_OBJECTIVE[task]`.
`default_space("regression")` exposed `objective` as a tunable
(`("huber", "fair")`), but trials sampling `"fair"` actually trained
with `"huber"`. The displayed `objective` in `tuning_table()` was a lie
relative to the trained booster.

This PR replaces the unconditional strip with a task-compatibility
check, plus invariant guards layered to make the regression
unrecoverable in future refactors.

## Changes

| File | Purpose |
|---|---|
| `lizyml/estimators/lgbm/defaults.py` | New `TASK_COMPATIBLE_OBJECTIVES` whitelist (regression 9 / binary 3 / multiclass 2 canonical LightGBM objectives) |
| `lizyml/estimators/lgbm/adapter.py` | Replace strip with `_check_objective_compatible()`; add L5 invariant assertion at end of `_build_params()` |
| `tests/test_estimators/test_lgbm_objective_identity.py` (new) | L1 — 14 task×objective parametric end-to-end identity + 7 cross-task reject (21 tests) |
| `tests/test_tuning/test_tune_fit_identity.py` | L2 — `TestTuneSampledObjectiveIdentity` for regression default_space |
| `tests/test_code_review_fixes.py`, `tests/test_estimators/test_param_behavioral_effect.py` | Update existing cross-task injection tests to assert `CONFIG_INVALID` raise instead of silent strip |
| `CHANGELOG.md` | "Changed (potentially breaking)" + "Added" entries under `[Unreleased]` |
| `docs/DEPRECATIONS.md` | Row + migration note |
| `HISTORY.md` | H-0079 Proposal + Phase 1 Decision |

## Behaviour change (potentially breaking)

- **Same-task non-default objectives now actually train with the
  requested loss.** `LGBMConfig.params={"objective": "fair"}` for
  regression used to be silently demoted to `"huber"`; now it trains
  with Fair loss. Re-running tune over `default_space` may yield a
  different `best_params` / `best_score` for identical config + data.
- **Cross-task values raise `LizyMLError(CONFIG_INVALID)`** instead of
  being silently dropped. The defensive intent is preserved — same
  contract, explicit failure.

## Regression prevention layers landed in this PR

- **L1** — parametric end-to-end identity (14 task×objective pairs)
- **L2** — tune-sampled-objective identity guard (regression)
- **L5** — `assert` at the end of `_build_params()` (active in
  dev / test / CI; suppressed under `python -O`)
- **L6** — CHANGELOG `[Unreleased]` "Changed (potentially breaking)"
  entry + DEPRECATIONS row & migration note

L3 (Provider drift smoke-fits) and L4 (MetricRegistry coverage drift)
land in Phase 2 / Phase 3 because they consume the
`objective_choices()` / `metric_choices()` Provider APIs introduced
in Phase 2. L7 (docs/config-reference.md) lands in Phase 3.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy lizyml/` clean
- [x] `uv run pytest` — **1794 passed** (1709 baseline + 85 net new
      / migrated tests across 3 phases-worth of guards plus existing
      coverage)
- [x] L1 RED-then-GREEN verified: `[regression-fair]` failed before
      the fix, passes after
- [x] L2 RED-then-GREEN verified: tune samples `"fair"` and refit
      booster reports `"fair"`

## Related

- Issue [#159](https://github.com/nbx-liz/LizyML/issues/159)
- HISTORY: H-0079 (this PR establishes Phase 1 Decision row)
- Phase 2 (Provider choice APIs) and Phase 3 (internal migration +
  docs) ship as separate PRs.
- Sibling pattern: H-0078 (also 3-phase, also EstimatorProvider
  expansion).
