### PR TITLE
ci: enable branch coverage and re-baseline cov-fail-under to 96 (#173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,15 @@ jobs:
         run: uv run mypy lizyml/
 
       - name: Test (pytest)
+        # cov-fail-under=96 is branch-inclusive (branch=true, #173): the
+        # not-slow develop lane measures ~97% with branches counted, so 96 is a
+        # realistic floor with a 1-point buffer. The main lane (full suite)
+        # measures higher, so the same floor holds there.
         run: |
           if [ "${{ github.base_ref }}" = "main" ]; then
-            uv run pytest tests/ -m "" --cov=lizyml --cov-report=term-missing --cov-fail-under=95 -q
+            uv run pytest tests/ -m "" --cov=lizyml --cov-report=term-missing --cov-fail-under=96 -q
           else
-            uv run pytest tests/ -m "not slow" --cov=lizyml --cov-report=term-missing --cov-fail-under=95 -q
+            uv run pytest tests/ -m "not slow" --cov=lizyml --cov-report=term-missing --cov-fail-under=96 -q
           fi
 
   quality-lowest-deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ ignore_missing_imports = true
 [tool.coverage.run]
 source = ["lizyml"]
 omit = ["lizyml/_version.py"]
+branch = true
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]


### PR DESCRIPTION
## Summary
Closes #173. Coverage was line-only (98%). Leak-critical and reproducibility-critical logic is branch-shaped (ndim dispatch, stratify/group-count fallbacks), so a one-sided branch could read as "covered" by line while its other arm was untested — the headline number slightly overstated real path coverage for exactly the dimensions the project prioritizes.

**Tooling only — no Change Gate.**

## Changes
- `pyproject.toml`: `[tool.coverage.run]` → `branch = true`.
- `.github/workflows/ci.yml`: `--cov-fail-under` re-baselined `95 → 96` on both lanes, now branch-inclusive.

## Re-baseline rationale
With `branch = true`, the **not-slow develop lane** (the binding constraint) measures **97.34%** branch-inclusive (was 98% line-only). The floor is set to **96** — a realistic, branch-inclusive number with a ~1.3-point buffer to avoid flakiness. The `main` lane (full suite) measures higher, so the same floor holds there.

## Verification
- `pytest -m "not slow" --cov=lizyml --cov-fail-under=96` → **"Required test coverage of 96% reached. Total coverage: 97.34%"**, exit 0, 1967 passed.

## DoD
- [x] `branch = true` enabled.
- [x] `--cov-fail-under` re-baselined to a realistic branch-inclusive value (96).
- [x] Both CI lanes pass at the new floor.
