### PR TITLE
docs: scope bit-identical reproducibility to fixed (num_threads, CPU) env (H-0081, #170)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -27,7 +27,7 @@
 
 # 2. 設計原則
 
-- 再現性を最優先する。
+- 再現性を最優先する。bit 一致保証（同一 `config + seed` で同一結果）は**固定 `(num_threads, CPU)` 環境**を前提とする。LightGBM の histogram 構築はスレッド数に依存するため、CPU / スレッド数が異なる環境間での bit 一致は保証範囲外とする（クロス環境再現性は将来 opt-in で提供しうるが、現状の defaults はスコープしない。詳細は H-0081）。
 - `seed / split / params / versions / data schema / split indices / data fingerprint` を必ず保存する。
 - 仕様未確定は仮実装しない。
 - 独自推測実装を禁止し、必ず提案プロセス（`HISTORY.md`）を経る。
@@ -1378,7 +1378,7 @@ YourLibError(code, user_message, debug_message=None, cause=None)
 ### 18.1.1 基本テストカテゴリ
 
 - **Golden test（契約固定）**: `FitResult / PredictionResult / RunMeta / SplitIndices` のフィールド名・型・構造を固定し、意図しない破壊的変更を検知する。
-- **再現性テスト**: 同一 config + seed で `oof_pred`, `predict`, `metrics`, `split indices` が bit 一致する。`tune()` も同一 seed で `best_params` / `best_score` / trial 順序が一致する。
+- **再現性テスト**: 同一 config + seed で `oof_pred`, `predict`, `metrics`, `split indices` が bit 一致する。`tune()` も同一 seed で `best_params` / `best_score` / trial 順序が一致する。bit 一致は**固定 `(num_threads, CPU)` 環境**（同一スレッド数の同一プロセス / マシン）を前提とする。LightGBM の histogram 構築がスレッド数依存のため、クロス環境 bit 一致は保証範囲外（H-0081）。
 - **リーク防止テスト**: OOF が held-out データのみから生成されること、calibration が cross-fit で分離されていること、feature pipeline が train fold のみで fit されることを検証する。
 - **列ズレテスト**: 余剰 / 不足 / unseen category のポリシー通り動く。カテゴリ順序ずれ（学習時と推論時で同一カテゴリだが出現順が異なる）もカバーする。
 - **例外テスト**: 全 `ErrorCode` に対して少なくとも 1 テストが存在し、`context` dict の必須キーを検証する。

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6677,3 +6677,37 @@ Issue #159 で要求された全 7 層を Phase に分散して実装する。
 - 既存テスト全件 green（loader default split の `random_state` ハードコード除去に伴う回帰なし）。
 
 
+## H-0081: bit 一致の再現性保証を「固定 `(num_threads, CPU)` 環境」にスコープ明記（doc-scope）
+
+- **ステータス**: Accepted
+- **起票日**: 2026-06-01
+- **決定日**: 2026-06-01
+- **スコープ**: BLUEPRINT.md（§2 設計原則の再現性原則、§18.1.1 再現性テスト）, README.md（Design Priorities の bit 一致記述）。**コード変更なし（defaults 不変）**。
+- **関連**: [Issue #170](https://github.com/nbx-liz/LizyML/issues/170), v0.15.0 品質監査
+
+### 目的（課題）
+
+BLUEPRINT は「同一 `config + seed` で bit 一致」を再現性の最優先保証として掲げるが、LightGBM のデフォルト（`feature_fraction` / `bagging_fraction` / `bagging_freq` による確率的サブサンプリング）は `deterministic` / `force_row_wise` / `num_threads` 未設定のままである。LightGBM の histogram 構築はスレッド数に依存するため、CPU / スレッド数が異なるマシン間（CI runner / ユーザー環境）では bit 一致が崩れうる。保証の文言が環境スコープを明示していないため、**文書上の over-promise** になっている。
+
+### 対応方針（doc-scope: 保証をスコープ明記）
+
+bit 一致保証を「**固定 `(num_threads, CPU)` 環境**」にスコープする旨を BLUEPRINT / README に明記する。defaults への `deterministic: true` / `force_row_wise: true` 追加は行わない。
+
+- BLUEPRINT §2 設計原則: 再現性原則に「bit 一致は固定 `(num_threads, CPU)` 環境を前提とする」旨の注記を追加。
+- BLUEPRINT §18.1.1 再現性テスト: 再現性テストが同一環境（同一スレッド数）を前提とすることを明記。
+- README: Reproducibility 記述に同趣旨の注記を追加。
+
+### 代替案（不採用）
+
+defaults に `deterministic: true` + `force_row_wise: true` を追加し、クロス環境 bit 一致を実際に保証する案。**性能コスト**（`force_row_wise` による学習速度低下、`deterministic` のオーバーヘッド）が大きく、最頻ユースケースに恒久的なペナルティを課すため不採用。将来、クロス環境再現性を opt-in で提供する場合は別 Proposal（Change-Gate）とする。
+
+### 影響範囲 / 互換性
+
+- **ドキュメントのみ**。公開 API / Config / FitResult / PredictionResult / Artifacts / defaults いずれも不変。`format_version` 変更不要。
+- 既存ユーザーの実行結果・保存 artifact に一切変化なし。
+
+### 受け入れ基準（テスト観点）
+
+- コード変更なしのため新規テスト不要。既存テスト全件 green（回帰なし）を確認する。
+- BLUEPRINT / README の文言に「固定 `(num_threads, CPU)` 環境」のスコープが明記されていること（レビュー観点）。
+

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full diagrams and module layout.
 
 ## Design Priorities
 
-**Reproducibility** -- Same config + seed = same splits, same OOF predictions, same metrics. Every run captures seed, split indices, params, library versions, and a data fingerprint.
+**Reproducibility** -- Same config + seed = same splits, same OOF predictions, same metrics, **within a fixed `(num_threads, CPU)` environment**. (LightGBM's histogram construction is thread-count sensitive, so bit-identical results across machines with different CPU/thread counts are out of scope.) Every run captures seed, split indices, params, library versions, and a data fingerprint.
 
 **Leakage prevention** -- OOF rows are never seen during training. Calibration cross-fit reuses outer CV splits. Time and group constraints propagate to inner validation (early stopping) and calibration.
 


### PR DESCRIPTION
## Summary
Closes #170 (doc-scope resolution, no behavior change). The BLUEPRINT bit-identical reproducibility guarantee did not state an environment scope, while LightGBM's default stochastic subsampling (`feature_fraction` / `bagging_fraction` / `bagging_freq`) with `deterministic` / `force_row_wise` / `num_threads` unset can produce bit-different results across machines with different CPU/thread counts.

Per the locked Change-Gate decision (2026-06-01), this is resolved **doc-only**: scope the guarantee to a fixed `(num_threads, CPU)` environment rather than adding `deterministic` / `force_row_wise` to defaults (rejected for performance cost).

## Changes
- `HISTORY.md`: add proposal/decision **H-0081** (Accepted, doc-scope).
- `BLUEPRINT.md`: §2 design principles + §18.1.1 reproducibility test — note bit-identical holds within a fixed `(num_threads, CPU)` environment.
- `README.md`: Design Priorities — scope the "same config + seed = same results" claim to a fixed environment.

## Skill
`skills/spec-update`, `skills/history-proposals`.

## Change Gate
H-0081 (Accepted). Documentation-only scoping of an existing guarantee; no public API / Config / FitResult / PredictionResult / Artifacts / defaults change. No `format_version` bump.

## DoD
- [x] HISTORY proposal commit precedes implementation commit (CLAUDE.md §5.4 order).
- [x] `ruff check .` / `ruff format --check .` clean.
- [x] No code change → existing tests unaffected (markdown-only diff).
