### PR TITLE
refactor(core): extract predict/calibration body out of the facade (#172)

### DIFF
--- a/lizyml/core/_model_predict.py
+++ b/lizyml/core/_model_predict.py
@@ -1,0 +1,92 @@
+"""Prediction + calibration assembly (#172).
+
+Extracted from ``model.py`` so the facade stays assembly-only (CLAUDE.md §3).
+The per-task estimator dispatch, ``CalibrationResult`` handling (with the
+raw-score-vs-probability backward-compat fallback), the ``proba >= 0.5``
+threshold, and SHAP computation all live here — this is the seam where
+god-object pressure would otherwise reconcentrate when a second estimator is
+added. ``Model.predict`` now only resolves state and delegates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from lizyml.core.types.predict_result import PredictionResult
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from lizyml.core.types.fit_result import FitResult
+    from lizyml.core.types.task import TaskType
+    from lizyml.training.refit_trainer import RefitResult
+
+
+def run_predict(
+    *,
+    task: TaskType,
+    fit_result: FitResult,
+    refit_result: RefitResult,
+    provider: Any,
+    X: pd.DataFrame,
+    return_shap: bool,
+) -> PredictionResult:
+    """Generate a :class:`PredictionResult` from the full-data refit model.
+
+    Mirrors the previous inline body of :meth:`Model.predict` exactly — same
+    pipeline restore, per-task branching, calibration, label inverse-mapping
+    (H-0070), and optional SHAP — so the public output is unchanged.
+    """
+    # Restore the fitted pipeline from saved state via the provider.
+    pipeline = provider.build_pipeline_factory()()
+    pipeline.load_state(refit_result.pipeline_state)
+    X_t, warnings = pipeline.transform_with_warnings(X)
+
+    model = refit_result.model
+
+    # H-0070: pred may be int (numeric target) or original-label dtype
+    # (object / string / category) after inverse_transform.
+    pred: npt.NDArray[Any]
+    proba: npt.NDArray[np.float64] | None = None
+
+    if task == "regression":
+        pred = model.predict(X_t)
+    elif task == "binary":
+        proba_2d = model.predict_proba(X_t)
+        proba = proba_2d[:, 1]
+        # Apply C_final calibrator when available (H-0030: raw score input).
+        if fit_result.calibrator is not None:
+            from lizyml.calibration.cross_fit import CalibrationResult
+
+            if isinstance(fit_result.calibrator, CalibrationResult):
+                if fit_result.oof_raw_scores is not None:
+                    raw_scores: npt.NDArray[np.float64] = model.predict_raw(X_t)
+                    proba = fit_result.calibrator.c_final.predict(raw_scores)
+                else:
+                    # Backward compat: old artifact trained on probabilities.
+                    proba = fit_result.calibrator.c_final.predict(proba)
+        pred_codes: npt.NDArray[Any] = (proba >= 0.5).astype(int)
+        # H-0070: inverse-map int codes back to original labels when the
+        # target was non-numeric at fit time.
+        pred = fit_result.target_encoder.inverse_transform(pred_codes)
+    else:  # multiclass
+        proba = model.predict_proba(X_t)
+        pred_codes = proba.argmax(axis=1)
+        pred = fit_result.target_encoder.inverse_transform(pred_codes)
+
+    shap_values: npt.NDArray[np.float64] | None = None
+    if return_shap:
+        from lizyml.explain.shap_explainer import compute_shap_values
+
+        shap_values = compute_shap_values(refit_result.model, X_t, task)
+
+    return PredictionResult(
+        pred=pred,
+        proba=proba,
+        shap_values=shap_values,
+        used_features=refit_result.feature_names,
+        warnings=warnings,
+    )

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -57,6 +57,7 @@ from lizyml.core._model_factories import (
 from lizyml.core._model_metrics import assemble_calibrated_metrics, filter_metrics
 from lizyml.core._model_persistence import ModelPersistenceMixin
 from lizyml.core._model_plots import ModelPlotsMixin
+from lizyml.core._model_predict import run_predict
 from lizyml.core._model_tables import ModelTablesMixin
 from lizyml.core.exceptions import ErrorCode, LizyMLError
 from lizyml.core.logging import generate_run_id, get_logger
@@ -346,59 +347,17 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
         """
         fit = self._require_fit()
         refit = self._require_refit()
-
-        # Restore pipeline from saved state via provider
         provider = get_provider(self._cfg.model)
-        pipeline = provider.build_pipeline_factory()()
-        pipeline.load_state(refit.pipeline_state)
 
-        X_t, warnings = pipeline.transform_with_warnings(X)
-
-        model = refit.model
-        task = self._cfg.task
-
-        # H-0070: pred may be int (numeric target) or original-label dtype
-        # (object / string / category) after inverse_transform.
-        pred: npt.NDArray[Any]
-        proba: npt.NDArray[np.float64] | None = None
-
-        if task == "regression":
-            pred = model.predict(X_t)
-        elif task == "binary":
-            proba_2d = model.predict_proba(X_t)
-            proba = proba_2d[:, 1]
-            # Apply C_final calibrator when available (H-0030: raw score input)
-            if fit.calibrator is not None:
-                from lizyml.calibration.cross_fit import CalibrationResult
-
-                if isinstance(fit.calibrator, CalibrationResult):
-                    if fit.oof_raw_scores is not None:
-                        raw_scores: npt.NDArray[np.float64] = model.predict_raw(X_t)
-                        proba = fit.calibrator.c_final.predict(raw_scores)
-                    else:
-                        # Backward compat: old artifact trained on probabilities
-                        proba = fit.calibrator.c_final.predict(proba)
-            pred_codes: npt.NDArray[Any] = (proba >= 0.5).astype(int)
-            # H-0070: inverse-map int codes back to original labels when
-            # the target was non-numeric at fit time.
-            pred = fit.target_encoder.inverse_transform(pred_codes)
-        else:  # multiclass
-            proba = model.predict_proba(X_t)
-            pred_codes = proba.argmax(axis=1)
-            pred = fit.target_encoder.inverse_transform(pred_codes)
-
-        shap_values: npt.NDArray[np.float64] | None = None
-        if return_shap:
-            from lizyml.explain.shap_explainer import compute_shap_values
-
-            shap_values = compute_shap_values(refit.model, X_t, task)
-
-        return PredictionResult(
-            pred=pred,
-            proba=proba,
-            shap_values=shap_values,
-            used_features=refit.feature_names,
-            warnings=warnings,
+        # Estimator/calibration/SHAP branching lives behind this seam (#172);
+        # the facade only resolves state and delegates.
+        return run_predict(
+            task=self._cfg.task,
+            fit_result=fit,
+            refit_result=refit,
+            provider=provider,
+            X=X,
+            return_shap=return_shap,
         )
 
     def tune(


### PR DESCRIPTION
## Summary
Closes #172. `Model.fit()` / `Model.tune()` were clean branch-free delegations, but `Model.predict()` still held estimator/calibration-specific branching inline (per-task dispatch, `isinstance(calibrator, CalibrationResult)` + lazy import, raw-score-vs-proba backward-compat fallback, the `proba >= 0.5` threshold, SHAP). That is the SoC seam where god-object pressure reconcentrates when a second estimator is added, and the main remaining violation of CLAUDE.md §3 ("facade = assembly only").

**Pure refactor — no contract change, no Change Gate** (as scoped in the issue).

## Changes
- New `lizyml/core/_model_predict.py` with `run_predict(*, task, fit_result, refit_result, provider, X, return_shap) -> PredictionResult`, mirroring the previous inline body exactly (pipeline restore → per-task branching → calibration → label inverse-map (H-0070) → optional SHAP). Follows the `_model_metrics.py` extraction precedent.
- `Model.predict()` now only resolves state (`_require_fit` / `_require_refit` / `get_provider`) and delegates. The `provider.predict_with_calibration(...)` alternative was rejected because it would change the `EstimatorProvider` protocol (a Change Gate); the module extraction keeps the contract fixed.

## Invariants (refactor equivalence)
- INV-1: `Model.predict()` output (`pred` / `proba` / `shap_values` / `used_features` / `warnings`) is byte-identical before/after, for regression, binary (+Platt/Isotonic/Beta calibration, incl. the legacy probability fallback), and multiclass.
- INV-2: no behavior change to calibration, label inverse-mapping, or SHAP.

## Verification / E2E gate (development-workflow §3.5)
- `pytest -m "not slow"` — **1967 passed, 0 failed** (identical to pre-refactor).
- E2E gate: `tests/test_e2e/` + `tests/test_codegen/` — **342 passed**, including the codegen real-subprocess equivalence (#178) that runs the generated `predict.py` and `assert_allclose`s vs `Model.predict()` across all three tasks — a strong end-to-end equivalence guard for this seam.
- `ruff check .` / `ruff format --check .` / `mypy lizyml/` clean (104 files).

## Skill
`skills/add-estimator-adapter` (provider seam), `skills/explain` (SHAP path).

## DoD
- [x] Facade is assembly-only for `predict()` now (CLAUDE.md §3).
- [x] No contract / public-API / protocol change; no Change Gate.
- [x] E2E gate green (structural refactor crossing a module boundary).
