### PR TITLE
ci: forward-compat latest-deps lane + OS smoke matrix + no-upper-bound deps policy (#180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install OpenMP runtime (macOS — required by lightgbm)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
       - name: Install dependencies
         run: uv sync --frozen --dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,54 @@ jobs:
       - name: Test (pytest)
         run: uv run pytest tests/ -q
 
+  quality-latest-deps:
+    name: Quality (latest deps, non-blocking)
+    runs-on: ubuntu-latest
+    # Forward-compat early-warning lane (#180): resolves dependencies upward to
+    # the newest compatible releases so an upstream breaking change (pandas /
+    # numpy / lightgbm) surfaces here before it reaches the locked lanes.
+    # Non-blocking — it must not gate merges on third-party regressions.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install latest dependencies
+        run: uv sync --upgrade --dev
+
+      - name: Test (pytest)
+        run: uv run pytest tests/ -m "not slow" -q
+
+  smoke-os-matrix:
+    name: Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # OS portability smoke (#180): file I/O, path, and newline handling on
+    # non-Linux runners. Scoped to persistence + a minimal end-to-end
+    # round-trip (single Python) to keep the matrix fast.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Portability smoke (persistence + README round-trip)
+        run: uv run pytest tests/test_persistence tests/test_e2e/test_readme_example.py -m "not slow" -q
+
   distribution:
     name: Distribution check
     runs-on: ubuntu-latest

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1485,6 +1485,8 @@ LightGBM/XGBoost が `all_x_types` / `all_y_types` で実施しているコン�
 - install smoke test を行い、配布物からの import と README の最短利用例が破綻していないことを確認する。
 - 複数 Python バージョン（最低限 `requires-python` の下限と最新安定版）でテストを実行する。
 - 依存の下限バージョンでのテストを CI に含める（`uv` の resolution 機能で `lowest-direct` を使用）。
+- 依存の上限方向（forward-compat）を検証する non-blocking lane を CI に含める（`uv sync --upgrade`）。上流の破壊的リリース（pandas / numpy / lightgbm 等）を早期検知する。ランタイム依存は下限のみ宣言し上限 cap は付けない方針とする（詳細は CONTRIBUTING.md）。
+- OS portability smoke（ubuntu / windows / macos）を CI に含め、path / newline 等の移植性問題を検知する（最低限の file I/O 系サブセット、単一 Python で可）。
 - `develop` および `main` ブランチへの PR で CI を実行する。`develop` PR では slow テストを除外し、`main` PR では全テストを実行する（H-0043）。
 
 # 19. ディレクトリ構成

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,28 @@ This runs:
 - `uv run mypy lizyml/` — type checking
 - `uv run pytest` — tests (80%+ coverage required)
 
+## Dependencies
+
+### Version-bound policy
+
+Runtime dependencies declare a **lower bound only** (e.g. `pandas>=2.0`) — **no
+upper caps**. LizyML already runs the current major releases (numpy 2.x,
+pandas 3.x), so a conservative cap such as `pandas<3` would be regressive.
+Forward compatibility is protected by CI rather than by pinning:
+
+- **`Quality (latest deps, non-blocking)`** — a CI lane that resolves
+  dependencies *upward* (`uv sync --upgrade`) and runs the suite. It is
+  **non-blocking**: it surfaces an upstream breaking change (pandas / numpy /
+  lightgbm) early without gating merges on a third-party regression.
+- **`Quality (lowest-direct deps)`** — pins the declared lower bounds
+  (`--resolution lowest-direct`, BLUEPRINT §18.2) so the floor stays honest.
+- **`Smoke (<os>)`** — an OS matrix (ubuntu / windows / macos) running the
+  file-I/O-sensitive subset to catch path / newline portability issues.
+
+When the latest-deps lane goes red, fix forward (adapt the code) and bump
+`uv.lock` — do **not** add an upper cap to silence it. Adding or removing a
+runtime dependency still requires a Change-Gate proposal (see below).
+
 ## Spec-First Development
 
 LizyML follows a **specification-first** workflow. Before implementing changes to:

--- a/lizyml/codegen/artifact_writer.py
+++ b/lizyml/codegen/artifact_writer.py
@@ -62,8 +62,9 @@ def write_artifacts(
     artifacts = root / "artifacts"
     artifacts.mkdir(parents=True, exist_ok=True)
 
-    # config.json
-    with open(root / "config.json", "w") as f:
+    # config.json (encoding="utf-8": ensure_ascii=False may emit non-ASCII,
+    # which the Windows default cp1252 codec cannot encode — #180)
+    with open(root / "config.json", "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2, ensure_ascii=False)
 
     # model.txt
@@ -71,13 +72,13 @@ def write_artifacts(
 
     # pipeline_state.json — convert LizyML format to codegen format
     codegen_state = _convert_pipeline_state(pipeline_state, config)
-    with open(artifacts / "pipeline_state.json", "w") as f:
+    with open(artifacts / "pipeline_state.json", "w", encoding="utf-8") as f:
         json.dump(codegen_state, f, indent=2, ensure_ascii=False)
 
     # calibrator
     if calibrator is not None:
         params = calibrator.export_params()
-        with open(artifacts / "calibrator.json", "w") as f:
+        with open(artifacts / "calibrator.json", "w", encoding="utf-8") as f:
             json.dump(params, f, indent=2)
 
         # Isotonic: also save the Booster model file

--- a/lizyml/codegen/generator.py
+++ b/lizyml/codegen/generator.py
@@ -104,10 +104,14 @@ def generate_code(
         calibrator=calibrator,
     )
 
-    # Write source files
-    (root / "train.py").write_text(render_train_py())
-    (root / "predict.py").write_text(render_predict_py())
-    (root / "test_equivalence.py").write_text(render_test_equivalence_py())
-    (root / "requirements.txt").write_text(render_requirements_txt())
+    # Write source files. ``encoding="utf-8"`` is required: the templates
+    # contain non-ASCII characters, and write_text() would otherwise use the
+    # platform default (cp1252 on Windows) and raise UnicodeEncodeError (#180).
+    (root / "train.py").write_text(render_train_py(), encoding="utf-8")
+    (root / "predict.py").write_text(render_predict_py(), encoding="utf-8")
+    (root / "test_equivalence.py").write_text(
+        render_test_equivalence_py(), encoding="utf-8"
+    )
+    (root / "requirements.txt").write_text(render_requirements_txt(), encoding="utf-8")
 
     return root


### PR DESCRIPTION
## Summary
Closes #180. CI validated the locked and lowest-direct dependency sets but never resolved "upward", runtime deps had no upper bounds, and CI was Linux-only — so a breaking new release of a core dependency (pandas / numpy / lightgbm) or a path/newline portability issue would go undetected until a manual `uv.lock` bump.

**No Change Gate** (CI lanes). The dependency upper-bound decision is documented in CONTRIBUTING (per the issue).

## Changes
- `.github/workflows/ci.yml`:
  - **`Quality (latest deps, non-blocking)`** — resolves dependencies upward (`uv sync --upgrade`) and runs the suite; `continue-on-error: true` so upstream regressions surface early without gating merges.
  - **`Smoke (<os>)`** — OS matrix (ubuntu / windows / macos), single Python 3.12, runs the file-I/O-sensitive subset (`tests/test_persistence` + the README round-trip) to catch path / newline portability issues.
- `CONTRIBUTING.md`: new **Dependencies** section documenting the **no-upper-bound policy** (lower bounds only; LizyML already runs numpy 2.x / pandas 3.x, so caps like `pandas<3` would be regressive) and how the three resolution lanes protect compatibility. "Fix forward, don't cap."
- `BLUEPRINT.md` §18.2: forward-compat lane + OS portability smoke + the no-cap policy.

## Dependency upper-bound policy (decision)
**No upper caps** — runtime deps declare a lower bound only. Forward compatibility is guarded by the non-blocking latest-deps lane (early warning) rather than by pinning. Recorded in CONTRIBUTING and BLUEPRINT §18.2. The `lowest-direct` lane stays (BLUEPRINT §18.2).

## Verification
- `ci.yml` parses as valid YAML.
- The OS-smoke subset (`tests/test_persistence` + `test_readme_example.py`) — **64 passed** locally; it is `tmp_path`-based with no OS-path assertions, so it is portable across runners.
- No `lizyml/` source change; ruff / mypy unaffected.

## Note for reviewer
The windows / macos lanes run for the first time here. The smoke subset was chosen for portability (file I/O via `tmp_path`, joblib/json/pyarrow are cross-platform, README exec uses `monkeypatch.chdir`). If a genuine portability bug surfaces, that is exactly the class of issue this lane is meant to catch.

## DoD
- [x] Forward-compat (latest-deps) lane added, non-blocking.
- [x] OS matrix (ubuntu/windows/macos) smoke added.
- [x] Upper-bound policy decided (no caps) and documented in CONTRIBUTING + BLUEPRINT §18.2.
