### PR TITLE
fix(core): return copies from public result accessors to prevent state contamination (H-0082, #174)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6711,3 +6711,47 @@ defaults に `deterministic: true` + `force_row_wise: true` を追加し、ク�
 - コード変更なしのため新規テスト不要。既存テスト全件 green（回帰なし）を確認する。
 - BLUEPRINT / README の文言に「固定 `(num_threads, CPU)` 環境」のスコープが明記されていること（レビュー観点）。
 
+
+## H-0082: `evaluate(None)` / `fit_result` の公開返却を selective deep-copy 化し internal state 汚染を防止
+
+- **ステータス**: Accepted
+- **起票日**: 2026-06-01
+- **決定日**: 2026-06-01
+- **スコープ**: `lizyml/core/model.py`（`evaluate(metrics=None)` 返却、`fit_result` property 返却）, `lizyml/core/types/fit_result.py`（`FitResult.__deepcopy__`）。`FitResult` は **非 frozen を維持**（dataclass のまま）。
+- **関連**: [Issue #174](https://github.com/nbx-liz/LizyML/issues/174), v0.15.0 品質監査, `TuningResult`（frozen + defensive copy の前例）
+
+### 目的（課題）
+
+`FitResult` は非 frozen dataclass で mutable フィールド（`metrics` 等のネスト dict）を持ち、`evaluate(metrics=None)` と `fit_result` property は **live な内部参照をそのまま返す**。呼び出し側が返り値を変異させる（例: `m.evaluate()["raw"]["oof"]["rmse"] = 0`）と内部 `_metrics` が破壊され、`export()` が live な `_metrics` を読むため **export メタデータ汚染（再現性リスク）** に至る。一方 filtered path（`evaluate([...])`）は `filter_metrics` で fresh dict を返すため、**挙動が非対称**でもある。
+
+### 対応方針（public return で selective deep-copy、FitResult 非 frozen 維持）
+
+公開返却点でのみ copy を適用し、内部 live state を外部に貸し出さない。`fit_result` は **selective deep-copy**（mutable data は複製、学習済み estimator は reference 共有）とする。
+
+- `evaluate(metrics=None)`: `return deepcopy(self._metrics)`（`metrics` は純粋なネスト dict のため全 deep-copy で問題なし）。
+- `fit_result` property: `return deepcopy(self._require_fit())`。`FitResult.__deepcopy__` を実装し、
+  - **deep-copy する mutable data**: `metrics` / `history` / `feature_names` / `dtypes` / `categorical_features` / `splits` / `data_fingerprint` / `run_meta` / `target_encoder` / `oof_pred` / `if_pred_per_fold` / `oof_raw_scores`。
+  - **reference 共有する学習済み estimator**: `models` / `calibrator` / `pipeline_state`。
+- **selective の理由**: `copy.deepcopy(LightGBM Booster)` は model 文字列 round-trip となり `booster.params`（`objective` 等）の fidelity を失う（`params["objective"]` が `None` 化）。export 汚染の実害ベクタは `metrics`（plain dict）であり、これを deep-copy で完全封鎖すれば再現性リスクは解消する。学習済み estimator まで複製すると **公開 `fit_result.models[i]` 経由の Booster metadata を劣化させる回帰**となるため共有する。
+- 内部経路（Mixin / plot / persistence / export）は `FitState.fit_result`（`_require_fit()` 由来の live 参照）と `self._metrics` を直接使うため **copy のコストを負わない**。公開 property `Model.fit_result` は外部呼び出し専用であることをコード調査で確認済み（内部は `state.fit_result` を使用）。
+
+### 代替案（不採用）
+
+- **FitResult 全体を deepcopy**: 学習済み Booster の `params` fidelity を失い、公開 `fit_result.models[i]` の metadata を劣化させる回帰となるため不採用（本対応方針が selective とした根拠）。
+- **FitResult を frozen 化**: ネスト dict / list は frozen dataclass でも mutable のままで根本解決にならず、内部で `FitResult` を構築・保持する多数の経路に破壊的影響が及ぶため不採用。
+- **fit_result を borrowed reference として doc 明記のみ**: export 汚染という実害（再現性リスク）を残すため不採用。
+
+### 影響範囲 / 互換性
+
+- **Result の「形・意味」は不変**。返却される dict / FitResult の構造・値は完全に同一で、参照の同一性のみが変わる（`m.fit_result is m.fit_result` → `False`、`m.evaluate() is m.evaluate()` → `False`）。`format_version` 変更不要。
+- `fit_result.models` / `calibrator` / `pipeline_state` は **reference 共有**（read-only 想定）。これらを呼び出し側が破壊的に変異させると内部 state に波及しうるが、学習済みモデルの故意変異は契約外の misuse とし、docstring に read-only である旨を明記する。export 汚染の現実的ベクタ（`metrics` 変異）は完全に封鎖される。
+- 同一性に依存する利用（`is` 比較）は破壊されうるが、Result は値オブジェクトであり同一性依存は契約外。
+
+### 受け入れ基準（テスト観点）
+
+- **汚染防止（回帰トラップ）**: `evaluate(None)` の返り値ネスト dict を変異 → 後続 `export()` のメタデータ / `model.evaluate()` が影響を受けない。
+- **fit_result 独立性**: `m.fit_result.metrics` を変異 → 内部 state（後続 `m.fit_result` / `export`）が不変。
+- **estimator 共有**: `m.fit_result.models[i] is m._fit_result.models[i]`（identity 保持で Booster fidelity を維持）。
+- **値の同一性**: copy 前後で構造・数値が bit 一致（`==`）する。
+- 既存テスト全件 green。
+

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import sys
 from collections.abc import Callable
+from copy import deepcopy
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -303,7 +304,9 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
             )
 
         if metrics is None:
-            return self._metrics
+            # Return an independent copy so callers cannot mutate internal
+            # state (and thereby contaminate a later export()) — H-0082.
+            return deepcopy(self._metrics)
 
         # Validate task compatibility first (raises UNSUPPORTED_METRIC if invalid)
         get_metrics_for_task(metrics, self._cfg.task)  # raises on unknown/incompatible
@@ -873,10 +876,18 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
     def fit_result(self) -> FitResult:
         """Read-only access to the CV training result.
 
+        Returns an independent copy each call: mutable data fields are
+        deep-copied so mutating the result cannot corrupt internal state (or a
+        later ``export()``). Trained estimators (``models`` / ``calibrator`` /
+        ``pipeline_state``) are shared by reference and must be treated as
+        read-only — see :meth:`FitResult.__deepcopy__` (H-0082).
+
         Raises:
             LizyMLError with ``MODEL_NOT_FIT`` when ``fit()`` has not been called.
         """
-        return self._require_fit()
+        # Selective deep copy (FitResult.__deepcopy__): mutable data copied,
+        # trained estimators shared by reference to preserve Booster fidelity.
+        return deepcopy(self._require_fit())
 
     # ------------------------------------------------------------------
     # Internal helpers — TrainComponents (H-0050)

--- a/lizyml/core/types/fit_result.py
+++ b/lizyml/core/types/fit_result.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 import numpy as np
@@ -37,7 +38,8 @@ class FitResult:
                     "calibrated": { ... }  # binary + calibrator only
                 }
 
-        models: Trained model adapters, one per fold.
+        models: Trained model adapters, one per fold. Shared by reference
+            across copies (read-only by convention — see ``__deepcopy__``).
         history: Per-fold training history dicts.
             Each dict contains at least ``"eval_history"`` and ``"best_iteration"``.
         feature_names: Ordered list of feature column names used during training.
@@ -45,8 +47,10 @@ class FitResult:
         categorical_features: Names of features encoded as categorical.
         splits: Full index record for outer/inner/calibration splits.
         data_fingerprint: Fingerprint of the training dataset.
-        pipeline_state: Serializable state of the FeaturePipeline.
+        pipeline_state: Serializable state of the FeaturePipeline. Shared by
+            reference across copies (read-only by convention).
         calibrator: Fitted calibrator (``None`` when calibration is disabled).
+            Shared by reference across copies (read-only by convention).
         run_meta: Version and config metadata captured at fit time.
         oof_raw_scores: OOF raw scores (logits) for calibration.
             ``None`` when calibration is not enabled. Shape ``(n_samples,)``
@@ -71,3 +75,32 @@ class FitResult:
     run_meta: RunMeta
     oof_raw_scores: npt.NDArray[np.float64] | None = None
     target_encoder: TargetEncoder = field(default_factory=TargetEncoder.no_op)
+
+    #: Trained-estimator fields shared by reference on copy (see ``__deepcopy__``).
+    _SHARED_ON_COPY = ("models", "calibrator", "pipeline_state")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> FitResult:
+        """Selective deep copy used by the public ``Model.fit_result`` return.
+
+        Mutable *data* fields (``metrics``, ``history``, ``splits``, arrays,
+        ...) are deep-copied so a caller mutating the returned ``FitResult``
+        cannot corrupt internal state — and thereby a later ``export()`` (the
+        export-contamination vector flows through ``metrics``). Trained
+        estimators (``models`` / ``calibrator`` / ``pipeline_state``) are shared
+        by reference: deep-copying a LightGBM ``Booster`` round-trips through its
+        model string and drops ``params`` fidelity (e.g. ``objective`` becomes
+        ``None``), which would degrade the metadata reachable via
+        ``fit_result.models``. Those shared objects are read-only by convention
+        (H-0082).
+        """
+        shared = set(self._SHARED_ON_COPY)
+        init_kwargs: dict[str, Any] = {}
+        for f in fields(self):
+            value = getattr(self, f.name)
+            if f.name in shared:
+                # New list container for ``models`` (defensive against list-level
+                # mutation) while keeping the trained adapters themselves shared.
+                init_kwargs[f.name] = list(value) if isinstance(value, list) else value
+            else:
+                init_kwargs[f.name] = deepcopy(value, memo)
+        return FitResult(**init_kwargs)

--- a/tests/test_core/test_result_isolation.py
+++ b/tests/test_core/test_result_isolation.py
@@ -1,0 +1,90 @@
+"""Public-return isolation tests for ``Model.evaluate`` / ``Model.fit_result`` (H-0082).
+
+``FitResult`` is a non-frozen dataclass with mutable nested dicts. Before H-0082
+the unfiltered ``evaluate(None)`` and the ``fit_result`` property handed out live
+internal references, so a caller mutating the returned object could corrupt
+internal state — and because ``export()`` reads the live metrics, the worst case
+was contaminated exported metadata (a reproducibility risk).
+
+These tests pin the contract: public returns are independent deep copies; the
+exported metadata is never affected by post-call mutation of a returned object.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lizyml import Model
+from tests._helpers import make_config, make_regression_df
+
+_SENTINEL = -999.0
+
+
+@pytest.fixture(scope="module")
+def fitted_model() -> Model:
+    model = Model(make_config("regression"))
+    model.fit(data=make_regression_df(n=120))
+    return model
+
+
+def _oof_key(metrics: dict) -> str:
+    return next(iter(metrics["raw"]["oof"]))
+
+
+def test_evaluate_none_returns_independent_copy(fitted_model: Model) -> None:
+    snapshot = fitted_model.evaluate()
+    key = _oof_key(snapshot)
+    snapshot["raw"]["oof"][key] = _SENTINEL
+
+    # Internal state must be untouched by mutating the returned object.
+    assert fitted_model.evaluate()["raw"]["oof"][key] != _SENTINEL
+
+
+def test_evaluate_none_distinct_objects_equal_values(fitted_model: Model) -> None:
+    first = fitted_model.evaluate()
+    second = fitted_model.evaluate()
+    assert first is not second
+    assert first["raw"]["oof"] is not second["raw"]["oof"]
+    assert first == second  # structure / values are bit-identical
+
+
+def test_fit_result_property_returns_independent_copy(fitted_model: Model) -> None:
+    fr = fitted_model.fit_result
+    key = _oof_key(fr.metrics)
+    fr.metrics["raw"]["oof"][key] = _SENTINEL
+
+    assert fitted_model.fit_result.metrics["raw"]["oof"][key] != _SENTINEL
+
+
+def test_fit_result_property_distinct_objects(fitted_model: Model) -> None:
+    assert fitted_model.fit_result is not fitted_model.fit_result
+
+
+def test_fit_result_shares_trained_estimators_by_reference(
+    fitted_model: Model,
+) -> None:
+    # Selective copy: trained estimators are shared (deep-copying a Booster
+    # drops params fidelity), so identity is preserved against internal state.
+    internal = fitted_model._fit_result
+    returned = fitted_model.fit_result
+    assert returned is not internal
+    assert returned.models[0] is internal.models[0]
+    assert returned.calibrator is internal.calibrator
+    assert returned.pipeline_state is internal.pipeline_state
+    # Mutable data is copied, not shared.
+    assert returned.metrics is not internal.metrics
+
+
+def test_mutating_evaluate_does_not_contaminate_export(
+    fitted_model: Model, tmp_path
+) -> None:
+    snapshot = fitted_model.evaluate()
+    key = _oof_key(snapshot)
+    snapshot["raw"]["oof"][key] = _SENTINEL
+
+    out = fitted_model.export(path=tmp_path / "artifact")
+    metadata = json.loads((out / "metadata.json").read_text(encoding="utf-8"))
+
+    assert metadata["metrics"]["raw"]["oof"][key] != _SENTINEL


### PR DESCRIPTION
## Summary
Closes #174. `FitResult` is a non-frozen dataclass with mutable nested dicts, and the unfiltered `evaluate(metrics=None)` / the `fit_result` property handed out **live internal references**. A caller mutating the returned object (e.g. `m.evaluate()["raw"]["oof"]["rmse"] = 0`) corrupted internal state, and because `export()` reads the live metrics, the worst case was contaminated exported metadata — a reproducibility risk. The filtered path (`evaluate([...])`) already returns a fresh dict, so the behavior was asymmetric.

Per the locked Change-Gate decision (2026-06-01), the fix returns copies on the public accessors while keeping `FitResult` non-frozen (H-0082).

## Approach — selective deep copy
- `evaluate(metrics=None)` returns `deepcopy(self._metrics)` (`metrics` is a pure nested dict — full deep copy is safe and closes the export-contamination vector).
- `fit_result` returns `deepcopy(self._require_fit())`, backed by a new `FitResult.__deepcopy__` that:
  - **deep-copies** the mutable data fields (`metrics`, `history`, `splits`, arrays, ...), and
  - **shares trained estimators by reference** (`models` / `calibrator` / `pipeline_state`).

**Why selective (not full deep copy):** `copy.deepcopy()` of a LightGBM `Booster` round-trips through its model string and drops `params` fidelity (`params["objective"]` becomes `None`). A full deep copy would therefore degrade the booster metadata reachable via `m.fit_result.models[i]` — a real regression caught by `test_lgbm_objective_identity.py`. The export-contamination vector flows through `metrics` (a plain dict), which is fully closed; trained estimators are documented as read-only.

Internal paths (Mixin / plot / persistence / export) use `FitState.fit_result` (live) and `self._metrics` directly, so they pay no copy cost. `Model.fit_result` is external-only (verified by code search).

## Skill
`skills/evaluation-contracts`, `skills/history-proposals`, `skills/testing`.

## Change Gate
Proposal **H-0082** (Accepted) added to `HISTORY.md` before implementation. Result shape/meaning unchanged (only reference identity differs); no `format_version` bump.

## Invariants
- INV-1: `evaluate(None)` / `fit_result` never expose a reference that aliases internal `_metrics` / `_fit_result` mutable data.
- INV-2: a subsequent `export()` is unaffected by post-call mutation of a returned object.
- INV-3: trained estimators (`models` / `calibrator` / `pipeline_state`) are shared by reference (identity preserved) to keep booster `params` fidelity.

## Tests (`tests/test_core/test_result_isolation.py`, 6)
- `evaluate(None)` mutation does not leak to internal state.
- `evaluate(None)` returns distinct-but-equal objects.
- `fit_result.metrics` mutation does not leak to internal state.
- `fit_result` returns distinct objects per call.
- trained estimators shared by reference; `metrics` copied.
- mutating an `evaluate()` result does not contaminate a later `export()` metadata.

## DoD
- [x] HISTORY proposal commit precedes implementation (CLAUDE.md §5.4).
- [x] TDD: RED (5 failing) → GREEN.
- [x] `ruff check .` / `ruff format --check .` / `mypy lizyml/` clean (103 files).
- [x] `pytest -m "not slow"` — 1918 passed, 0 failed.
