### PR TITLE
fix(training): unify RefitTrainer pipeline fit boundary to full data (H-0085, #208)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -626,9 +626,10 @@ LizyML 非依存の学習・推論コードを自動生成する。
 - `FeaturePipeline.fit` は outer fold の `train` 全体に対して行う。inner valid は estimator の early stopping 用 evaluation set であり、FeaturePipeline の fit 境界は outer train のままとする。
 - estimator は inner valid が有効な場合 `inner_train` のみで学習し、`inner_valid` を eval set として early stopping を行う。OOF の割当先は引き続き outer fold の `valid` のみとする。
 - `RefitTrainer` でも同じ `InnerValidStrategy` を全データに適用して final model の early stopping 用 split を作る。
-  - inner valid がある場合、pipeline は **inner-train のみ**で fit する（CVTrainer と一致する leakage 境界）。estimator は inner-train で学習、inner-valid で early stopping。
-  - 最終的な `pipeline_state`（推論用）は、別途全データで fit した pipeline から取得する。`categorical_features` も全データ fit 由来の pipeline から取得する。
-  - inner valid が無い場合（`NoInnerValid`）は、pipeline は全データで 1 回のみ fit する（二重 fit を回避）。
+  - **pipeline は全データで 1 回のみ fit する**（H-0085）。CVTrainer が outer fold の `train` 全体で pipeline を fit するのと同じ境界であり、Refit における「outer train 全体」は全データに相当する。inner-train には狭めない。
+  - estimator は inner valid がある場合、変換後データから slice した `inner_train` で学習し、`inner_valid` を eval set として early stopping を行う。
+  - 最終的な `pipeline_state`（推論用）および `categorical_features` は、この全データ fit 済み pipeline から取得する（二重 fit は行わない）。
+  - inner valid が無い場合（`NoInnerValid`）も、pipeline は全データで 1 回 fit し、estimator を全データで学習する。
   - `time_series` / `purged_time_series` / `group_time_series` では、`Model._prepare_training_data()` により時系列昇順へ並べ替えた後の全データに対して inner valid を切る。
 
 ### 10.3.3 各 strategy の分割規則

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed (potentially breaking)
+
+- **Unified the inner-valid (early-stopping) pipeline fit boundary** (H-0085, [#208](https://github.com/nbx-liz/LizyML/issues/208)). `RefitTrainer` now fits the feature pipeline **once on the full dataset** — the same outer-train boundary `CVTrainer` already uses — instead of fitting on the inner-train slice and then refitting a second pipeline on all data. This removes the double fit and aligns `best_iteration` selection with the CV folds. OOF predictions are unaffected (the y-free `NativeFeaturePipeline` never let outer-valid rows into the fit); however, a model's `best_iteration` — and therefore the refit model — can change for configs that use early stopping. Resolves a BLUEPRINT self-contradiction (§6.2 / §10.3.2). `format_version` unchanged.
+
 ## [0.16.1] - 2026-06-30
 
 ### Fixed

--- a/lizyml/training/refit_trainer.py
+++ b/lizyml/training/refit_trainer.py
@@ -92,18 +92,13 @@ class RefitTrainer:
         # Inner validation split for early stopping
         iv_result = self.inner_valid.split(n_samples, y=y.to_numpy(), groups=groups)
 
-        # Fit pipeline on inner-train only to prevent leakage into
-        # early-stopping validation (consistent with CVTrainer).
+        # H-0085: fit the feature pipeline once on the FULL dataset. This is the
+        # outer-train boundary (the whole set for a full-data refit), matching
+        # CVTrainer, where the pipeline is fit on the whole outer-fold train and
+        # the inner-valid rows are sliced from the transformed data. It also
+        # serves as the inference-time ``pipeline_state`` — no second fit.
         pipeline = self.pipeline_factory()
-        if iv_result is not None:
-            inner_train_rel, inner_valid_rel = iv_result
-            pipeline.fit(
-                X.iloc[inner_train_rel].reset_index(drop=True),
-                y.iloc[inner_train_rel].reset_index(drop=True),
-            )
-        else:
-            pipeline.fit(X, y)
-
+        pipeline.fit(X, y)
         X_t = pipeline.transform(X)
 
         cat_cols: list[str] = (
@@ -121,6 +116,7 @@ class RefitTrainer:
             estimator.update_params(self.ratio_param_resolver(n_inner))
 
         if iv_result is not None:
+            inner_train_rel, inner_valid_rel = iv_result
             X_iv_train = X_t.iloc[inner_train_rel].reset_index(drop=True)
             y_iv_train = y.iloc[inner_train_rel].reset_index(drop=True)
             X_iv_valid = X_t.iloc[inner_valid_rel].reset_index(drop=True)
@@ -140,26 +136,11 @@ class RefitTrainer:
         train_pred = get_fold_pred(estimator, X_t, self.task)
         eval_hist: dict[str, Any] = dict(estimator.eval_results)
 
-        # Refit pipeline on ALL data for the final pipeline_state
-        # (used at inference time).  When no inner-valid split was used,
-        # the first pipeline was already fitted on all data — reuse it.
-        if iv_result is not None:
-            final_pipeline = self.pipeline_factory()
-            final_pipeline.fit(X, y)
-        else:
-            final_pipeline = pipeline
-
-        final_cat_cols: list[str] = (
-            final_pipeline.get_state().get("categorical_cols", [])
-            if hasattr(final_pipeline, "get_state")
-            else []
-        )
-
         return RefitResult(
             model=estimator,
-            pipeline_state=final_pipeline.get_state(),
+            pipeline_state=pipeline.get_state(),
             feature_names=list(X.columns),
-            categorical_features=final_cat_cols,
+            categorical_features=cat_cols,
             best_iteration=estimator.best_iteration,
             train_pred=train_pred,
             history=eval_hist,

--- a/tests/test_bugfix_batch_2026_04_part2.py
+++ b/tests/test_bugfix_batch_2026_04_part2.py
@@ -1,6 +1,7 @@
 """Regression tests for issues #5, #6, #7 discovered 2026-04-10.
 
-#5: RefitTrainer pipeline fitted on all data (inner-valid included).
+#5: RefitTrainer pipeline fit boundary — now unified to full-data, single
+    fit by H-0085 (#208); this file pins the current (post-H-0085) contract.
 #6: cross_fit_calibrate passes NaN val_idx to calibrator.predict.
 #7: calibrated metrics missing oof_per_fold key.
 """
@@ -81,12 +82,19 @@ class StubEstimator:
 
 
 class TestRefitTrainerPipelineLeakage:
-    """Pipeline must be fitted on inner-train only, not all data."""
+    """Pipeline fit boundary is the full dataset, fitted once (H-0085).
 
-    def test_pipeline_fit_excludes_inner_valid_rows(self) -> None:
-        """When inner-valid is used, the initial pipeline.fit must
-        be called on inner-train rows only (not the full dataset).
-        The final pipeline_state should be from a full-data refit.
+    Superseded the 2026-04 #5 fix: H-0085 (#208) unified the pipeline fit
+    boundary to the full outer-train set — for a refit that is all rows,
+    fitted exactly once (matching CVTrainer's outer-train boundary), and the
+    same pipeline provides ``pipeline_state``. No inner-train fit, no double
+    fit. The y-free ``NativeFeaturePipeline`` keeps OOF clean either way; see
+    HISTORY.md H-0085.
+    """
+
+    def test_pipeline_fits_once_on_full_data(self) -> None:
+        """When inner-valid is used, pipeline.fit is called exactly once, on
+        the full dataset, and ``pipeline_state`` comes from that single fit.
         """
         n = 100
         X = pd.DataFrame({"f1": np.arange(n, dtype=float)})
@@ -109,22 +117,15 @@ class TestRefitTrainerPipelineLeakage:
 
         result = trainer.fit(X, y)
 
-        # Two pipelines: inner-train fit + full-data fit
-        assert len(spy_pipelines) == 2, (
-            f"Expected 2 pipeline instances, got {len(spy_pipelines)}"
+        # Exactly one pipeline, fitted on all rows (no double fit).
+        assert len(spy_pipelines) == 1, (
+            f"Expected 1 pipeline instance, got {len(spy_pipelines)}"
         )
-        # First pipeline: fitted on inner-train only
-        assert spy_pipelines[0].fit_n_rows is not None
-        assert spy_pipelines[0].fit_n_rows < n, (
-            f"First pipeline fitted on {spy_pipelines[0].fit_n_rows} "
-            f"rows, expected < {n} (inner-train only)"
-        )
-        # Second pipeline: fitted on full data
-        assert spy_pipelines[1].fit_n_rows == n, (
-            f"Second pipeline fitted on {spy_pipelines[1].fit_n_rows} "
+        assert spy_pipelines[0].fit_n_rows == n, (
+            f"Pipeline fitted on {spy_pipelines[0].fit_n_rows} "
             f"rows, expected {n} (full data)"
         )
-        # pipeline_state comes from full-data fit
+        # pipeline_state comes from that single full-data fit
         assert result.pipeline_state == {"cols": ["f1"]}
 
 

--- a/tests/test_training/test_refit_pipeline_fit_boundary.py
+++ b/tests/test_training/test_refit_pipeline_fit_boundary.py
@@ -1,0 +1,99 @@
+"""Boundary pin for ``RefitTrainer`` pipeline fit (H-0085 / #208).
+
+H-0085 unifies the pipeline fit boundary to the **full outer-train** set — for
+``RefitTrainer`` that is the whole dataset, fitted **exactly once**. The previous
+implementation fitted the pipeline on the inner-train slice only and then fitted
+a *second* pipeline on all data for ``pipeline_state`` (a double fit whose
+early-stopping boundary was stricter than the CV folds it mirrors).
+
+These tests fail closed on a regression to either the old inner-train boundary
+or the double fit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from lizyml.estimators.lgbm import LGBMAdapter
+from lizyml.features.encoders.categorical_encoder import UnseenPolicy
+from lizyml.features.pipelines_native import NativeFeaturePipeline
+from lizyml.training.inner_valid import HoldoutInnerValid, TimeHoldoutInnerValid
+from lizyml.training.refit_trainer import RefitTrainer
+
+
+class _FitCountingPipeline(NativeFeaturePipeline):
+    """Records the row count of every ``fit`` call into a shared log."""
+
+    def __init__(self, log: list[int], unseen_policy: UnseenPolicy = "mode") -> None:
+        super().__init__(unseen_policy=unseen_policy)
+        self._log = log
+
+    def fit(self, X: pd.DataFrame, y: pd.Series) -> _FitCountingPipeline:
+        self._log.append(len(X))
+        super().fit(X, y)
+        return self
+
+
+def _reg_data(n: int = 200) -> tuple[pd.DataFrame, pd.Series]:
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame({"a": rng.normal(size=n), "b": rng.normal(size=n)})
+    y = pd.Series(rng.normal(size=n), name="target")
+    return X, y
+
+
+def test_refit_fits_pipeline_once_on_full_data() -> None:
+    """Pipeline is fit exactly once, on the full dataset (no inner-train fit,
+    no second full-data refit)."""
+    X, y = _reg_data(n=200)
+    fit_rows: list[int] = []
+    trainer = RefitTrainer(
+        inner_valid=HoldoutInnerValid(ratio=0.15, random_state=0),
+        pipeline_factory=lambda: _FitCountingPipeline(fit_rows),
+        estimator_factory=lambda: LGBMAdapter(
+            task="regression",
+            params={"n_estimators": 30, "learning_rate": 0.1},
+            early_stopping_rounds=5,
+            random_state=0,
+        ),
+        task="regression",
+    )
+    result = trainer.fit(X, y)
+
+    # H-0085: single fit, on all rows — matches CVTrainer's outer-train boundary.
+    assert fit_rows == [len(X)]
+    assert result.pipeline_state is not None
+    assert result.best_iteration is not None
+
+
+def test_refit_pipeline_sees_inner_valid_categories() -> None:
+    """A category present only in the inner-valid tail must be known to the
+    pipeline — proving the fit boundary is the full data, not inner-train.
+
+    With ``unseen_policy="error"`` the old inner-train boundary raised while
+    transforming the full ``X`` (the tail category was unseen); the unified
+    full-data boundary completes without error.
+    """
+    n = 200
+    rng = np.random.default_rng(1)
+    cat = np.array(["common"] * n, dtype=object)
+    cat[-1] = "TAIL_ONLY"  # last row → falls in the time-holdout inner-valid tail
+    X = pd.DataFrame({"num": rng.normal(size=n), "cat": cat})
+    y = pd.Series(rng.normal(size=n), name="target")
+
+    trainer = RefitTrainer(
+        inner_valid=TimeHoldoutInnerValid(ratio=0.1),
+        pipeline_factory=lambda: NativeFeaturePipeline(unseen_policy="error"),
+        estimator_factory=lambda: LGBMAdapter(
+            task="regression",
+            params={"n_estimators": 20},
+            early_stopping_rounds=5,
+            random_state=0,
+        ),
+        task="regression",
+    )
+
+    # Must not raise: the full-data pipeline has learned "TAIL_ONLY".
+    result = trainer.fit(X, y)
+    assert result.pipeline_state is not None
+    assert "cat" in result.pipeline_state["categorical_cols"]


### PR DESCRIPTION
## Summary

`RefitTrainer` fitted the pipeline on the inner-train slice then refit a second pipeline on all data — the opposite boundary from `CVTrainer` (which fits on the whole outer-train) and a BLUEPRINT self-contradiction (§6.2 vs §10.3.2). Per accepted proposal H-0085 (#219), unify to the full-data boundary, fitted once.

## Changes

- `RefitTrainer` now fits the feature pipeline once on the full dataset, slices inner-train/valid from the transformed data (mirrors `CVTrainer._build_iv_subsets`), and removes the double fit and the misleading "consistent with CVTrainer" comment.
- BLUEPRINT.md §10.3.2 revised to describe the single full-data fit boundary.
- CHANGELOG.md `[Unreleased]` entry documents the behavior change.

## Invariants

- INV-1: RefitTrainer fits the feature pipeline exactly once, on the full dataset (no inner-train fit, no double fit).
- INV-2: RefitTrainer and CVTrainer share the same pipeline fit boundary (whole outer-train / full data).
- INV-3: OOF cleanliness unchanged — CVTrainer still never lets outer-valid rows into pipeline.fit.

## Failure Paths Covered

- [x] Normal completion with early stopping (`test_refit_fits_pipeline_once_on_full_data` / `test_refit_with_early_stopping`)
- [x] No inner valid (`NoInnerValid`) — single full-data fit (existing `test_refit_produces_result`)
- [x] Category present only in inner-valid rows (`test_refit_pipeline_sees_inner_valid_categories`)
- [ ] Cancellation / crash / timeout — out of scope (synchronous single-call trainer, no resource lifecycle)

## Behavior change note

`best_iteration` (and the refit model) can change for early-stopping configs; OOF/metrics unaffected; `format_version` unchanged.

## Relevant SKILL

training-cv-and-inner-valid

## DoD

- RED tests added and shown failing pre-fix, GREEN post-fix
- Superseded test updated (not deleted)
- ruff / mypy / full pytest green locally (1979 passed)

Relates to H-0085 / #208.
