### PR TITLE
fix(metrics,calibration): harden degenerate-fold handling (#167, #168)

### DIFF
--- a/lizyml/calibration/cross_fit.py
+++ b/lizyml/calibration/cross_fit.py
@@ -94,6 +94,13 @@ def cross_fit_calibrate(
             # probabilities as-is (no calibration applied).
             calibrated_oof[val_idx] = fallback[val_idx]
             continue
+        if np.unique(train_y[finite_mask]).size < 2:
+            # Single-class training fold — a calibrator (e.g. Platt's
+            # LogisticRegression) cannot fit on one class.  Fall back to the
+            # uncalibrated OOF probabilities for this fold's validation rows
+            # rather than letting an opaque sklearn ValueError escape.
+            calibrated_oof[val_idx] = fallback[val_idx]
+            continue
         cal = calibrator_factory()
         cal.fit(train_scores[finite_mask], train_y[finite_mask])
 

--- a/lizyml/metrics/classification.py
+++ b/lizyml/metrics/classification.py
@@ -5,6 +5,7 @@ LogLoss, AUC-ROC, AUC-PR, F1, Accuracy, Brier, ECE, Precision@K.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -41,6 +42,70 @@ def _require_1d_same_len(
             ),
             context={"metric": name},
         )
+
+
+def _multiclass_ovr_macro(
+    y_true: npt.NDArray[Any],
+    y_pred: npt.NDArray[Any],
+    name: str,
+    per_class_fn: Callable[[npt.NDArray[Any], npt.NDArray[Any]], float],
+    *,
+    min_classes: int,
+) -> float:
+    """Macro-average a One-vs-Rest metric over classes present in ``y_true``.
+
+    Per-fold CV evaluation can legitimately produce a validation fold whose
+    ``y_true`` is missing one or more classes. Rather than letting the
+    underlying sklearn call raise an opaque ``ValueError`` (AUC) or silently
+    fold a degenerate zero-filled column into the mean (AUC-PR / Brier), the
+    macro average is restricted to the classes that actually occur in
+    ``y_true`` and at least ``min_classes`` of them are required. When every
+    class is present (the non-degenerate case) the result is identical to
+    averaging over all ``y_pred`` columns, so golden / calibrated numbers are
+    unchanged.
+
+    Raises:
+        LizyMLError(UNSUPPORTED_METRIC): on sample-count mismatch, a label
+            outside the ``y_pred`` column range, or fewer than ``min_classes``
+            classes present in this fold.
+    """
+    if y_pred.shape[0] != len(y_true):
+        raise LizyMLError(
+            code=ErrorCode.UNSUPPORTED_METRIC,
+            user_message=(
+                f"Metric '{name}' requires y_true and y_pred to have the same "
+                f"number of samples. Got {len(y_true)} vs {y_pred.shape[0]}."
+            ),
+            context={"metric": name},
+        )
+    present = np.unique(y_true).astype(np.intp)
+    n_columns = int(y_pred.shape[1])
+    if present.size and (int(present.min()) < 0 or int(present.max()) >= n_columns):
+        raise LizyMLError(
+            code=ErrorCode.UNSUPPORTED_METRIC,
+            user_message=(
+                f"Metric '{name}' received a y_true label outside the range of "
+                f"y_pred columns (0..{n_columns - 1})."
+            ),
+            context={"metric": name, "n_columns": n_columns},
+        )
+    if len(present) < min_classes:
+        raise LizyMLError(
+            code=ErrorCode.UNSUPPORTED_METRIC,
+            user_message=(
+                f"Metric '{name}' on multiclass needs at least {min_classes} "
+                f"class(es) present in this fold's y_true; found {len(present)}. "
+                f"Evaluate on the full OOF, or aggregate folds that each cover "
+                f"all classes."
+            ),
+            context={
+                "metric": name,
+                "n_present_classes": int(len(present)),
+                "n_columns": n_columns,
+            },
+        )
+    per_class = [per_class_fn((y_true == k).astype(int), y_pred[:, k]) for k in present]
+    return float(np.mean(per_class))
 
 
 @MetricRegistry.register("logloss")
@@ -90,19 +155,14 @@ class AUC(BaseMetric):
 
     def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
         if y_pred.ndim == 2:
-            # Multiclass OvR: y_pred is (n_samples, n_classes)
-            if y_pred.shape[0] != len(y_true):
-                raise LizyMLError(
-                    code=ErrorCode.UNSUPPORTED_METRIC,
-                    user_message=(
-                        f"Metric '{self.name}' requires y_true and y_pred to have "
-                        f"the same number of samples. "
-                        f"Got {len(y_true)} vs {y_pred.shape[0]}."
-                    ),
-                    context={"metric": self.name},
-                )
-            return float(
-                roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
+            # Multiclass OvR: macro-average per-class ROC AUC over classes
+            # present in y_true (needs >= 2 so each OvR split has pos + neg).
+            return _multiclass_ovr_macro(
+                y_true,
+                y_pred,
+                self.name,
+                lambda yb, s: float(roc_auc_score(yb, s)),
+                min_classes=2,
             )
         _require_1d_same_len(y_true, y_pred, self.name)
         return float(roc_auc_score(y_true, y_pred))
@@ -126,26 +186,15 @@ class AUCPR(BaseMetric):
 
     def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
         if y_pred.ndim == 2:
-            # Multiclass OvR: per-class average_precision_score, macro average
-            if y_pred.shape[0] != len(y_true):
-                raise LizyMLError(
-                    code=ErrorCode.UNSUPPORTED_METRIC,
-                    user_message=(
-                        f"Metric '{self.name}' requires y_true and y_pred to have "
-                        f"the same number of samples. "
-                        f"Got {len(y_true)} vs {y_pred.shape[0]}."
-                    ),
-                    context={"metric": self.name},
-                )
-            from sklearn.preprocessing import label_binarize
-
-            classes = np.arange(y_pred.shape[1])
-            y_bin = label_binarize(y_true, classes=classes)
-            per_class = [
-                float(average_precision_score(y_bin[:, k], y_pred[:, k]))
-                for k in range(y_pred.shape[1])
-            ]
-            return float(np.mean(per_class))
+            # Multiclass OvR: macro-average per-class average precision over
+            # classes present in y_true (each present class has >= 1 positive).
+            return _multiclass_ovr_macro(
+                y_true,
+                y_pred,
+                self.name,
+                lambda yb, s: float(average_precision_score(yb, s)),
+                min_classes=1,
+            )
         _require_1d_same_len(y_true, y_pred, self.name)
         return float(average_precision_score(y_true, y_pred))
 
@@ -214,26 +263,15 @@ class Brier(BaseMetric):
 
     def __call__(self, y_true: npt.NDArray[Any], y_pred: npt.NDArray[Any]) -> float:
         if y_pred.ndim == 2:
-            # Multiclass OvR: per-class brier_score_loss, macro average
-            if y_pred.shape[0] != len(y_true):
-                raise LizyMLError(
-                    code=ErrorCode.UNSUPPORTED_METRIC,
-                    user_message=(
-                        f"Metric '{self.name}' requires y_true and y_pred to have "
-                        f"the same number of samples. "
-                        f"Got {len(y_true)} vs {y_pred.shape[0]}."
-                    ),
-                    context={"metric": self.name},
-                )
-            from sklearn.preprocessing import label_binarize
-
-            classes = np.arange(y_pred.shape[1])
-            y_bin = label_binarize(y_true, classes=classes)
-            per_class = [
-                float(brier_score_loss(y_bin[:, k], y_pred[:, k]))
-                for k in range(y_pred.shape[1])
-            ]
-            return float(np.mean(per_class))
+            # Multiclass OvR: macro-average per-class Brier over classes
+            # present in y_true.
+            return _multiclass_ovr_macro(
+                y_true,
+                y_pred,
+                self.name,
+                lambda yb, s: float(brier_score_loss(yb, s)),
+                min_classes=1,
+            )
         _require_1d_same_len(y_true, y_pred, self.name)
         return float(brier_score_loss(y_true, y_pred))
 

--- a/tests/test_calibration/test_calibration.py
+++ b/tests/test_calibration/test_calibration.py
@@ -308,3 +308,62 @@ class TestCalibrationContract:
         fr = m.fit(data=df)
         assert isinstance(fr.calibrator, CalibrationResult)
         assert fr.calibrator.method == "beta"
+
+
+# ---------------------------------------------------------------------------
+# cross_fit_calibrate — single-class training fold (issue #168)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFitSingleClassFold:
+    """A fold whose training slice is single-class must fall back to the
+    uncalibrated OOF instead of raising a raw sklearn ValueError."""
+
+    def test_all_folds_single_class_fall_back_without_raising(self) -> None:
+        # Fold A trains on rows {0,1} (both class 0); fold B on {2,3} (both
+        # class 1). Pre-fix, PlattCalibrator's LogisticRegression raised on the
+        # single-class slice. Post-fix both folds fall back to oof_pred.
+        oof_scores = np.array([0.2, 0.3, 0.7, 0.8])
+        y = np.array([0.0, 0.0, 1.0, 1.0])
+        oof_pred = oof_scores.copy()
+        split_indices = [
+            (np.array([0, 1], dtype=np.intp), np.array([2, 3], dtype=np.intp)),
+            (np.array([2, 3], dtype=np.intp), np.array([0, 1], dtype=np.intp)),
+        ]
+        result = cross_fit_calibrate(
+            oof_scores,
+            y,
+            calibrator_factory=PlattCalibrator,
+            split_indices=split_indices,
+            oof_pred=oof_pred,
+        )
+        np.testing.assert_array_equal(result.calibrated_oof, oof_pred)
+
+    def test_mixed_single_and_two_class_folds(self) -> None:
+        # Imbalanced 4:2 data, every row validated exactly once.
+        # Fold A trains on the 4 class-0 rows {0,1,2,3} -> single-class ->
+        # falls back for its validation rows {4,5}. Folds B and C have both
+        # classes in training and actually calibrate rows {0,1} and {2,3}.
+        oof_scores = np.array([0.1, 0.2, 0.3, 0.4, 0.85, 0.9])
+        y = np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0])
+        oof_pred = oof_scores.copy()
+        split_indices = [
+            (np.array([0, 1, 2, 3], dtype=np.intp), np.array([4, 5], dtype=np.intp)),
+            (np.array([2, 3, 4, 5], dtype=np.intp), np.array([0, 1], dtype=np.intp)),
+            (np.array([0, 1, 4, 5], dtype=np.intp), np.array([2, 3], dtype=np.intp)),
+        ]
+        result = cross_fit_calibrate(
+            oof_scores,
+            y,
+            calibrator_factory=PlattCalibrator,
+            split_indices=split_indices,
+            oof_pred=oof_pred,
+        )
+        # Every row is validated once -> no uncovered NaN.
+        assert not np.isnan(result.calibrated_oof).any()
+        # The single-class fold fell back to the uncalibrated OOF for {4,5}.
+        np.testing.assert_array_equal(result.calibrated_oof[[4, 5]], oof_pred[[4, 5]])
+        # The two-class folds actually calibrated {0,1,2,3} (not a passthrough).
+        assert not np.allclose(
+            result.calibrated_oof[[0, 1, 2, 3]], oof_pred[[0, 1, 2, 3]]
+        )

--- a/tests/test_metrics/test_multiclass_ovr_metrics.py
+++ b/tests/test_metrics/test_multiclass_ovr_metrics.py
@@ -1,11 +1,16 @@
-"""Tests for multiclass OvR metrics: AUC, AUC-PR, Brier (H-0018)."""
+"""Tests for multiclass OvR metrics: AUC, AUC-PR, Brier (H-0018).
+
+Degenerate-fold robustness (a validation fold missing a class) is covered by
+``TestMulticlassMissingClass`` (issue #167).
+"""
 
 from __future__ import annotations
 
 import numpy as np
 import pytest
+from sklearn.metrics import average_precision_score, brier_score_loss, roc_auc_score
 
-from lizyml.core.exceptions import LizyMLError
+from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.metrics.classification import AUC, AUCPR, Brier
 from lizyml.metrics.registry import get_metrics_for_task
 
@@ -118,3 +123,107 @@ class TestMulticlassRegistered:
         with pytest.raises(LizyMLError) as exc_info:
             get_metrics_for_task(["auc"], "regression")
         assert exc_info.value.code.value == "UNSUPPORTED_METRIC"
+
+
+# y_pred has 3 columns but class 2 never occurs in y_true — the shape a CV
+# fold takes when one class is absent from the validation slice.
+_MISSING_CLASS_Y = np.array([0, 0, 0, 1, 1, 1])
+_MISSING_CLASS_P = np.array(
+    [
+        [0.8, 0.1, 0.1],
+        [0.7, 0.2, 0.1],
+        [0.6, 0.3, 0.1],
+        [0.2, 0.7, 0.1],
+        [0.1, 0.8, 0.1],
+        [0.3, 0.6, 0.1],
+    ]
+)
+
+
+class TestMulticlassMissingClass:
+    """A validation fold missing a class must not crash (AUC) or silently fold
+    a degenerate zero-filled column into the macro mean (AUC-PR / Brier)."""
+
+    def test_auc_macro_over_present_classes_no_crash(self) -> None:
+        # Pre-fix this raised a raw sklearn ValueError.
+        result = AUC()(_MISSING_CLASS_Y, _MISSING_CLASS_P)
+        expected = float(
+            np.mean(
+                [
+                    roc_auc_score(
+                        (k == _MISSING_CLASS_Y).astype(int), _MISSING_CLASS_P[:, k]
+                    )
+                    for k in (0, 1)
+                ]
+            )
+        )
+        assert result == pytest.approx(expected)
+
+    def test_aucpr_excludes_absent_class(self) -> None:
+        result = AUCPR()(_MISSING_CLASS_Y, _MISSING_CLASS_P)
+        present_only = float(
+            np.mean(
+                [
+                    average_precision_score(
+                        (k == _MISSING_CLASS_Y).astype(int), _MISSING_CLASS_P[:, k]
+                    )
+                    for k in (0, 1)
+                ]
+            )
+        )
+        # Old behaviour averaged class 2's zero-filled column (AP == 0.0) too,
+        # dragging the mean down; the fix must exclude it.
+        include_absent = present_only * 2 / 3
+        assert result == pytest.approx(present_only)
+        assert result != pytest.approx(include_absent)
+
+    def test_brier_excludes_absent_class(self) -> None:
+        result = Brier()(_MISSING_CLASS_Y, _MISSING_CLASS_P)
+        expected = float(
+            np.mean(
+                [
+                    brier_score_loss(
+                        (k == _MISSING_CLASS_Y).astype(int), _MISSING_CLASS_P[:, k]
+                    )
+                    for k in (0, 1)
+                ]
+            )
+        )
+        assert result == pytest.approx(expected)
+
+    def test_auc_single_class_fold_raises_coded(self) -> None:
+        y_true = np.array([0, 0, 0])
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.7, 0.2, 0.1], [0.6, 0.3, 0.1]])
+        with pytest.raises(LizyMLError) as exc_info:
+            AUC()(y_true, y_pred)
+        err = exc_info.value
+        assert err.code is ErrorCode.UNSUPPORTED_METRIC
+        assert err.context["metric"] == "auc"
+        assert err.context["n_present_classes"] == 1
+        assert err.context["n_columns"] == 3
+
+    def test_aucpr_single_class_fold_no_crash(self) -> None:
+        # min_classes=1: AUC-PR / Brier stay defined on a single-class fold.
+        y_true = np.array([0, 0, 0])
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.7, 0.2, 0.1], [0.6, 0.3, 0.1]])
+        assert isinstance(AUCPR()(y_true, y_pred), float)
+        assert isinstance(Brier()(y_true, y_pred), float)
+
+    def test_label_out_of_range_raises_coded(self) -> None:
+        # y_true label 5 with only 3 prediction columns — would IndexError
+        # pre-fix; now a coded error.
+        y_true = np.array([0, 1, 5])
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1], [0.3, 0.3, 0.4]])
+        with pytest.raises(LizyMLError) as exc_info:
+            AUC()(y_true, y_pred)
+        assert exc_info.value.code is ErrorCode.UNSUPPORTED_METRIC
+
+    def test_all_classes_present_matches_sklearn_macro(
+        self, multiclass_data: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        # Refactor must preserve the happy-path number (regression guard).
+        y_true, y_pred = multiclass_data
+        expected = float(
+            roc_auc_score(y_true, y_pred, multi_class="ovr", average="macro")
+        )
+        assert AUC()(y_true, y_pred) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
Fixes two degenerate-fold robustness bugs surfaced by the v0.15.0 quality audit. No Change Gate (no contract/shape change; aligns errors with the existing `LizyMLError` contract; happy-path numbers unchanged).

- **#167** — multiclass One-vs-Rest metrics (`AUC` / `AUC-PR` / `Brier`) assumed every class is present in the fold. A validation fold missing a class made `roc_auc_score` raise a raw sklearn `ValueError` (AUC), or silently fold a zero-filled absent-class column into the macro mean (AUC-PR / Brier). This is a **documented, supported path** (`Model.evaluate(metrics=["auc"])`, H-0079 Phase 3).
- **#168** — `cross_fit_calibrate()` fitted a per-fold calibrator without checking the fold's training labels contained both classes; an imbalanced split could produce a single-class training slice and an unwrapped `LogisticRegression` `ValueError`.

## Changes
- `lizyml/metrics/classification.py`: new `_multiclass_ovr_macro()` helper macro-averages a per-class OvR metric **only over classes present in `y_true`**, raising a coded `LizyMLError(UNSUPPORTED_METRIC)` (with fold context) when fewer than `min_classes` are present (AUC needs ≥2; AUC-PR / Brier need ≥1) or a label is out of the `y_pred` column range. AUC/AUC-PR/Brier now route through it. The `label_binarize` import is no longer needed.
- `lizyml/calibration/cross_fit.py`: single-class training-fold guard falls back to the uncalibrated OOF for that fold (mirrors the existing no-covered-rows fallback at the same site).

## Invariant preserved
When every class is present (the non-degenerate case), `_multiclass_ovr_macro` averages over exactly the same columns as before, so existing golden / calibrated numbers are unchanged. A regression test pins AUC against `roc_auc_score(multi_class="ovr", average="macro")`.

## Test plan / DoD
- Relevant SKILLs: `metrics`, `calibration`, `testing`.
- Added falling-example / behavior tests:
  - `tests/test_metrics/test_multiclass_ovr_metrics.py::TestMulticlassMissingClass` — missing-class macro (AUC/AUC-PR/Brier), single-class coded error (AUC), out-of-range label, happy-path equivalence vs sklearn.
  - `tests/test_calibration/test_calibration.py::TestCrossFitSingleClassFold` — all-folds-single-class fallback (would raise pre-fix) + mixed single/two-class folds.
- `ruff check` / `ruff format --check` / `mypy --strict`: clean.
- `pytest -m "not slow"`: 1905 passed, 0 failed; coverage 98% (≥95 gate).

## Notes
- CHANGELOG intentionally untouched — entries are consolidated in the release PR (per CLAUDE.md §5.4).
- Resolves #167 and #168.
