### PR TITLE
test: forward-looking test hardening (codegen equivalence, leak trap, bit-equality, ratio guards, README, notebooks) (#178)

### DIFF
--- a/tests/test_codegen/test_predict_subprocess_equivalence.py
+++ b/tests/test_codegen/test_predict_subprocess_equivalence.py
@@ -1,0 +1,102 @@
+"""Real-subprocess equivalence for the generated predict.py (H-0178 item 1).
+
+The existing equivalence suite re-implements the predict logic in-test, so a
+regression in ``lizyml/codegen/templates.py`` would not be caught. These tests
+execute the *generated* ``predict.py`` as a user would (subprocess + file I/O)
+and assert numeric equality against ``Model.predict()``. Inference data is
+written as Parquet so the input reaches the script without CSV precision loss.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from lizyml import Model
+from tests._helpers import (
+    make_binary_df,
+    make_config,
+    make_multiclass_df,
+    make_regression_df,
+)
+
+
+def _predict_via_subprocess(
+    codegen_dir: Path, X: pd.DataFrame, tmp_path: Path
+) -> pd.DataFrame:
+    infer = tmp_path / "infer.parquet"
+    X.to_parquet(infer)
+    out_csv = tmp_path / "preds.csv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(codegen_dir / "predict.py"),
+            str(infer),
+            "-o",
+            str(out_csv),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert out_csv.exists(), result.stderr
+    return pd.read_csv(out_csv)
+
+
+def test_regression_predict_script_matches_model(tmp_path: Path) -> None:
+    df = make_regression_df(n=200)
+    m = Model(make_config("regression", n_estimators=40))
+    m.fit(data=df)
+    X = df.drop(columns=["target"]).iloc[:50].reset_index(drop=True)
+
+    codegen_dir = tmp_path / "codegen"
+    m.export_code(codegen_dir)
+    out = _predict_via_subprocess(codegen_dir, X, tmp_path)
+
+    np.testing.assert_allclose(out["pred"].to_numpy(), m.predict(X).pred, rtol=1e-7)
+
+
+def test_binary_calibrated_predict_script_matches_model(tmp_path: Path) -> None:
+    df = make_binary_df(n=300)
+    m = Model(
+        make_config(
+            "binary",
+            n_estimators=40,
+            split_method="stratified_kfold",
+            calibration="platt",
+        )
+    )
+    m.fit(data=df)
+    X = df.drop(columns=["target"]).iloc[:60].reset_index(drop=True)
+
+    codegen_dir = tmp_path / "codegen"
+    m.export_code(codegen_dir)
+    out = _predict_via_subprocess(codegen_dir, X, tmp_path)
+
+    ref = m.predict(X)
+    np.testing.assert_array_equal(out["pred"].to_numpy(), ref.pred)
+    assert ref.proba is not None
+    np.testing.assert_allclose(out["proba"].to_numpy(), ref.proba, rtol=1e-6)
+
+
+def test_multiclass_predict_script_matches_model(tmp_path: Path) -> None:
+    df = make_multiclass_df(n=300)
+    m = Model(make_config("multiclass", n_estimators=40))
+    m.fit(data=df)
+    X = df.drop(columns=["target"]).iloc[:60].reset_index(drop=True)
+
+    codegen_dir = tmp_path / "codegen"
+    m.export_code(codegen_dir)
+    out = _predict_via_subprocess(codegen_dir, X, tmp_path)
+
+    ref = m.predict(X)
+    np.testing.assert_array_equal(out["pred"].to_numpy(), ref.pred)
+    assert ref.proba is not None
+    proba_cols = [c for c in out.columns if c.startswith("proba_")]
+    assert len(proba_cols) == ref.proba.shape[1]
+    out_proba = out[sorted(proba_cols, key=lambda c: int(c.split("_")[1]))].to_numpy()
+    np.testing.assert_allclose(out_proba, ref.proba, rtol=1e-6)

--- a/tests/test_e2e/test_readme_example.py
+++ b/tests/test_e2e/test_readme_example.py
@@ -1,50 +1,60 @@
 """README example test.
 
-Verifies that the code shown in README.md runs without exceptions.
-The example must work immediately after installation without extra config.
+Executes the actual fenced code blocks from ``README.md`` so that drift between
+the documented Quick Start and the real API is caught. Previously this test
+hardcoded its own copy of the example, so README regressions went undetected
+(H-0178 item 4).
 """
 
 from __future__ import annotations
+
+import re
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from lizyml import Model
 
+_README = Path(__file__).resolve().parents[2] / "README.md"
+_PY_BLOCK = re.compile(r"```python\n(.*?)```", re.DOTALL)
 
-def test_readme_example_runs() -> None:
-    """Minimal Model.fit → evaluate → predict example from README."""
-    rng = np.random.default_rng(42)
-    df = pd.DataFrame(
-        {
-            "feat_a": rng.uniform(0, 10, 200),
-            "feat_b": rng.uniform(-1, 1, 200),
-            "target": rng.uniform(0, 1, 200),
-        }
-    )
 
-    config = {
-        "config_version": 1,
-        "task": "regression",
-        "data": {"target": "target"},
-        "split": {"method": "kfold", "n_splits": 3, "random_state": 42},
-        "model": {"name": "lgbm", "params": {"n_estimators": 20}},
-        "training": {"seed": 0},
-    }
+def _python_blocks() -> list[str]:
+    return _PY_BLOCK.findall(_README.read_text(encoding="utf-8"))
 
-    model = Model(config)
-    result = model.fit(data=df)
-    metrics = model.evaluate()
-    X_new = df.drop(columns=["target"]).iloc[:10].reset_index(drop=True)
-    predictions = model.predict(X_new)
 
-    assert result is not None
-    assert "raw" in metrics
-    assert predictions.pred.shape == (10,)
+def _quick_start_block() -> str:
+    # The Quick Start block is the first python block that trains a Model.
+    for block in _python_blocks():
+        if "model.fit(" in block and "model.evaluate(" in block:
+            return block
+    raise AssertionError("Quick Start block not found in README.md")
+
+
+def _codegen_block() -> str:
+    for block in _python_blocks():
+        if "export_code(" in block:
+            return block
+    raise AssertionError("Codegen block not found in README.md")
+
+
+def test_readme_quick_start_block_executes(monkeypatch, tmp_path: Path) -> None:
+    """The Quick Start snippet must run verbatim from README.md."""
+    # export()/load() in the snippet use relative paths — run in a temp cwd.
+    monkeypatch.chdir(tmp_path)
+    namespace: dict = {}
+    exec(compile(_quick_start_block(), str(_README), "exec"), namespace)
+
+    # The snippet binds ``model`` and ``metrics``; assert the documented shape.
+    assert "raw" in namespace["metrics"]
+    # The same ``model`` powers the codegen one-liner shown later in the README.
+    exec(compile(_codegen_block(), str(_README), "exec"), namespace)
+    assert (tmp_path / "deploy" / "my_model" / "predict.py").exists()
 
 
 def test_binary_readme_example() -> None:
-    """Binary classification minimal example."""
+    """Binary classification minimal smoke example (not sourced from README)."""
     rng = np.random.default_rng(1)
     df = pd.DataFrame(
         {

--- a/tests/test_e2e/test_reproducibility.py
+++ b/tests/test_e2e/test_reproducibility.py
@@ -32,7 +32,10 @@ class TestReproducibility:
         df = _TASK_DATA[task]()
         r1 = Model(make_config(task, n_estimators=20)).fit(data=df)
         r2 = Model(make_config(task, n_estimators=20)).fit(data=df)
-        np.testing.assert_array_almost_equal(r1.oof_pred, r2.oof_pred)
+        # BLUEPRINT promises bit-identical results for the same config + seed
+        # within a fixed (num_threads, CPU) env (H-0081); assert exact equality
+        # so a real reproducibility regression cannot hide under rounding.
+        np.testing.assert_array_equal(r1.oof_pred, r2.oof_pred)
 
     def test_predict_identical(self) -> None:
         df = make_regression_df()
@@ -43,7 +46,7 @@ class TestReproducibility:
         m2.fit(data=df)
         p1 = m1.predict(X_new).pred
         p2 = m2.predict(X_new).pred
-        np.testing.assert_array_almost_equal(p1, p2)
+        np.testing.assert_array_equal(p1, p2)
 
     def test_metrics_reproducible(self) -> None:
         df = make_regression_df()
@@ -54,3 +57,47 @@ class TestReproducibility:
         rmse1 = m1.evaluate()["raw"]["oof"]["rmse"]
         rmse2 = m2.evaluate()["raw"]["oof"]["rmse"]
         assert rmse1 == rmse2
+
+
+class TestSeedSensitivity:
+    """Different ``training.seed`` must change results (decoupling guard).
+
+    The bit-equality tests above both use the default seed, so they cannot
+    detect a regression where ``training.seed`` stops propagating (H-0080).
+    These tests fail if two distinct seeds yield identical OOF — which would
+    mean the seed is silently ignored. ``split.random_state=None`` lets the
+    outer splitter inherit ``training.seed`` (H-0080).
+    """
+
+    @pytest.mark.parametrize("task", ["regression", "binary", "multiclass"])
+    def test_different_seed_changes_oof(self, task: str) -> None:
+        df = _TASK_DATA[task]()
+        cfg_a = make_config(
+            task, n_estimators=20, seed=0, split_overrides={"random_state": None}
+        )
+        cfg_b = make_config(
+            task, n_estimators=20, seed=123, split_overrides={"random_state": None}
+        )
+        r1 = Model(cfg_a).fit(data=df)
+        r2 = Model(cfg_b).fit(data=df)
+        assert not np.array_equal(r1.oof_pred, r2.oof_pred), (
+            "OOF predictions are identical across different training.seed values "
+            "— the seed is not propagating to the outer split (H-0080 regression)."
+        )
+
+    def test_same_seed_is_bit_identical_with_inherited_split(self) -> None:
+        # Sanity counterpart: with split.random_state=None and the same seed,
+        # results stay bit-identical (inheritance is deterministic).
+        df = make_regression_df()
+
+        def _cfg() -> dict:
+            return make_config(
+                "regression",
+                n_estimators=20,
+                seed=7,
+                split_overrides={"random_state": None},
+            )
+
+        r1 = Model(_cfg()).fit(data=df)
+        r2 = Model(_cfg()).fit(data=df)
+        np.testing.assert_array_equal(r1.oof_pred, r2.oof_pred)

--- a/tests/test_notebooks/test_notebook_execution.py
+++ b/tests/test_notebooks/test_notebook_execution.py
@@ -1,7 +1,15 @@
-"""Notebook execution tests — verify notebooks run end-to-end without errors.
+"""Notebook tests.
 
-Uses nbconvert's ExecutePreprocessor to execute each notebook in-process.
-Marked with ``pytest.mark.slow`` so they can be skipped with ``-m "not slow"``.
+Two tiers:
+- A **slow** tier executes every notebook end-to-end via nbconvert (skipped by
+  ``-m "not slow"`` on develop PRs).
+- A **fast** tier (runs on develop PRs) statically validates every notebook —
+  it must parse, contain runnable code, and use LizyML. This catches missing,
+  empty, or unreferenced notebooks without paying the execution cost (H-0178
+  item 6: 3 tutorials were previously referenced by no test).
+
+Notebooks are auto-discovered so a newly added tutorial cannot silently escape
+coverage.
 """
 
 from __future__ import annotations
@@ -17,17 +25,40 @@ nbconvert_pp = pytest.importorskip(
 
 NOTEBOOKS_DIR = Path(__file__).resolve().parents[2] / "notebooks"
 
-_NOTEBOOKS = [
+_ALL_NOTEBOOKS = sorted(p.name for p in NOTEBOOKS_DIR.glob("*.ipynb"))
+
+# Tutorials that must always ship (guards against accidental deletion and
+# pins the three that were previously unreferenced by any test).
+_REQUIRED_NOTEBOOKS = {
     "tutorial_binary_lgbm.ipynb",
     "tutorial_multiclass_lgbm.ipynb",
     "tutorial_regression_lgbm.ipynb",
     "tutorial_regression_tuning_lgbm.ipynb",
     "tutorial_time_series_lgbm.ipynb",
-]
+    "tutorial_calibration.ipynb",
+    "tutorial_codegen_export.ipynb",
+    "tutorial_shap_explanations.ipynb",
+}
+
+
+def test_all_required_notebooks_present() -> None:
+    """Every expected tutorial exists and is discovered (no orphan notebooks)."""
+    missing = _REQUIRED_NOTEBOOKS - set(_ALL_NOTEBOOKS)
+    assert not missing, f"Required notebooks missing: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("notebook_name", _ALL_NOTEBOOKS)
+def test_notebook_is_valid_and_uses_lizyml(notebook_name: str) -> None:
+    """Fast static check: parses, has runnable code, and imports LizyML."""
+    nb = nbformat.read(str(NOTEBOOKS_DIR / notebook_name), as_version=4)
+    code_cells = [c for c in nb.cells if c.cell_type == "code" and c.source.strip()]
+    assert code_cells, f"{notebook_name} has no non-empty code cells"
+    sources = "\n".join(c.source for c in code_cells)
+    assert "lizyml" in sources, f"{notebook_name} does not use lizyml"
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("notebook_name", _NOTEBOOKS)
+@pytest.mark.parametrize("notebook_name", _ALL_NOTEBOOKS)
 def test_notebook_executes(notebook_name: str) -> None:
     """Execute a notebook and assert no CellExecutionError."""
     path = NOTEBOOKS_DIR / notebook_name

--- a/tests/test_training/test_inner_valid_ratio_guards.py
+++ b/tests/test_training/test_inner_valid_ratio_guards.py
@@ -1,0 +1,42 @@
+"""Constructor ratio-guard tests for every inner-valid strategy (H-0178 item 5).
+
+The ``ratio in (0, 1)`` constructor guards are the *only* enforcement point —
+the config-side ratios (``schema.py``) are unbounded floats — yet only
+``HoldoutInnerValid`` was previously covered. A regression weakening any other
+strategy's guard would go unnoticed. This parametrizes the boundary and
+out-of-range ratios across all five guarded strategies.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lizyml.training.inner_valid import (
+    BlockedGroupInnerValid,
+    GroupHoldoutInnerValid,
+    HoldoutInnerValid,
+    StratifiedTimeHoldoutInnerValid,
+    TimeHoldoutInnerValid,
+)
+
+# All strategies accept ``ratio`` as the first positional argument.
+_GUARDED_STRATEGIES = [
+    HoldoutInnerValid,
+    GroupHoldoutInnerValid,
+    TimeHoldoutInnerValid,
+    StratifiedTimeHoldoutInnerValid,
+    BlockedGroupInnerValid,
+]
+
+
+@pytest.mark.parametrize("strategy_cls", _GUARDED_STRATEGIES, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("bad_ratio", [0.0, 1.0, -0.1, 1.5])
+def test_ratio_out_of_open_interval_raises(strategy_cls, bad_ratio: float) -> None:
+    with pytest.raises(ValueError, match=r"ratio must be in \(0, 1\)"):
+        strategy_cls(bad_ratio)
+
+
+@pytest.mark.parametrize("strategy_cls", _GUARDED_STRATEGIES, ids=lambda c: c.__name__)
+def test_in_range_ratio_is_accepted(strategy_cls) -> None:
+    # A valid ratio must not raise (guards reject only out-of-range values).
+    strategy_cls(0.2)

--- a/tests/test_training/test_pipeline_fit_boundary.py
+++ b/tests/test_training/test_pipeline_fit_boundary.py
@@ -1,0 +1,102 @@
+"""Leakage trap: the feature pipeline must be fit on the train fold only.
+
+The existing guard (``test_leakage_all.py``) only asserts ``pipeline_state is
+not None`` — it would still pass if ``pipeline.fit`` were changed to use the
+full dataset. This drives ``CVTrainer`` with a *controlled* split and a
+categorical value that appears **only in the validation fold**. With
+``unseen_policy="error"`` the encoder raises *iff* the pipeline was fit on the
+train rows alone (so the valid-only category is genuinely unseen). A pipeline
+leaking the full data would have learned the category and would NOT raise — so
+this test fails closed on a leakage regression.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lizyml.core.exceptions import ErrorCode, LizyMLError
+from lizyml.core.types.artifacts import RunMeta
+from lizyml.data.fingerprint import compute as fp_compute
+from lizyml.estimators.lgbm import LGBMAdapter
+from lizyml.features.pipelines_native import NativeFeaturePipeline
+from lizyml.splitters.base import BaseSplitter
+from lizyml.training.cv_trainer import CVTrainer
+from lizyml.training.inner_valid import NoInnerValid
+
+
+class _FixedSplitter(BaseSplitter):
+    """Yields a single, caller-controlled ``(train_idx, valid_idx)`` fold."""
+
+    def __init__(self, train_idx: list[int], valid_idx: list[int]) -> None:
+        self._train = np.asarray(train_idx, dtype=np.intp)
+        self._valid = np.asarray(valid_idx, dtype=np.intp)
+
+    def split(self, n_samples, y=None, groups=None):  # type: ignore[override]
+        yield self._train, self._valid
+
+
+def _data_with_rare_category() -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(0)
+    n = 40
+    cat = np.array(["common"] * n, dtype=object)
+    cat[0] = "RARE"  # the single valid-fold-only category
+    cat[1] = "RARE"
+    X = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "cat": cat,
+        }
+    )
+    y = pd.Series(rng.normal(size=n), name="target")
+    return X, y
+
+
+def _run_cv(X: pd.DataFrame, y: pd.Series, splitter: BaseSplitter):
+    trainer = CVTrainer(
+        outer_splitter=splitter,
+        inner_valid=NoInnerValid(),
+        pipeline_factory=lambda: NativeFeaturePipeline(unseen_policy="error"),
+        estimator_factory=lambda: LGBMAdapter(
+            task="regression",
+            params={"n_estimators": 10},
+            random_state=0,
+        ),
+        task="regression",
+    )
+    rm = RunMeta(
+        lizyml_version="0.0.0",
+        python_version="3.11",
+        deps_versions={},
+        config_normalized={},
+        config_version=1,
+        run_id="trap",
+        timestamp="2026-01-01T00:00:00",
+    )
+    return trainer.fit(
+        X, y, data_fingerprint=fp_compute(X, file_path=None), run_meta=rm
+    )
+
+
+def test_valid_only_category_raises_proving_train_only_fit() -> None:
+    X, y = _data_with_rare_category()
+    # RARE rows (0, 1) are in the validation fold, absent from the train fold.
+    splitter = _FixedSplitter(train_idx=list(range(2, 40)), valid_idx=[0, 1])
+
+    with pytest.raises(LizyMLError) as excinfo:
+        _run_cv(X, y, splitter)
+    assert excinfo.value.code == ErrorCode.DATA_SCHEMA_INVALID
+    assert excinfo.value.context.get("column") == "cat"
+
+
+def test_category_present_in_train_does_not_raise() -> None:
+    # Control: the same data, but RARE rows are in the TRAIN fold, so the
+    # validation fold has only known categories — no error, fit completes.
+    X, y = _data_with_rare_category()
+    splitter = _FixedSplitter(
+        train_idx=list(range(0, 30)), valid_idx=list(range(30, 40))
+    )
+
+    result = _run_cv(X, y, splitter)
+    assert result.pipeline_state is not None


### PR DESCRIPTION
## Summary
Closes #178 — a test-hardening epic. Each guard targeted a "forward-looking" gap: the code is currently correct, but the existing test would not fail if the behavior regressed. **Tests only — no Change Gate** (CLAUDE.md §2).

## Items
1. **Codegen `predict.py` real-subprocess numeric equivalence** (`tests/test_codegen/test_predict_subprocess_equivalence.py`, new). Runs the *generated* `predict.py` via `subprocess` and `assert_allclose` vs `Model.predict()` for regression / binary+Platt / multiclass. Inference data is Parquet (no CSV precision loss). Replaces reliance on the in-test re-implementation, which a template regression could slip past.
2. **Feature-pipeline leak trap** (`tests/test_training/test_pipeline_fit_boundary.py`, new). Drives `CVTrainer` with a controlled split and a categorical value present **only in the validation fold** + `unseen_policy="error"`. The encoder raises `DATA_SCHEMA_INVALID` *iff* the pipeline was fit on train rows only — so a leak to full-data fit fails closed. Control test confirms no raise when the category is in the train fold.
3. **Reproducibility bit-equality + seed-sensitivity** (`tests/test_e2e/test_reproducibility.py`). Promoted `assert_array_almost_equal` → `assert_array_equal` (BLUEPRINT promises bit-identical within a fixed env, H-0081); added a `TestSeedSensitivity` class — different `training.seed` with `split.random_state=None` must change OOF (guards H-0080 propagation), and same seed stays bit-identical.
4. **README sample executes the real fenced block** (`tests/test_e2e/test_readme_example.py`). Extracts and `exec`s the actual Quick Start block from `README.md` (in a temp cwd, incl. `export`/`load` and the codegen one-liner), so README drift is caught instead of validating a hardcoded copy.
5. **Inner-valid ratio guards across all 5 strategies** (`tests/test_training/test_inner_valid_ratio_guards.py`, new). Parametrizes `ratio ∈ {0.0, 1.0, -0.1, 1.5}` over `Holdout` / `GroupHoldout` / `TimeHoldout` / `StratifiedTimeHoldout` / `BlockedGroup` — these constructor guards are the only enforcement point (config ratios are unbounded floats); previously only `Holdout` was covered.
6. **Notebook coverage** (`tests/test_notebooks/test_notebook_execution.py`). Auto-discovers all notebooks via glob (no orphan can escape), pins the 8 required tutorials (incl. the 3 previously unreferenced: calibration / codegen_export / shap_explanations), and adds a **fast** (non-slow) static check — parses, has runnable code, uses `lizyml` — that runs on develop PRs; full execution stays `@pytest.mark.slow`.

## Skill
`skills/testing`.

## DoD
- [x] No Change Gate (tests only); no `lizyml/` source change.
- [x] Each new guard fails closed on the regression it targets (verified by control cases / trap design).
- [x] `ruff check .` / `ruff format --check .` / `mypy lizyml/` clean.
- [x] `pytest -m "not slow"` — 1967 passed, 0 failed (8 slow notebook-execution deselected).
