### PR TITLE
ci: floor numba to stop the latest-deps lane backtracking to unbuildable llvmlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,15 @@ dev = [
     "vulture>=2.15",
 ]
 
+[tool.uv]
+# Forward-compat lane guard (#180 lane): `uv sync --upgrade` prefers the newest
+# numpy, which no modern numba supports yet, so the resolver backtracks numba to
+# an ancient, uncapped release (0.53.x) that drags in llvmlite 0.36.0 — a version
+# with no Python 3.12 wheel that fails to build. Flooring numba keeps the
+# numba/llvmlite/numpy chain modern so the lane surfaces real upstream breakage
+# instead of resolver-backtracking noise. numba (via shap) is transitive-only.
+constraint-dependencies = ["numba>=0.60"]
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+constraints = [{ name = "numba", specifier = ">=0.60" }]
+
 [[package]]
 name = "alembic"
 version = "1.18.4"


### PR DESCRIPTION
## Problem

The non-blocking `Quality (latest deps)` lane (`uv sync --upgrade --dev`, Python 3.12) fails at the install step. Root cause: the resolver prefers the newest numpy (2.5.0), which no modern numba supports, so it backtracks numba to an ancient uncapped `0.53.1` that pulls in `llvmlite==0.36.0` — a version with no Python 3.12 wheel that fails to build.

## Fix

Add `[tool.uv] constraint-dependencies = ["numba>=0.60"]`. numba is transitive-only (via `shap`). With the floor, the upgrade resolution becomes `llvmlite 0.48.0` / `numba 0.66.0` / `numpy 2.4.6` / `shap 0.52.0` — all with Python 3.12 wheels.

## Impact

- Locked lanes unchanged: `uv.lock` still resolves `numba 0.64.0` / `llvmlite 0.46.0`; `uv lock --check` passes.
- No source code change.
- Not a Change Gate item: this floors an existing transitive dependency's minimum version; it does not add or remove a dependency.

## Verification

- `uv pip compile --group dev --upgrade` now resolves `llvmlite==0.48.0`.
- `uv lock --check` green.
- `ruff check` / `ruff format --check` green.

## Relevant SKILL

`skills/dev-environment/SKILL.md`

## Test plan

- [x] `uv lock --check` passes (locked resolution unchanged)
- [x] `ruff check .` / `ruff format --check .` pass
- [ ] CI: confirm the `Quality (latest deps, non-blocking)` lane now succeeds on this PR
