### PR TITLE
feat(config,core): inherit training.seed in splitter and isotonic calibrator (H-0080, #169)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6632,4 +6632,48 @@ Issue #159 で要求された全 7 層を Phase に分散して実装する。
   - 既存 1873 → 1885 テスト全件 pass（+12 L4 drift coverage）。
   - **リリース予定**: v0.15.0 で 3 phase まとめて配布。
 
+## H-0080: `training.seed` を outer splitter / isotonic calibrator に伝搬（`split.random_state` を sentinel None 化）
+
+- **ステータス**: Accepted
+- **起票日**: 2026-06-01
+- **決定日**: 2026-06-01
+- **スコープ**: Config schema (`KFoldConfig` / `StratifiedKFoldConfig` / `StratifiedGroupKFoldConfig` の `random_state`), `lizyml/config/loader.py`（default split 注入）, `lizyml/core/_model_factories.py`（`build_splitter` / `_build_splitter_for_method`）, `lizyml/core/model.py`（calibration params 構築）
+- **関連**: [Issue #169](https://github.com/nbx-liz/LizyML/issues/169), v0.15.0 品質監査, H-0069（フィールド同期の前例）
+
+### 目的（課題）
+
+「single seed が deterministic に全乱数へ伝搬する」という再現性要件に反し、`training.seed` が **outer splitter と isotonic calibrator に届いていなかった**。
+
+- `build_splitter()` は `BlockedGroupKFoldConfig` 分岐でのみ `cfg.training.seed` を転送し、一般分岐（KFold / StratifiedKFold / StratifiedGroupKFold）は `split.random_state`（既定 42）を直接使用していた。さらに `loader._normalize_split_default()` が split 省略時に `random_state: 42` を**ハードコード注入**していたため、最頻ケース（split 省略 + `training.seed` 指定）でも fold は 42 固定だった。
+- isotonic calibrator は内部 validation split 用 seed を `calibration.params["seed"]`（既定 42）から取り、`training.seed` を見ていなかった。
+
+結果として `training.seed=123` に変えても CV fold / calibrator split は 42 のままで、再シードに複数フィールドの lockstep 変更が必要な usability trap になっていた。
+
+### 対応方針（Option A: sentinel None）
+
+`split.random_state` を `int | None`（既定 `None`）に変更し、`None` を「`training.seed` を継承」の sentinel とする。解決は **splitter-build 時のみ**で行い、config には書き戻さない（H-0069 の dual-write round-trip 破壊を回避）。
+
+- `KFoldConfig` / `StratifiedKFoldConfig` / `StratifiedGroupKFoldConfig`: `random_state: int | None = None`。
+- `loader._normalize_split_default()`: default split から `random_state: 42` を除去（schema 既定 None を効かせる）。
+- `build_splitter()`: 一般分岐でも `seed=cfg.training.seed` を `_build_splitter_for_method` に渡す。
+- `_build_splitter_for_method()`: `random_state = explicit if explicit is not None else seed`（明示値が優先、未指定は training.seed、最終 fallback 42）。
+- `model.py` calibration: `method == "isotonic"` かつ `calibration.params` に `seed` 不在のとき `cfg.training.seed` を `setdefault`。
+
+代替案 Option D（`split.random_state` を computed mirror 化して seed を単一化）は、既存の明示指定ユーザー向け legacy 吸収が必要で破壊度が高く、独立 split seed の能力を失うため不採用。
+
+### 影響範囲 / 互換性
+
+- **後方互換（無変更ケース）**: `training.seed` も既定 42 のため、全デフォルト構成・`training.seed` 未変更構成では実効 seed は 42 のまま。fold / OOF / calibrated は不変。
+- **変化するケース（＝意図した修正）**: `training.seed` を非 42 に設定し、かつ `split.random_state` を明示していない構成。これらは fold が `training.seed` を反映するようになる（**potentially breaking**: OOF / metrics / split indices / 保存 artifact の fold 構成が変わりうる）。CHANGELOG に「Changed (potentially breaking)」として明記する。
+- 明示 `split.random_state` 指定は従来通り優先され不変。
+- `model_dump()` は `random_state: None` をそのまま round-trip（書き戻しなし）。保存 artifact 互換に `format_version` 変更は不要。
+- inner_valid は既に `cfg.training.seed` を継承済（`build_inner_valid`, BLUEPRINT §10.3.1）のため対象外。明示 inner_valid config の `random_state`（既定 42）は本提案のスコープ外。
+
+### 受け入れ基準（テスト観点）
+
+- `build_splitter`: ①全デフォルト（`training.seed=42`, split `random_state` None）→ splitter `random_state == 42`（後方互換）、②`training.seed=123` + split `random_state` None → splitter `random_state == 123`、③`split.random_state=7` 明示 + `training.seed=123` → splitter `random_state == 7`（明示優先）。
+- **seed sensitivity（invariant）**: `training.seed` のみ異なる 2 構成で OOF / outer split indices が変化する（同一なら fail）。同一 seed では bit 一致。
+- isotonic calibrator: `calibration.params` に seed 不在時に `training.seed` を継承する。
+- 既存テスト全件 green（loader default split の `random_state` ハードコード除去に伴う回帰なし）。
+
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -72,8 +72,8 @@ Method-specific keys:
 
 | method | Keys |
 |---|---|
-| `kfold` | `n_splits=5`, `random_state=42`, `shuffle=True` |
-| `stratified_kfold` | `n_splits=5`, `random_state=42` |
+| `kfold` | `n_splits=5`, `random_state=null` (inherits `training.seed`, default `42`), `shuffle=True` |
+| `stratified_kfold` | `n_splits=5`, `random_state=null` (inherits `training.seed`, default `42`) |
 | `group_kfold` | `n_splits=5` |
 | `time_series` | `n_splits=5`, `gap=0`, `train_size_max=null`, `test_size_max=null` |
 | `purged_time_series` | `n_splits=5`, `purge_gap=0`, `embargo=0`, `train_size_max=null`, `test_size_max=null` |
@@ -82,8 +82,13 @@ Method-specific keys:
 
 Default when `split` is omitted:
 
-- `task in {"binary", "multiclass"}` -> `{"method": "stratified_kfold", "n_splits": 5, "random_state": 42}`
-- `task == "regression"` -> `{"method": "kfold", "n_splits": 5, "random_state": 42, "shuffle": True}`
+- `task in {"binary", "multiclass"}` -> `{"method": "stratified_kfold", "n_splits": 5}` (`random_state` inherits `training.seed`)
+- `task == "regression"` -> `{"method": "kfold", "n_splits": 5, "shuffle": True}` (`random_state` inherits `training.seed`)
+
+`split.random_state` defaults to `null`, meaning the splitter inherits
+`training.seed` (H-0080). An explicit `random_state` overrides it. Because
+`training.seed` also defaults to `42`, a fully-default config reproduces the
+historical seed; only changing `training.seed` now also changes the CV folds.
 
 Time-series notes:
 

--- a/lizyml/config/loader.py
+++ b/lizyml/config/loader.py
@@ -52,13 +52,15 @@ def _normalize_split_default(raw: dict[str, Any]) -> dict[str, Any]:
     """
     if "split" not in raw:
         task = raw.get("task", "regression")
+        # random_state is intentionally omitted so the schema default (None)
+        # applies and the splitter inherits training.seed (H-0080). With the
+        # default training.seed=42 this reproduces the historical seed.
         if task in ("binary", "multiclass"):
             raw = {
                 **raw,
                 "split": {
                     "method": "stratified_kfold",
                     "n_splits": 5,
-                    "random_state": 42,
                 },
             }
         else:
@@ -67,7 +69,6 @@ def _normalize_split_default(raw: dict[str, Any]) -> dict[str, Any]:
                 "split": {
                     "method": "kfold",
                     "n_splits": 5,
-                    "random_state": 42,
                     "shuffle": True,
                 },
             }

--- a/lizyml/config/schema.py
+++ b/lizyml/config/schema.py
@@ -54,7 +54,8 @@ class KFoldConfig(BaseModel):
 
     method: Literal["kfold"]
     n_splits: int = 5
-    random_state: int = 42
+    # None -> inherit training.seed at splitter-build time (H-0080).
+    random_state: int | None = None
     shuffle: bool = True
 
 
@@ -63,7 +64,8 @@ class StratifiedKFoldConfig(BaseModel):
 
     method: Literal["stratified_kfold"]
     n_splits: int = 5
-    random_state: int = 42
+    # None -> inherit training.seed at splitter-build time (H-0080).
+    random_state: int | None = None
 
 
 class GroupKFoldConfig(BaseModel):
@@ -78,7 +80,8 @@ class StratifiedGroupKFoldConfig(BaseModel):
 
     method: Literal["stratified_group_kfold"]
     n_splits: int = 5
-    random_state: int = 42
+    # None -> inherit training.seed at splitter-build time (H-0080).
+    random_state: int | None = None
     shuffle: bool = True
 
 

--- a/lizyml/core/_model_factories.py
+++ b/lizyml/core/_model_factories.py
@@ -76,7 +76,13 @@ def _build_splitter_for_method(
     Shared implementation for both outer CV and calibration CV splitters.
     The *n_splits* parameter is separated so that callers can override it
     (e.g. ``calibration.n_splits`` instead of ``split.n_splits``).
+
+    ``seed`` is the fallback used when a split config's ``random_state`` is
+    ``None`` (H-0080): an explicit ``random_state`` wins, otherwise the
+    splitter inherits ``training.seed`` (passed by ``build_splitter`` as
+    ``seed``). ``seed=None`` itself falls back to the historical default 42.
     """
+    resolved_seed = 42 if seed is None else seed
     if isinstance(split_cfg, BlockedGroupKFoldConfig):
         if block_values is None:
             from lizyml.core.exceptions import ErrorCode, LizyMLError
@@ -103,7 +109,7 @@ def _build_splitter_for_method(
             n_splits=split_cfg.groups.n_splits,
             stratify=stratify_bool,
             shuffle=split_cfg.groups.shuffle,
-            random_state=42 if seed is None else seed,
+            random_state=resolved_seed,
             min_train_rows=split_cfg.min_train_rows,
             min_valid_rows=split_cfg.min_valid_rows,
         )
@@ -111,7 +117,11 @@ def _build_splitter_for_method(
         return StratifiedKFoldSplitter(
             n_splits=n_splits,
             shuffle=True,
-            random_state=split_cfg.random_state,
+            random_state=(
+                split_cfg.random_state
+                if split_cfg.random_state is not None
+                else resolved_seed
+            ),
         )
     if isinstance(split_cfg, GroupKFoldConfig):
         return GroupKFoldSplitter(n_splits=n_splits)
@@ -119,7 +129,11 @@ def _build_splitter_for_method(
         return StratifiedGroupKFoldSplitter(
             n_splits=n_splits,
             shuffle=split_cfg.shuffle,
-            random_state=split_cfg.random_state,
+            random_state=(
+                split_cfg.random_state
+                if split_cfg.random_state is not None
+                else resolved_seed
+            ),
         )
     if isinstance(split_cfg, TimeSeriesConfig):
         return TimeSeriesSplitter(
@@ -147,7 +161,11 @@ def _build_splitter_for_method(
         return KFoldSplitter(
             n_splits=n_splits,
             shuffle=split_cfg.shuffle,
-            random_state=split_cfg.random_state,
+            random_state=(
+                split_cfg.random_state
+                if split_cfg.random_state is not None
+                else resolved_seed
+            ),
         )
     # Loud fail — adding a new SplitConfig variant without updating this
     # dispatch must not silently produce KFold splits (#119).
@@ -209,7 +227,13 @@ def build_splitter(
             seed=cfg.training.seed if seed is None else seed,
         )
 
-    return _build_splitter_for_method(split_cfg, n_splits)
+    # General (non-blocked) splitters: thread training.seed as the fallback
+    # for any split config whose random_state is None (H-0080).
+    return _build_splitter_for_method(
+        split_cfg,
+        n_splits,
+        seed=cfg.training.seed if seed is None else seed,
+    )
 
 
 def build_calibration_splitter(cfg: LizyMLConfig) -> BaseSplitter:

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -1230,7 +1230,13 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         from lizyml.calibration.registry import get_calibrator
 
         method = cfg.calibration.method
-        cal_params = cfg.calibration.params or None
+        # Inherit training.seed for isotonic's internal validation split when
+        # no explicit calibration seed is given (H-0080). Other calibrators
+        # (platt / beta) do not use a seed, so leave their params untouched.
+        cal_params_dict = dict(cfg.calibration.params or {})
+        if method == "isotonic":
+            cal_params_dict.setdefault("seed", cfg.training.seed)
+        cal_params = cal_params_dict or None
         # Use raw scores (logits) for calibration (H-0030)
         cal_scores = (
             fit_result.oof_raw_scores

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -176,7 +176,8 @@ class TestStratifiedGroupKFoldConfig:
         cfg = load_config(raw)
         assert cfg.split.method == "stratified_group_kfold"
         assert cfg.split.n_splits == 5
-        assert cfg.split.random_state == 42
+        # H-0080: default is None (sentinel) → inherits training.seed at build.
+        assert cfg.split.random_state is None
         assert cfg.split.shuffle is True
 
     def test_custom_fields(self) -> None:

--- a/tests/test_core/test_seed_propagation.py
+++ b/tests/test_core/test_seed_propagation.py
@@ -1,0 +1,132 @@
+"""Seed propagation invariants (H-0080, issue #169).
+
+`training.seed` must reach the outer splitter and the isotonic calibrator.
+`split.random_state` is a sentinel: ``None`` (the default) inherits
+``training.seed``; an explicit value overrides it. Because ``training.seed``
+also defaults to 42, fully-default configs reproduce the historical seed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from lizyml import Model
+from lizyml.config.loader import load_config
+from lizyml.core._model_factories import build_splitter
+from tests._helpers import make_binary_df, make_config
+
+
+def _outer_valid_indices(
+    cfg_dict: dict[str, Any], n: int = 60
+) -> list[tuple[int, ...]]:
+    splitter = build_splitter(load_config(cfg_dict))
+    return [tuple(int(i) for i in valid) for _, valid in splitter.split(n)]
+
+
+class TestBuildSplitterSeedResolution:
+    def test_default_inherits_training_seed_backward_compat(self) -> None:
+        # split.random_state=None + training.seed=42 must reproduce the folds
+        # of an explicit random_state=42 (historical behavior).
+        inherited = _outer_valid_indices(
+            make_config("regression", seed=42, split_overrides={"random_state": None})
+        )
+        explicit_42 = _outer_valid_indices(
+            make_config("regression", seed=999, split_overrides={"random_state": 42})
+        )
+        assert inherited == explicit_42
+
+    def test_training_seed_propagates_to_splitter(self) -> None:
+        a = _outer_valid_indices(
+            make_config("regression", seed=42, split_overrides={"random_state": None})
+        )
+        b = _outer_valid_indices(
+            make_config("regression", seed=123, split_overrides={"random_state": None})
+        )
+        # Pre-fix these were identical (both used random_state=42 regardless).
+        assert a != b
+
+    def test_explicit_random_state_overrides_training_seed(self) -> None:
+        a = _outer_valid_indices(
+            make_config("regression", seed=123, split_overrides={"random_state": 7})
+        )
+        b = _outer_valid_indices(
+            make_config("regression", seed=999, split_overrides={"random_state": 7})
+        )
+        assert a == b
+
+
+class TestSeedSensitivityE2E:
+    def test_oof_splits_differ_by_training_seed(self) -> None:
+        df = make_binary_df()
+        r1 = Model(
+            make_config(
+                "binary",
+                seed=42,
+                split_overrides={"random_state": None},
+                n_estimators=10,
+            )
+        ).fit(data=df)
+        r2 = Model(
+            make_config(
+                "binary",
+                seed=123,
+                split_overrides={"random_state": None},
+                n_estimators=10,
+            )
+        ).fit(data=df)
+        v1 = [tuple(int(i) for i in v) for _, v in r1.splits.outer]
+        v2 = [tuple(int(i) for i in v) for _, v in r2.splits.outer]
+        assert v1 != v2
+
+    def test_same_training_seed_identical_oof(self) -> None:
+        df = make_binary_df()
+        r1 = Model(
+            make_config(
+                "binary",
+                seed=42,
+                split_overrides={"random_state": None},
+                n_estimators=10,
+            )
+        ).fit(data=df)
+        r2 = Model(
+            make_config(
+                "binary",
+                seed=42,
+                split_overrides={"random_state": None},
+                n_estimators=10,
+            )
+        ).fit(data=df)
+        np.testing.assert_array_equal(r1.oof_pred, r2.oof_pred)
+
+
+class TestIsotonicCalibratorInheritsSeed:
+    """With folds fixed (explicit split seed) and the base-model seed held
+    constant, the isotonic calibrator's internal seed is the only variable."""
+
+    def _calibrated_oof(self, cal_params: dict[str, Any] | None) -> np.ndarray:
+        df = make_binary_df()
+        cfg = make_config(
+            "binary",
+            seed=7,  # base model + (explicit) folds identical across runs
+            split_overrides={"random_state": 42},
+            calibration="isotonic",
+            calibration_params=cal_params,
+            n_estimators=30,
+        )
+        result = Model(cfg).fit(data=df)
+        return np.asarray(result.calibrator.calibrated_oof)
+
+    def test_inherited_seed_equals_explicit_match(self) -> None:
+        # No calibration seed -> inherits training.seed (7); explicit 7 must match.
+        inherited = self._calibrated_oof(None)
+        explicit_7 = self._calibrated_oof({"seed": 7})
+        np.testing.assert_array_equal(inherited, explicit_7)
+
+    def test_calibrator_seed_actually_matters(self) -> None:
+        # Negative control: a different calibrator seed changes the output,
+        # so the equivalence above is not vacuous.
+        inherited = self._calibrated_oof(None)
+        explicit_999 = self._calibrated_oof({"seed": 999})
+        assert not np.array_equal(inherited, explicit_999)


### PR DESCRIPTION
## Summary
Implements **H-0080** (resolves #169): `training.seed` now propagates to the outer CV splitter and the isotonic calibrator. `split.random_state` becomes a sentinel — `None` (the new default) inherits `training.seed`; an explicit value still overrides it. Because `training.seed` also defaults to `42`, fully-default configs reproduce the historical seed; only configs that set a custom `training.seed` (without an explicit split seed) now see their CV folds follow it — the intended fix.

**Change Gate:** HISTORY proposal `H-0080` is included (Accepted, Option A). This is **potentially breaking** for configs that set a non-default `training.seed` without an explicit `split.random_state` (their OOF / split indices / saved-artifact fold composition change). No `format_version` bump — `model_dump()` round-trips `random_state: None` unchanged (no dual-write; avoids the H-0069 trap).

## Invariants
- **INV-1:** `split.random_state is None` resolves to `training.seed` at splitter-build time and is **never written back** to the config.
- **INV-2:** an explicit `split.random_state` always wins over `training.seed`.
- **INV-3:** a fully-default config (`training.seed=42`, `split.random_state=None`) produces the same folds as an explicit `random_state=42` (backward compatibility).
- **INV-4:** the isotonic calibrator's internal-split seed inherits `training.seed` when `calibration.params` has no `seed`; an explicit `seed` overrides it.

## Changes
- `lizyml/config/schema.py`: `KFoldConfig` / `StratifiedKFoldConfig` / `StratifiedGroupKFoldConfig` `random_state: int = 42` → `int | None = None`.
- `lizyml/config/loader.py`: `_normalize_split_default()` no longer hardcodes `random_state: 42` into the auto-injected default split (so the schema default `None` applies and inheritance works for the common "omit split" case).
- `lizyml/core/_model_factories.py`: `build_splitter()` threads `cfg.training.seed` into the general (non-blocked) branch; `_build_splitter_for_method()` resolves `explicit if not None else seed` for the three seeded splitters.
- `lizyml/core/model.py`: calibration path `setdefault`s `training.seed` into the isotonic calibrator params.
- `docs/config-reference.md`: documents the new `random_state=null → inherits training.seed` semantics.
- `HISTORY.md`: H-0080 proposal (purpose / approach / impact & compatibility / acceptance criteria).

## Failure paths covered
- [x] Default config (no seed set) — unchanged folds (INV-3).
- [x] Custom `training.seed`, no split seed — folds follow it (the fix).
- [x] Explicit `split.random_state` + custom `training.seed` — explicit wins (INV-2).
- [x] Same seed twice — bit-identical OOF (determinism).
- [x] Isotonic calibrator seed inheritance + negative control (seed actually matters).
- [ ] Timeout / cancellation — N/A (no concurrency in this layer).

## Test plan / DoD
- Relevant SKILLs: `splitters-and-splitplan`, `calibration`, `history-proposals`, `testing`.
- New: `tests/test_core/test_seed_propagation.py` (7 tests: build_splitter resolution ×3, e2e seed-sensitivity + determinism ×2, isotonic inheritance + negative control ×2).
- `ruff` / `ruff format` / `mypy --strict`: clean. `pytest -m "not slow"`: green (no regression from the loader/schema default change).
- inner_valid already inherited `training.seed` (BLUEPRINT §10.3.1) — untouched. Explicit `inner_valid.random_state` (default 42) is out of scope.
- CHANGELOG: the potentially-breaking note will be added in the release PR (consolidated per CLAUDE.md §5.4); flagged in H-0080.

Resolves #169.
