### PR TITLE
chore(release): prepare v0.16.1 (#192)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -75,7 +75,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -100,7 +100,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.16.1] - 2026-06-30
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
Release-prep for **v0.16.1** (patch). Promotes the `[Unreleased]` CHANGELOG section — the #192 codegen UTF-8 fix — to `[0.16.1]`, and syncs `actions/checkout@v6 -> v7` across the CI/release workflows so develop matches main (#199 landed directly on main via dependabot). Restoring workflow parity lets the upcoming develop->main merge commit fully connect the histories.

## Changes
- `CHANGELOG.md`: `[Unreleased]` -> `[0.16.1] - 2026-06-30`.
- `.github/workflows/{ci,auto-release,release}.yml`: `actions/checkout@v6` -> `@v7` (7 occurrences), matching main.

## Relevant SKILL
skills/release, skills/version-tagging

## Change Gate
Not required — release bookkeeping (CHANGELOG) + CI action version sync. No public-API / Config / FitResult / Artifacts / format change. Version is derived from the git tag (hatch-vcs); no source bump needed.

## DoD
- [x] CHANGELOG section header matches auto-release extraction (`## [0.16.1]`)
- [x] Workflow checkout pins match main (develop<->main parity)
- [x] No code change (full suite already green on develop: 1969 passed)

After this merges (squash) into develop, the release proceeds via a develop->main PR titled `release: v0.16.1` (merge commit), which triggers auto-release (tag + GitHub Release + PyPI publish).