### PR TITLE
feat(persistence): bind .pkl SHA-256 integrity into artifact metadata (H-0083, #179)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6755,3 +6755,55 @@ defaults に `deterministic: true` + `force_row_wise: true` を追加し、ク�
 - **値の同一性**: copy 前後で構造・数値が bit 一致（`==`）する。
 - 既存テスト全件 green。
 
+
+## H-0083: export 時に各 .pkl の SHA-256 を metadata.json に記録し load 時に検証
+
+- **ステータス**: Accepted
+- **起票日**: 2026-06-01
+- **決定日**: 2026-06-01
+- **スコープ**: `lizyml/persistence/exporter.py`（metadata に `checksums` 追加）, `lizyml/persistence/loader.py`（load 前の digest 検証）。`FORMAT_VERSION` は **2 のまま据置（additive・後方互換 read）**。
+- **関連**: [Issue #179](https://github.com/nbx-liz/LizyML/issues/179), v0.15.0 品質監査（SECURITY/LOW）
+
+### 目的（課題）
+
+`Model.load()` は `.pkl`（`fit_result` / `refit_model` / `analysis_context`）を `joblib.load` で復元するが、これは任意 Python を実行する。load 前検証は `metadata.json` のみで、**検証済み metadata と .pkl バイト列の間に整合バインドが無い**。良性 metadata に改竄 .pkl を組み合わせると ACE に至る。「trusted-source のみ」契約＋pickle-free codegen 代替の開示により LOW だが、安価な整合チェックで改竄/破損を検出できる。
+
+### 対応方針（additive checksum、format_version 据置）
+
+`export()` で各 .pkl の SHA-256 を計算し `metadata.json` に additive フィールドとして記録。`load()` で `joblib.load` 前に digest を照合し、不一致は `DESERIALIZATION_FAILED` を送出する。
+
+- metadata 構造（additive）::
+
+      "checksums": {
+          "algorithm": "sha256",
+          "files": {
+              "fit_result.pkl": "<hex>",
+              "refit_model.pkl": "<hex>",
+              "analysis_context.pkl": "<hex>"   # 任意（存在時のみ）
+          }
+      }
+
+- `export()`: .pkl を dump 後にバイト列の SHA-256 を計算し metadata に格納（書き込み順を「.pkl → metadata.json」に変更）。
+- `load()`: `checksums` が存在し当該ファイルの digest が登録されていれば照合。`algorithm` が `sha256` 以外、または digest 不一致は `DESERIALIZATION_FAILED`（context に `file` / `expected` / `actual` を格納）。
+- **後方互換 read**: `checksums` 不在（H-0083 以前の format_version 2、または format_version 1）の artifact は検証を skip して従来通り load する。これにより `FORMAT_VERSION` 据置で旧 artifact を読める。
+
+### 代替案（不採用）
+
+- **`FORMAT_VERSION` を 3 に bump**: checksum は additive で旧 read を壊さないため不要。migration 負荷を避ける（locked 決定）。
+- **署名（HMAC/公開鍵）**: 鍵管理が必要で LOW リスクに対し過剰。SHA-256 は「改竄/破損検出」目的に十分（fully-trusted-but-malicious producer に対し pickle を安全化するとは主張しない）。
+- **検証を warning に留める**: 整合バインドの意味を成さないため、不一致は fail-closed（例外）とする。
+
+### 影響範囲 / 互換性
+
+- **後方互換**: 旧 artifact（checksums 不在）は従来通り load 可能。新 artifact は旧 loader でも load 可能（`checksums` は未知フィールドとして無視される）。`FORMAT_VERSION` 不変。
+- 公開 API（`export` / `load` の引数・戻り値）不変。`load()` の戻り `metadata` dict に `checksums` キーが増えるのみ。
+- **TOCTOU 対策**: `load()` は .pkl のバイト列を 1 回だけ読み、in-memory で digest 照合後 `joblib.load(io.BytesIO(...))` で復元する（ファイルを再 open しない）。hash 後・load 前のすり替え窓を排除（security-review 指摘）。
+- **脅威モデル（明示）**: `metadata.json` 自体は署名しないため、書き込み権限を持つ攻撃者は `checksums` を改竄/除去できる。本機能は「改竄/破損の検出」が目的であり、trusted-but-malicious producer に対し pickle を安全化するものではない（既存の trusted-source 契約を維持）。
+
+### 受け入れ基準（テスト観点）
+
+- **正常**: export→load round-trip が成功し、`metadata["checksums"]["files"]` に全 .pkl の SHA-256 が入る。
+- **改竄検出（落ちるべき例）**: export 後に `fit_result.pkl` のバイトを書き換え→`load()` が `DESERIALIZATION_FAILED`（context に file/expected/actual）。`refit_model.pkl` / `analysis_context.pkl` も同様。
+- **後方互換**: `checksums` を持たない metadata（旧 artifact 模擬）で `load()` が従来通り成功する。
+- 既存 persistence テスト全件 green。
+

--- a/lizyml/persistence/exporter.py
+++ b/lizyml/persistence/exporter.py
@@ -3,16 +3,22 @@
 Directory layout (format_version=2)::
 
     {path}/
-        metadata.json        — human-readable metadata + version info
+        metadata.json        — human-readable metadata + version info +
+                               SHA-256 checksums of each .pkl (H-0083)
         fit_result.pkl       — FitResult (joblib compressed)
         refit_model.pkl      — RefitResult (joblib compressed)
         analysis_context.pkl — (optional) y_true + X for diagnostic APIs
 
 Security note: pickle/joblib files must only be loaded from trusted sources.
+The SHA-256 ``checksums`` in metadata.json bind the validated metadata to the
+.pkl bytes so that tampering/corruption is detected on load (it does not make
+pickle safe against a fully trusted-but-malicious producer). The field is
+additive: artifacts without it (pre-H-0083) still load (FORMAT_VERSION=2).
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +35,14 @@ if TYPE_CHECKING:
     from lizyml.training.refit_trainer import RefitResult
 
 FORMAT_VERSION = 2
+
+#: Checksum algorithm recorded in ``metadata.json`` and verified on load.
+CHECKSUM_ALGORITHM = "sha256"
+
+
+def sha256_file(path: Path) -> str:
+    """Return the hex SHA-256 digest of *path*'s bytes (H-0083)."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
 
 @dataclass
@@ -66,6 +80,16 @@ def export(
     try:
         out.mkdir(parents=True, exist_ok=True)
 
+        # Serialize payloads first so their bytes can be hashed into metadata
+        # (integrity binding verified on load — H-0083).
+        joblib.dump(fit_result, out / "fit_result.pkl", compress=3)
+        joblib.dump(refit_result, out / "refit_model.pkl", compress=3)
+        pkl_names = ["fit_result.pkl", "refit_model.pkl"]
+
+        if analysis_context is not None:
+            joblib.dump(analysis_context, out / "analysis_context.pkl", compress=3)
+            pkl_names.append("analysis_context.pkl")
+
         metadata: dict[str, Any] = {
             "format_version": FORMAT_VERSION,
             "lizyml_version": fit_result.run_meta.lizyml_version,
@@ -76,16 +100,14 @@ def export(
             "metrics": fit_result.metrics,
             "feature_names": fit_result.feature_names,
             "task": task,
+            "checksums": {
+                "algorithm": CHECKSUM_ALGORITHM,
+                "files": {name: sha256_file(out / name) for name in pkl_names},
+            },
         }
         (out / "metadata.json").write_text(
             json.dumps(metadata, indent=2, default=str), encoding="utf-8"
         )
-
-        joblib.dump(fit_result, out / "fit_result.pkl", compress=3)
-        joblib.dump(refit_result, out / "refit_model.pkl", compress=3)
-
-        if analysis_context is not None:
-            joblib.dump(analysis_context, out / "analysis_context.pkl", compress=3)
 
     except LizyMLError:
         raise

--- a/lizyml/persistence/loader.py
+++ b/lizyml/persistence/loader.py
@@ -12,6 +12,8 @@ Raises DESERIALIZATION_FAILED when:
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import io
 import json
 from pathlib import Path
 from typing import Any
@@ -21,7 +23,7 @@ import joblib
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.types.fit_result import FitResult
 from lizyml.core.types.target_encoder import TargetEncoder
-from lizyml.persistence.exporter import FORMAT_VERSION
+from lizyml.persistence.exporter import CHECKSUM_ALGORITHM, FORMAT_VERSION
 
 _REQUIRED_METADATA_KEYS = frozenset(
     {"format_version", "task", "feature_names", "config", "run_id"}
@@ -51,6 +53,50 @@ def _migrate_fit_result(fit_result: Any, source_version: int) -> Any:
             fit_result, target_encoder=TargetEncoder.no_op()
         )
     return fit_result
+
+
+def _verify_and_read_pkl(pkl_path: Path, checksums: dict[str, Any] | None) -> bytes:
+    """Read *pkl_path*, verify its digest, and return the bytes (H-0083).
+
+    Reading the bytes once and loading from them (the caller passes the return
+    value to ``joblib.load(io.BytesIO(...))``) closes the TOCTOU window between
+    hashing and deserialization — the file is never re-opened after the check.
+
+    No verification is performed when *checksums* is absent (legacy artifacts
+    exported before H-0083 — back-compatible read) or when the file is not
+    listed. Raises ``DESERIALIZATION_FAILED`` on an unknown algorithm or a
+    digest mismatch, detecting tampering/corruption *before* pickle executes.
+    """
+    raw = pkl_path.read_bytes()
+    if not checksums:
+        return raw
+    expected = checksums.get("files", {}).get(pkl_path.name)
+    if expected is None:
+        return raw
+
+    algorithm = checksums.get("algorithm")
+    if algorithm != CHECKSUM_ALGORITHM:
+        raise LizyMLError(
+            code=ErrorCode.DESERIALIZATION_FAILED,
+            user_message=(
+                f"Unsupported checksum algorithm {algorithm!r} for "
+                f"'{pkl_path.name}'. Expected {CHECKSUM_ALGORITHM!r}."
+            ),
+            context={"file": pkl_path.name, "algorithm": algorithm},
+        )
+
+    actual = hashlib.sha256(raw).hexdigest()
+    if actual != expected:
+        raise LizyMLError(
+            code=ErrorCode.DESERIALIZATION_FAILED,
+            user_message=(
+                f"Integrity check failed for '{pkl_path.name}': the file does "
+                f"not match the SHA-256 recorded in metadata.json. The artifact "
+                f"may be corrupted or tampered with."
+            ),
+            context={"file": pkl_path.name, "expected": expected, "actual": actual},
+        )
+    return raw
 
 
 def load(path: str | Path) -> tuple[Any, Any, dict[str, Any], Any]:
@@ -134,9 +180,15 @@ def load(path: str | Path) -> tuple[Any, Any, dict[str, Any], Any]:
                 context={"path": str(pkl_path)},
             )
 
+    # H-0083: verify payload integrity, then load from the verified bytes (no
+    # second file open) so pickle never executes unverified bytes.
+    checksums = metadata.get("checksums")
+    fit_raw = _verify_and_read_pkl(fit_pkl, checksums)
+    refit_raw = _verify_and_read_pkl(refit_pkl, checksums)
+
     try:
-        fit_result = joblib.load(fit_pkl)
-        refit_result = joblib.load(refit_pkl)
+        fit_result = joblib.load(io.BytesIO(fit_raw))
+        refit_result = joblib.load(io.BytesIO(refit_raw))
     except Exception as exc:
         raise LizyMLError(
             code=ErrorCode.DESERIALIZATION_FAILED,
@@ -153,8 +205,9 @@ def load(path: str | Path) -> tuple[Any, Any, dict[str, Any], Any]:
     analysis_context = None
     ctx_pkl = src / "analysis_context.pkl"
     if ctx_pkl.exists():
+        ctx_raw = _verify_and_read_pkl(ctx_pkl, checksums)
         try:
-            analysis_context = joblib.load(ctx_pkl)
+            analysis_context = joblib.load(io.BytesIO(ctx_raw))
         except Exception as exc:
             raise LizyMLError(
                 code=ErrorCode.DESERIALIZATION_FAILED,

--- a/tests/test_persistence/test_artifact_compat.py
+++ b/tests/test_persistence/test_artifact_compat.py
@@ -122,10 +122,13 @@ class TestFormatVersionV1Migration:
             make_config("regression", n_estimators=5, n_splits=2), df, tmp_path
         )
 
-        # Tamper metadata to claim v1 to simulate an older artifact.
+        # Tamper metadata to claim v1 to simulate an older artifact. Real v1
+        # artifacts predate the H-0083 integrity field, so drop ``checksums``
+        # too (otherwise the re-pickled payload below would mismatch).
         meta_path = export_dir / "metadata.json"
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         meta["format_version"] = 1
+        meta.pop("checksums", None)
         meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
         # Re-pickle the FitResult without target_encoder to mirror v1 layout.
@@ -211,6 +214,13 @@ class TestLegacyCalibrationPath:
         else:
             fit_result.oof_raw_scores = None
         joblib.dump(fit_result, fit_pkl, compress=3)
+
+        # Drop the H-0083 checksum so the re-pickled legacy-shaped payload
+        # loads (a pre-H-0083 artifact carries no integrity field).
+        meta_path = export_dir / "metadata.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta.pop("checksums", None)
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
         m2 = Model.load(export_dir)
         X_test = df.drop(columns=["target"]).iloc[:20]

--- a/tests/test_persistence/test_checksum_integrity.py
+++ b/tests/test_persistence/test_checksum_integrity.py
@@ -1,0 +1,78 @@
+"""Artifact integrity tests — SHA-256 binding between metadata and .pkl (H-0083).
+
+``Model.load`` deserializes ``.pkl`` payloads with joblib (arbitrary-code
+execution). H-0083 records the SHA-256 of each ``.pkl`` in ``metadata.json`` at
+export and verifies it before ``joblib.load`` so tampering/corruption is detected
+(``DESERIALIZATION_FAILED``). Verification is skipped for legacy artifacts that
+predate the ``checksums`` field (back-compatible read, no ``format_version`` bump).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import joblib
+import pytest
+
+from lizyml import Model
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from tests._helpers import make_config, make_regression_df
+
+
+def _export_model(tmp_path: Path) -> Path:
+    m = Model(make_config("regression"))
+    m.fit(data=make_regression_df(n=120))
+    out = tmp_path / "artifact"
+    m.export(out)
+    return out
+
+
+def _read_metadata(out: Path) -> dict:
+    return json.loads((out / "metadata.json").read_text(encoding="utf-8"))
+
+
+def test_export_records_sha256_for_each_pkl(tmp_path: Path) -> None:
+    import hashlib
+
+    out = _export_model(tmp_path)
+    checksums = _read_metadata(out)["checksums"]
+
+    assert checksums["algorithm"] == "sha256"
+    files = checksums["files"]
+    # Required artifacts plus the optional analysis_context written after fit.
+    for name in ("fit_result.pkl", "refit_model.pkl", "analysis_context.pkl"):
+        expected = hashlib.sha256((out / name).read_bytes()).hexdigest()
+        assert files[name] == expected
+
+
+def test_roundtrip_with_checksums_succeeds(tmp_path: Path) -> None:
+    out = _export_model(tmp_path)
+    # Should load without error when digests match.
+    Model.load(out)
+
+
+@pytest.mark.parametrize(
+    "pkl_name", ["fit_result.pkl", "refit_model.pkl", "analysis_context.pkl"]
+)
+def test_tampered_pkl_is_rejected(tmp_path: Path, pkl_name: str) -> None:
+    out = _export_model(tmp_path)
+    # Overwrite with a *valid but different* joblib payload: joblib.load would
+    # succeed, so only the checksum mismatch can catch the swap.
+    joblib.dump({"tampered": True}, out / pkl_name, compress=3)
+
+    with pytest.raises(LizyMLError) as excinfo:
+        Model.load(out)
+    assert excinfo.value.code == ErrorCode.DESERIALIZATION_FAILED
+    assert excinfo.value.context.get("file") == pkl_name
+
+
+def test_legacy_artifact_without_checksums_still_loads(tmp_path: Path) -> None:
+    out = _export_model(tmp_path)
+    metadata = _read_metadata(out)
+    # Simulate an artifact exported before H-0083 (no integrity field).
+    metadata.pop("checksums", None)
+    (out / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    # Back-compatible read: verification is skipped, load still works.
+    Model.load(out)


### PR DESCRIPTION
## Summary
Closes #179 (SECURITY/LOW). `Model.load()` deserializes `.pkl` payloads with `joblib.load` (arbitrary-code execution; trusted-sources-only contract). Pre-load validation covered only `metadata.json`, with no integrity binding between the validated metadata and the `.pkl` bytes — a tampered `.pkl` paired with benign metadata yielded ACE. H-0083 records the SHA-256 of each `.pkl` in `metadata.json` at export and verifies it before deserialization, detecting tampering/corruption.

Per the locked Change-Gate decision (2026-06-01): **additive** `checksums` field, **no `format_version` bump**, back-compatible read of legacy artifacts that lack the field.

## Changes
- `exporter.py`: dump `.pkl` files first, then write `metadata.json` with
  `checksums: {algorithm: "sha256", files: {<name>: <hex>}}` covering
  `fit_result.pkl` / `refit_model.pkl` / `analysis_context.pkl` (when present). New `sha256_file()` helper + `CHECKSUM_ALGORITHM` constant.
- `loader.py`: `_verify_and_read_pkl()` reads each `.pkl` once, verifies the digest, and returns the bytes; `load()` deserializes via `joblib.load(io.BytesIO(...))` so pickle never runs on unverified or re-opened bytes. Mismatch / unknown algorithm → `DESERIALIZATION_FAILED` (context: `file`, `expected`, `actual`). Absent `checksums` → verification skipped (legacy read).

## Security review
Ran the security-reviewer agent: **sound, no blocking issues**. It flagged a TOCTOU window between hashing and `joblib.load` (re-opening the file). **Fixed** by reading bytes once and loading from `io.BytesIO` (no second open). Threat model documented: `metadata.json` is unsigned, so this detects tampering/corruption — it does not make pickle safe against a fully trusted-but-malicious producer (the trusted-source contract stands).

## Skill
`skills/persistence-and-migration`, `skills/history-proposals`, `skills/testing`, security-reviewer.

## Change Gate
Proposal **H-0083** (Accepted) added to `HISTORY.md` before implementation. Persistence format extended additively; `FORMAT_VERSION` stays `2`; new and old artifacts interoperate both directions.

## Tests (`tests/test_persistence/test_checksum_integrity.py`, 6)
- export records the correct SHA-256 for each `.pkl`.
- round-trip with checksums loads cleanly.
- tampering each of the 3 `.pkl`s (valid-but-different joblib payload) → `DESERIALIZATION_FAILED` with `context["file"]`.
- legacy artifact without `checksums` still loads (back-compat).
- Updated two `test_artifact_compat.py` fixtures that re-pickle a `.pkl` to simulate v1/legacy: they now drop the stale `checksums` (a real pre-H-0083 artifact has none) — behavior/assertions unchanged.

## DoD
- [x] HISTORY proposal commit precedes implementation (CLAUDE.md §5.4).
- [x] TDD: RED (4 failing) → GREEN.
- [x] `ruff check .` / `ruff format --check .` / `mypy lizyml/` clean (103 files).
- [x] `pytest -m "not slow"` — 1924 passed, 0 failed.
