### PR TITLE
docs: reconcile v0.15.0 documentation drift (#175, #176, #177)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -454,7 +454,8 @@ LizyML 非依存の学習・推論コードを自動生成する。
 - `oof_pred`（`np.ndarray / pd.Series`）
 - `if_pred_per_fold`（`list[np.ndarray]`）
 - `metrics`（階層固定）
-  - 例: `{"raw": {"oof": {...}, "oof_per_fold": [...], "if_mean": {...}, "if_per_fold": [...]}, "calibrated": {...}}`
+  - 例: `{"raw": {"oof": {...}, "oof_per_fold": [...], "if_mean": {...}, "if_per_fold": [...], "oof_coverage": 1.0}, "calibrated": {...}}`
+  - `oof_coverage`（float, 0.0–1.0）: validation fold に覆われた行の割合（H-0057）。KFold では常に `1.0`、TimeSeriesCV では `< 1.0` になりうる。`calibrated` は raw と構造一致のため別途含めない（H-0058）。
 - `models`
   - fold ごとのモデル
   - 任意: refit モデル（全データ学習）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,5 +417,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Optuna-based tuning with unified search space (optional dependency)
 - Plotly-based visualizations: learning curve, importance, OOF distribution, residuals (optional dependency)
 - Export/load with format_version=1 and metadata
-- Simulate (bootstrap prediction distributions)
+- ~~Simulate (bootstrap prediction distributions)~~ — listed in error; this
+  feature was never shipped (no `simulate` API has existed in any release).
+  Tracked in [#177](https://github.com/nbx-liz/LizyML/issues/177).
 - YAML/JSON config loading with pydantic validation

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,8 @@ def tune(
     expand_boundary: bool | None = None,
     boundary_threshold: float = 0.05,
     progress_callback: TuneProgressCallback | None = None,
+    storage: str | BaseStorage | None = None,
+    study_name: str | None = None,
 ) -> TuningResult
 ```
 
@@ -95,11 +97,13 @@ automatically expanded in the promising direction (H-0068).
 | `expand_boundary` | `bool \| None` | Auto-expand dims near boundary. `None` means `True` for default space, `False` for user-specified space. |
 | `boundary_threshold` | `float` | Edge detection threshold (0.0–0.5). Best values within this fraction of the range from either edge trigger expansion. |
 | `progress_callback` | `TuneProgressCallback \| None` | Called after each trial with a `TuneProgressInfo`. Exceptions inside the callback are caught and emitted as `RuntimeWarning`; tuning is never aborted. |
+| `storage` | `str \| BaseStorage \| None` | Optional Optuna storage URL or `BaseStorage` for resumable tuning (H-0072). `None` keeps the in-memory behavior. Requires `study_name` when set. |
+| `study_name` | `str \| None` | Study identifier used together with `storage` (H-0072). Required when `storage` is given; re-using the same `(storage, study_name)` pair re-attaches to the persisted study. |
 
 **Returns:** [`TuningResult`](#tuningresult)
 
 **Raises:**
-- `LizyMLError(CONFIG_INVALID)` — no `tuning` section in config, or `boundary_threshold` out of range.
+- `LizyMLError(CONFIG_INVALID)` — no `tuning` section in config, `boundary_threshold` out of range, or `storage` set without `study_name`.
 - `LizyMLError(OPTIONAL_DEP_MISSING)` — `optuna` not installed.
 - `LizyMLError(TUNING_FAILED)` — `resume=True` without prior `tune()` call.
 - `LizyMLError(TUNING_FAILED)` — study failure.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -75,22 +75,33 @@ Common causes:
 
 ### How do I use a custom LightGBM objective?
 
-Pass it through `model.params` in the config:
+Set `model.params.objective` to a LightGBM built-in objective **string** that
+is valid for your task:
 
 ```yaml
 model:
-  type: lgbm
+  name: lgbm
   params:
-    objective: "binary"   # or any LightGBM built-in string
+    objective: "fair"   # a regression objective; see the per-task list below
 ```
 
-For a fully custom Python objective function, define it and pass it via
-`fit(params={"objective": my_fn})`. LizyML forwards all `model.params`
-values directly to LightGBM; no additional wrappers are needed.
+Since v0.15.0 (H-0079), LizyML validates the objective against the task:
 
-Note that custom objectives may require a corresponding `feval` function for
-evaluation during training. See `evaluation.metrics` in config and the
-metric bridge documentation.
+- A **same-task** built-in objective string flows through to `lgb.train`
+  (e.g. `objective: "fair"` or `"huber"` for regression actually trains with
+  that loss).
+- A **cross-task** objective (e.g. a binary objective on a regression task)
+  raises `LizyMLError(CONFIG_INVALID)` instead of being silently demoted.
+- A **callable** Python objective is **not supported** — it is rejected with
+  `LizyMLError(CONFIG_INVALID)`. Use a built-in objective string.
+
+The canonical per-task objective names are available programmatically via
+`LGBMProvider().objective_choices(task)` (and `TASK_COMPATIBLE_OBJECTIVES` in
+`lizyml.estimators.lgbm.defaults`).
+
+Note that some LizyML metrics are evaluated via a `feval` callback during
+training; see `evaluation.metrics` in config and the metric bridge
+documentation.
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -5,6 +5,41 @@ release from v0.5.0 onward.
 
 ---
 
+## v0.15.0
+
+### `LGBMConfig.params["objective"]` is now respected when task-compatible
+
+**Impact:** Tuning / training with a non-default LightGBM `objective` (H-0079).
+
+Before v0.15.0 a user/Optuna-supplied `objective` was silently stripped and
+replaced with the task default. From v0.15.0:
+
+- A **same-task** objective string flows through to `lgb.train` — e.g.
+  `objective: "fair"` on a regression task now actually trains with Fair loss.
+  Re-running `tune()` over `default_space` may therefore yield different
+  `best_params` / metrics than pre-0.15 runs.
+- A **cross-task** objective now raises `LizyMLError(CONFIG_INVALID)` instead of
+  being silently demoted (contract unchanged — still rejected).
+- A **callable** objective is rejected with `CONFIG_INVALID` (unsupported).
+
+No config edits are required; review any explicit non-default `objective`.
+
+---
+
+## v0.10.0
+
+### Persistence `format_version` bumped to 2
+
+**Impact:** Saved `model.lizyml` artifacts (H-0070).
+
+Auto-encoding of non-numeric classification targets added a `TargetEncoder` to
+the artifact, bumping `FORMAT_VERSION` from 1 to 2. `Model.load()` accepts
+**both** versions: v1 artifacts are migrated in memory by injecting a no-op
+`TargetEncoder`, so existing saved models keep loading with no user action. New
+saves are written as v2.
+
+---
+
 ## v0.8.x
 
 ### ECE formula corrected

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -287,7 +287,7 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
         Returns:
             Structured dict: ``{"raw": {"oof": ..., "oof_per_fold": ...,
-            "if_mean": ..., "if_per_fold": ...}}``.
+            "if_mean": ..., "if_per_fold": ..., "oof_coverage": float}}``.
 
         Raises:
             :class:`~lizyml.core.exceptions.LizyMLError` with
@@ -426,7 +426,8 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             expand_boundary: Whether to auto-expand search space dimensions
                 whose best params are near the boundary.  None means True
                 for default space, False for user-specified space.
-            boundary_threshold: Edge detection threshold (0.0–1.0).
+            boundary_threshold: Edge detection threshold; must be in the open
+                interval ``(0.0, 0.5)``.
             progress_callback: Optional callback invoked after each trial.
             storage: Optional Optuna storage URL or ``BaseStorage`` instance
                 for resumable tuning (H-0072). ``None`` keeps the in-memory

--- a/lizyml/core/types/fit_result.py
+++ b/lizyml/core/types/fit_result.py
@@ -32,6 +32,7 @@ class FitResult:
                         "oof_per_fold": [{metric_name: float}, ...],
                         "if_mean": {metric_name: float, ...},
                         "if_per_fold": [{metric_name: float}, ...],
+                        "oof_coverage": float,  # covered-row fraction (H-0057)
                     },
                     "calibrated": { ... }  # binary + calibrator only
                 }

--- a/lizyml/evaluation/evaluator.py
+++ b/lizyml/evaluation/evaluator.py
@@ -87,6 +87,8 @@ class Evaluator:
                 "oof_per_fold": [{metric_name: float}, ...],
                 "if_mean":      {metric_name: float, ...},
                 "if_per_fold":  [{metric_name: float}, ...],
+                "oof_coverage": float,   # fraction of rows covered by a
+                                         # validation fold (H-0057)
             },
             "calibrated": { ... }   # populated only when calibrator is set
         }

--- a/lizyml/persistence/exporter.py
+++ b/lizyml/persistence/exporter.py
@@ -1,6 +1,6 @@
 """Exporter — save Model artifacts to a directory.
 
-Directory layout (format_version=1)::
+Directory layout (format_version=2)::
 
     {path}/
         metadata.json        — human-readable metadata + version info

--- a/tests/test_core/test_contracts.py
+++ b/tests/test_core/test_contracts.py
@@ -69,6 +69,7 @@ def fit_result(
                 "oof_per_fold": [{"rmse": 0.5}],
                 "if_mean": {"rmse": 0.4},
                 "if_per_fold": [{"rmse": 0.4}],
+                "oof_coverage": 1.0,
             }
         },
         models=[object()],
@@ -175,12 +176,18 @@ class TestFitResultSchema:
 
     def test_metrics_raw_structure(self, fit_result: FitResult) -> None:
         raw = fit_result.metrics["raw"]
-        assert "oof" in raw
-        assert "oof_per_fold" in raw
+        # Exact key set — pins the raw metrics contract (incl. oof_coverage,
+        # H-0057) so a dropped or renamed key is caught, not silently tolerated.
+        assert set(raw) == {
+            "oof",
+            "oof_per_fold",
+            "if_mean",
+            "if_per_fold",
+            "oof_coverage",
+        }
         assert isinstance(raw["oof_per_fold"], list)
-        assert "if_mean" in raw
-        assert "if_per_fold" in raw
         assert isinstance(raw["if_per_fold"], list)
+        assert isinstance(raw["oof_coverage"], float)
 
     def test_calibrated_key_absent_when_no_calibrator(
         self, fit_result: FitResult


### PR DESCRIPTION
## Summary
Reconciles v0.15.0 documentation drift surfaced by the quality audit. No Change Gate: all edits document **already-implemented** behavior or correct stale text; the one BLUEPRINT touch records existing H-0057 behavior (`oof_coverage`). Resolves #175, #176, #177.

## Changes

### #175 — `docs/faq.md` custom-objective example was broken on v0.15.0
- Fixed the YAML discriminator (`type: lgbm` → `name: lgbm`; `extra="forbid"` rejected `type`).
- Replaced the "pass a callable via `fit(params={"objective": my_fn})`" guidance, which now raises `CONFIG_INVALID` after H-0079, with the actual v0.15 rules: same-task string objectives flow through; cross-task objectives raise `CONFIG_INVALID`; callables are unsupported. Pointed at `LGBMProvider().objective_choices(task)` / `TASK_COMPATIBLE_OBJECTIVES`.

### #176 — API / spec / docstring drift
- `docs/api.md` `tune()`: added the missing `storage` / `study_name` parameters (signature, parameter table, and the `CONFIG_INVALID — storage set without study_name` raise note) — H-0072 resumable tuning was undocumented.
- `docs/migration.md`: added `## v0.15.0` (H-0079 objective behavior) and `## v0.10.0` (`FORMAT_VERSION` 1→2, H-0070) sections; the guide previously stopped at v0.8.x.
- `lizyml/persistence/exporter.py`: module docstring `format_version=1` → `2` (matches `FORMAT_VERSION = 2`).
- `lizyml/core/model.py`: `tune()` docstring `boundary_threshold` range `(0.0–1.0)` → open interval `(0.0, 0.5)` (matches the validator and api.md).
- `oof_coverage` was returned by `Evaluator` but undocumented: added it to the `Evaluator` docstring, `FitResult.metrics` docstring, `Model.evaluate()` docstring, and BLUEPRINT §7.1. Tightened `test_metrics_raw_structure` to assert the **exact** raw key set (incl. `oof_coverage`) so a dropped/renamed key is caught.

### #177 — `simulate` listed in CHANGELOG but never shipped
- Verified `simulate` has **never** existed in `lizyml/` source (`git log -S simulate -- lizyml/` is empty; the v0.1.0 tag has no `simulate`). Annotated the erroneous `[0.1.0]` "Added" entry (strikethrough + note) and pointed to #177, which tracks whether to implement it later.

## Test plan / DoD
- Relevant SKILLs: `history-proposals`, `evaluation-contracts`, `config-and-specs`.
- `ruff check` / `ruff format --check` / `mypy --strict`: clean.
- `pytest -m "not slow"`: green; `test_metrics_raw_structure` now pins the exact `raw` contract.
- CHANGELOG intentionally not extended with a release entry — consolidated at release per CLAUDE.md §5.4 (the simulate edit is a correction to historical text, not a new release entry).

Resolves #175, #176, #177.
