### PR TITLE
docs(history): mark H-0079 accepted [docs-only]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6490,10 +6490,11 @@ Re-tune (`expand_boundary=True`) を繰り返した際、`expand_dims` がパラ
 
 ## H-0079: silent objective override 修正と `EstimatorProvider.objective_choices()` / `metric_choices()` 導入
 
-- **ステータス**: Proposed
+- **ステータス**: Accepted
 - **起票日**: 2026-05-10
+- **決定日**: 2026-05-10
 - **スコープ**: Public API (`EstimatorProvider`), `lizyml/estimators/lgbm/adapter.py`, `lizyml/estimators/lgbm/defaults.py`, `lizyml/estimators/lgbm/metric_bridge.py`, `lizyml/estimators/lgbm/provider.py`, `lizyml/tuning/search_space.py` (`default_space` signature)
-- **関連**: [Issue #159](https://github.com/nbx-liz/LizyML/issues/159), H-0078（同型の Provider 拡張パターン）, LizyStudio Issue #461（下流 UI consumer）
+- **関連**: [Issue #159](https://github.com/nbx-liz/LizyML/issues/159), H-0078（同型の Provider 拡張パターン）, LizyStudio Issue #461（下流 UI consumer）, PR [#160](https://github.com/nbx-liz/LizyML/pull/160) / [#161](https://github.com/nbx-liz/LizyML/pull/161) / [#162](https://github.com/nbx-liz/LizyML/pull/162)
 
 ### 目的
 


### PR DESCRIPTION
Status update following the Phase 3 merge (#162). All 3 phases of H-0079 are now landed:

- Phase 1: #160 (silent objective override fix + L1/L2/L5/L6 guards)
- Phase 2: #161 (objective_choices / metric_choices Provider APIs + L3 smoke-fits)
- Phase 3: #162 (_OBJECTIVE_CHOICES retirement + L4 drift guard + L7 docs; caught a real auc-multiclass whitelist bug)

Updates the H-0079 entry status from Proposed to Accepted with PR cross-references. Marked `[docs-only]` per the policy in `~/.claude/rules/common/git-workflow.md` (status update with no implementation follow-up).