### PR TITLE
release: v0.16.1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -75,7 +75,7 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -100,7 +100,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Generated `train.py` / `predict.py` / `test_equivalence.py` open JSON artifacts as UTF-8** ([#192](https://github.com/nbx-liz/LizyML/issues/192)) — every `open()` in the exported scripts now pins `encoding="utf-8"`. A Windows (`cp1252`) or `C`-locale end-user running the generated scripts over data with a non-ASCII categorical value previously hit a `UnicodeEncodeError` / `UnicodeDecodeError` when writing/reading `pipeline_state.json`. (Completes [#180](https://github.com/nbx-liz/LizyML/issues/180), which fixed only the LizyML-side codegen writes.)
+
 ## [0.16.0] - 2026-06-01
 
 Quality-audit remediation release: resolves the v0.15.0 comprehensive audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.16.1] - 2026-06-30
 
 ### Fixed
 

--- a/lizyml/codegen/templates.py
+++ b/lizyml/codegen/templates.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 ROOT = Path(__file__).parent
 ARTIFACTS = ROOT / "artifacts"
 
-with open(ROOT / "config.json") as _f:
+with open(ROOT / "config.json", encoding="utf-8") as _f:
     CFG = json.load(_f)
 
 
@@ -68,7 +68,7 @@ def fit_pipeline(df: pd.DataFrame) -> dict:
         "category_mappings": mappings,
     }
     ARTIFACTS.mkdir(parents=True, exist_ok=True)
-    with open(ARTIFACTS / "pipeline_state.json", "w") as f:
+    with open(ARTIFACTS / "pipeline_state.json", "w", encoding="utf-8") as f:
         json.dump(state, f, indent=2, ensure_ascii=False)
     return state
 
@@ -369,7 +369,7 @@ def fit_calibrator(X: np.ndarray, y: np.ndarray) -> dict | None:
             f"Supported: {list(_CAL_FITTERS)}"
         )
     params = _CAL_FITTERS[method](oof, y)
-    with open(ARTIFACTS / "calibrator.json", "w") as f:
+    with open(ARTIFACTS / "calibrator.json", "w", encoding="utf-8") as f:
         json.dump(params, f, indent=2)
     log.info("    saved calibrator.json")
     return params
@@ -467,7 +467,7 @@ log = logging.getLogger(__name__)
 ROOT = Path(__file__).parent
 ARTIFACTS = ROOT / "artifacts"
 
-with open(ROOT / "config.json") as _f:
+with open(ROOT / "config.json", encoding="utf-8") as _f:
     CFG = json.load(_f)
 
 
@@ -479,7 +479,7 @@ def _load_pipeline() -> dict:
     path = ARTIFACTS / "pipeline_state.json"
     if not path.exists():
         raise FileNotFoundError(f"{path} not found. Run train.py first.")
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -518,7 +518,7 @@ def _load_calibrator() -> dict | None:
     path = ARTIFACTS / "calibrator.json"
     if not path.exists():
         return None
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -641,7 +641,7 @@ log = logging.getLogger(__name__)
 ROOT = Path(__file__).parent
 ARTIFACTS = ROOT / "artifacts"
 
-with open(ROOT / "config.json") as _f:
+with open(ROOT / "config.json", encoding="utf-8") as _f:
     CFG = json.load(_f)
 
 
@@ -653,7 +653,7 @@ def _load_pipeline() -> dict:
     path = ARTIFACTS / "pipeline_state.json"
     if not path.exists():
         raise FileNotFoundError(f"{path} not found. Run train.py first.")
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -685,7 +685,7 @@ def _predict(df: pd.DataFrame) -> dict[str, np.ndarray | None]:
     if task == "binary":
         cal_path = ARTIFACTS / "calibrator.json"
         if cal_path.exists():
-            with open(cal_path) as f:
+            with open(cal_path, encoding="utf-8") as f:
                 cal = json.load(f)
             logits = np.asarray(booster.predict(X, raw_score=True), dtype=np.float64)
             m = cal["method"]

--- a/tests/test_codegen/test_nonascii_locale_portability.py
+++ b/tests/test_codegen/test_nonascii_locale_portability.py
@@ -1,0 +1,150 @@
+"""Non-ASCII portability regression for the generated scripts (#192).
+
+The generated ``train.py`` / ``predict.py`` / ``test_equivalence.py`` open the
+JSON artifacts (``config.json``, ``pipeline_state.json``, ``calibrator.json``)
+with ``open()``. If the encoding is not pinned, the default text encoding comes
+from the process locale -- ``cp1252`` on Windows, ``ascii`` under a ``C`` locale.
+A category value that contains non-ASCII characters is then written/read as
+raw UTF-8 by ``json`` (``ensure_ascii=False``), which raises
+``UnicodeEncodeError`` / ``UnicodeDecodeError`` under such a locale.
+
+These tests run the *generated* scripts as a subprocess with the default text
+encoding forced to ASCII (``PYTHONUTF8=0`` + ``LC_ALL=C``) over data carrying a
+non-ASCII categorical value, and assert they round-trip. They fail against the
+pre-fix templates (default ``open()``) and pass once every ``open()`` pins
+``encoding="utf-8"``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from lizyml import Model
+from tests._helpers import make_config
+
+# Default text encoding forced to ASCII to emulate a non-UTF-8 locale
+# (Windows cp1252 / POSIX C). PYTHONUTF8=0 disables the 3.15+ UTF-8 mode so the
+# locale actually governs open()'s default encoding; PYTHONIOENCODING keeps
+# stdio on utf-8 so only the file-open paths under test can fail.
+_ASCII_LOCALE_ENV = {
+    **os.environ,
+    "PYTHONUTF8": "0",
+    "PYTHONIOENCODING": "utf-8",
+    "LC_ALL": "C",
+    "LANG": "C",
+}
+
+# Non-ASCII categorical values spanning Latin-1 and CJK code points.
+_NON_ASCII_CATS = ["café", "naïve", "日本語", "Über"]
+
+
+def _make_non_ascii_binary_df(n: int = 200, seed: int = 1) -> pd.DataFrame:
+    """Binary DataFrame with a categorical column of non-ASCII values."""
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame({"feat_a": rng.uniform(0, 10, n)})
+    df["feat_cat"] = rng.choice(_NON_ASCII_CATS, n)
+    df["target"] = (df["feat_a"] > 5).astype(int)
+    return df
+
+
+def _export_codegen(tmp_path: Path) -> tuple[Path, pd.DataFrame]:
+    """Fit a calibrated binary model on non-ASCII data and export the scripts."""
+    df = _make_non_ascii_binary_df()
+    m = Model(
+        make_config(
+            "binary",
+            n_estimators=20,
+            split_method="stratified_kfold",
+            calibration="platt",
+        )
+    )
+    m.fit(data=df)
+    codegen_dir = tmp_path / "codegen"
+    m.export_code(codegen_dir)
+    return codegen_dir, df
+
+
+def test_train_script_round_trips_non_ascii_under_ascii_locale(
+    tmp_path: Path,
+) -> None:
+    """train.py reads config.json and writes the JSON artifacts as UTF-8.
+
+    Exercises the write paths (pipeline_state.json with ensure_ascii=False,
+    calibrator.json) and the config.json read path. Pre-fix this raised
+    UnicodeEncodeError when dumping the non-ASCII category mappings.
+    """
+    codegen_dir, df = _export_codegen(tmp_path)
+    train_data = codegen_dir / "train.parquet"
+    df.to_parquet(train_data)
+
+    # Remove the LizyML-written artifacts so train.py must regenerate them
+    # itself under the ASCII locale.
+    for art in (codegen_dir / "artifacts").glob("*"):
+        art.unlink()
+
+    result = subprocess.run(
+        [sys.executable, "train.py", "train.parquet"],
+        cwd=codegen_dir,
+        env=_ASCII_LOCALE_ENV,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    state_path = codegen_dir / "artifacts" / "pipeline_state.json"
+    raw = state_path.read_bytes()
+    assert any(b > 127 for b in raw), "expected non-ASCII bytes in pipeline_state"
+    mappings = json.loads(raw.decode("utf-8"))["category_mappings"]["feat_cat"]
+    assert set(mappings) == set(_NON_ASCII_CATS)
+    assert (codegen_dir / "artifacts" / "calibrator.json").exists()
+
+
+def test_predict_script_reads_non_ascii_artifacts_under_ascii_locale(
+    tmp_path: Path,
+) -> None:
+    """predict.py reads config.json / pipeline_state.json / calibrator.json.
+
+    Runs the full train.py -> predict.py flow a user would (so the model and
+    artifacts are consistent), both under the ASCII locale. The artifacts carry
+    non-ASCII category keys; pre-fix the default open() raised
+    UnicodeDecodeError when predict.py loaded pipeline_state.json.
+    """
+    codegen_dir, df = _export_codegen(tmp_path)
+    train_data = codegen_dir / "train.parquet"
+    df.to_parquet(train_data)
+    infer_data = codegen_dir / "infer.parquet"
+    df.drop(columns=["target"]).to_parquet(infer_data)
+
+    # Regenerate artifacts via the generated train.py so the categorical
+    # signature matches what predict.py reconstructs (decoupled from the
+    # LizyML-trained model.txt's categorical-feature predict semantics).
+    for art in (codegen_dir / "artifacts").glob("*"):
+        art.unlink()
+    train = subprocess.run(
+        [sys.executable, "train.py", "train.parquet"],
+        cwd=codegen_dir,
+        env=_ASCII_LOCALE_ENV,
+        capture_output=True,
+        text=True,
+    )
+    assert train.returncode == 0, train.stderr
+
+    result = subprocess.run(
+        [sys.executable, "predict.py", "infer.parquet", "-o", "preds.csv"],
+        cwd=codegen_dir,
+        env=_ASCII_LOCALE_ENV,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    preds = pd.read_csv(codegen_dir / "preds.csv")
+    assert len(preds) == len(df)
+    assert "pred" in preds.columns


### PR DESCRIPTION
## Release v0.16.1

Patch release. Single user-facing change since v0.16.0.

### Fixed
- **Generated `train.py` / `predict.py` / `test_equivalence.py` open JSON artifacts as UTF-8** (#192) — every `open()` in the exported scripts now pins `encoding="utf-8"`. A Windows (`cp1252`) or `C`-locale end-user running the generated scripts over data with a non-ASCII categorical value previously hit `UnicodeEncodeError` / `UnicodeDecodeError` when writing/reading `pipeline_state.json`. Completes #180.

### Internal
- Synced `actions/checkout@v6 -> v7` across CI/release workflows (#199 / #201) to restore develop<->main parity.

## Merge instruction
**Create a merge commit** (NOT squash) — connects develop and main histories; auto-release tags `v0.16.1` + GitHub Release, then triggers PyPI publish.

## Verification
- Full suite green on develop (1969 passed).
- All blocking CI checks passed on #200 and #201 (non-blocking latest-deps lane fails on upstream `uv sync --upgrade`, by design).
- CHANGELOG `## [0.16.1]` header matches auto-release note extraction.