### PR TITLE
feat(persistence): persist tuned params in metadata.json and restore on load (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`fit()` and `load()` no longer expose the internal `FitResult` by reference** (H-0086, [#204](https://github.com/nbx-liz/LizyML/issues/204)). `fit()` — the primary access path — now returns a selective deep copy (the same isolation the `fit_result` property already applied under H-0082), and `Model.load()` deep-copies the restored metrics dict. Mutating a returned result can no longer corrupt internal state or contaminate a later `export()`'s `metadata.json`. Trained estimators (`models` / `calibrator` / `pipeline_state`) stay shared by reference as before; the return type is unchanged.
 - **Config validation hardening** (H-0085, [#210](https://github.com/nbx-liz/LizyML/issues/210)):
   - **`config_version` string bypass** — a string value (e.g. `"999"`) previously skipped the supported-version gate and was then lax-coerced by pydantic, loading an unsupported version silently. The gate now coerces to `int` before the check, so unsupported versions are rejected as `CONFIG_VERSION_UNSUPPORTED` regardless of input type.
   - **Legacy `embargo_pct` / `gap` truncation** — a fractional legacy value (e.g. `embargo_pct=0.05`) was migrated via `int()` and silently collapsed to `0`, removing the leakage guard. Fractional legacy values are now rejected with `CONFIG_INVALID` and guidance to supply an integer observation count; integer-valued inputs still migrate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Tuned parameters are now persisted and restored across `export()` / `Model.load()`** (H-0086, [#215](https://github.com/nbx-liz/LizyML/issues/215)). `export()` records the tuned-param overlay (`best_model_params` / `best_smart_params` / `best_training_params` + score / metric / direction) under a `tuning` block in `metadata.json`, and `Model.load()` restores it into `_tuning_result`. A re-`fit()` after `load()` now reproduces the tuned params instead of silently reverting to config defaults. Additive and back-compatible — non-tuned and pre-#215 artifacts have no `tuning` block and load with `_tuning_result = None`; `format_version` stays `2`. (Restoring the full optuna study for a complete `tune(resume=True)` from a loaded model remains a follow-up.)
+
 ### Changed (potentially breaking)
 
 - **Unified the inner-valid (early-stopping) pipeline fit boundary** (H-0085, [#208](https://github.com/nbx-liz/LizyML/issues/208)). `RefitTrainer` now fits the feature pipeline **once on the full dataset** — the same outer-train boundary `CVTrainer` already uses — instead of fitting on the inner-train slice and then refitting a second pipeline on all data. This removes the double fit and aligns `best_iteration` selection with the CV folds. OOF predictions are unaffected (the y-free `NativeFeaturePipeline` never let outer-valid rows into the fit); however, a model's `best_iteration` — and therefore the refit model — can change for configs that use early stopping. Resolves a BLUEPRINT self-contradiction (§6.2 / §10.3.2). `format_version` unchanged.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6891,3 +6891,48 @@ inner-valid（early-stopping）境界に関する 4 つの課題を、一貫し�
 - **#210 item 3**: time-order outer split × shuffled 明示 inner_valid で `UserWarning` が発ることを検証するテスト。
 - 上記いずれも「落ちるべき例」を含む（CLAUDE.md §6 の split/leakage/calibration 必須要件）。
 
+## H-0086: Phase 3 契約/永続化/公開API の一括修正（FitResult 参照返し・tuned params 非永続化・config round-trip・top-level export）
+
+- **ステータス**: Accepted
+- **起票日**: 2026-07-03
+- **決定日**: 2026-07-03
+- **スコープ**: `core/model.py`（`fit()` の返却 / `load()` の metrics 共有）, `core/_model_persistence.py` + `persistence/exporter.py` + `persistence/loader.py`（tuned params の永続化・復元）, `config/schema.py`（inner_valid explicitness の round-trip 化）, `lizyml/__init__.py` + `core/types/__init__.py`（公開 re-export）, `BLUEPRINT.md`（公開 API surface / Artifacts metadata）。**format_version は据え置き（2、additive）**。
+- **関連**: [Issue #204](https://github.com/nbx-liz/LizyML/issues/204), [#215](https://github.com/nbx-liz/LizyML/issues/215), [#203](https://github.com/nbx-liz/LizyML/issues/203), [#213](https://github.com/nbx-liz/LizyML/issues/213)。H-0082（deep-copy 防御）, H-0069（inner_valid canonical）, H-0083（metadata additive 前例）。2026-07-02 full-package review。
+
+### 目的（課題）
+
+full-package review が検出した契約・永続化・公開 API の 4 課題を、Phase 3 の契約クラスタとして一括で解消する。
+
+1. **#204 — `fit()` / `load()` が内部 FitResult を参照で漏らす**: `fit_result` プロパティは H-0082 で selective deep-copy して internal state 汚染（→後続 `export()` の metadata 汚染）を防ぐが、主経路である `fit()` は `self._fit_result` と同一オブジェクトを返す（`model.py:275-277`）。`load()` も `instance._metrics = fit_result.metrics` で dict を共有する（`_model_persistence.py:192`）。最も使われる経路で防御が効いていない。
+2. **#215 — tuned params が永続化されない**: best params は in-memory の `_tuning_result` overlay 経由で fit 時に適用される（`model.py:185-201, 878-897`）のみで、`export()` は fit/refit/config/metrics だけを書き（`exporter.py:96-108`）、`load()` は `_tuning_result` を復元しない（`_model_persistence.py:191-201`）。`Model.load()` 後の再 `fit()` は tuned params を失い config デフォルトで学習する — artifact は tuned で predict するのに再学習は defaults という silent な再現性ドリフト。
+3. **#203 — config round-trip で明示 inner_valid が消失**: `model_dump()` は computed field `validation_ratio` を常に emit するため、再検証時に explicitness ヒューリスティック（`user_explicit_inner_valid = iv_in and not vr_present`）が `False` に倒れ、`_inner_valid_explicit`（`PrivateAttr`・非直列化）が失われる。factory は outer split から auto-resolve し直し、ユーザーの明示 `time_holdout` / `group_holdout` を silent に別戦略へ置換する（`export → load → fit` 経路を含む）。time/group データでは leakage-relevant。
+4. **#213 — 契約型 / LizyMLError が top-level 未 export**: `Model.fit/predict/tune` は `FitResult` / `PredictionResult` / `TuningResult` を返し、公開メソッドは `LizyMLError` を送出するが、いずれも `lizyml` 直下から import できない（`__init__.py:13-22` は `Model` + 5 tuning 型のみ）。ユーザーは型注釈や `except LizyMLError` のために `lizyml.core.types` / `lizyml.core.exceptions`（private に見えるパス）へ手を伸ばす必要があり、公開/内部境界が曖昧化して将来のリファクタが事実上破壊的になる。
+
+### 対応方針（決定）
+
+- **#204 → `fit()` も selective deep-copy を返す**。`fit()` は `self._fit_result` に internal 参照を保持したまま、返却値は `FitResult.__deepcopy__`（H-0082 の selective copy）を通す。`load()` は `instance._metrics` を metrics dict の deep-copy にして internal と外部返却の共有を断つ。公開 API の shape・意味は不変（返却型は FitResult のまま）。回帰テスト: `fit()` の返却値を mutate → 後続 `export()` の metadata が汚染されないこと。
+- **#215 → tuned params を metadata.json に additive 永続化し load で復元**。`export()` の metadata に `tuning` ブロック（`best_model_params` / `best_smart_params` / `best_training_params` / `best_score` / `metric_name` / `direction`）を追加し、`load()` が最小 `TuningResult`（`trials=()` / `rounds=()`）を復元して `_tuning_result` にセットする。これにより `load()` 後の再 `fit()` が tuned params を再現する。**format_version は 2 のまま（additive、H-0083 と同型）**: `tuning` キーの無い旧 artifact は従来どおり load でき `_tuning_result=None`（現行挙動）。**スコープ外**: optuna study 実体を要する完全な `tune(resume=True)`（trials/study の再構築）は本 Proposal では扱わず follow-up とする（params 復元により resume の seed には寄与するが study 継続は別途）。
+- **#203 → explicitness を round-trip 安全な marker で直列化**。`validation_ratio` と同様に wrap-validator で pop される computed marker `inner_valid_explicit` を emit し、再検証時に入力 dict にあればそれを explicitness の source of truth として尊重する（無ければ従来ヒューリスティックにフォールバック）。これで `dump → reload` と `export → load → fit` がユーザーの明示 inner_valid 戦略を再現する。**settable な公開フィールドは追加しない**（computed かつ入力時 pop）。互換性: 旧 dump（marker 無し）はヒューリスティックにフォールバック＝現行挙動。paired-config-fields skill 準拠。
+- **#213 → 契約型と例外を top-level に re-export**。`lizyml/__init__.py.__all__` に `FitResult` / `PredictionResult` / `TuningResult` / `LizyMLError` / `ErrorCode` / `load_config` / `TaskType` を追加、`core/types/__init__.py` に `DataFingerprint` を追加。公開 export set を固定するゴールデンテストを追加。純粋な additive（既存 import は不変）。
+
+### 代替案（不採用）
+
+- **#204 を「返却は参照のまま・doc で read-only を明記」**: コスト最小だが H-0082 の防御目的（export 汚染防止）を主経路で放棄するため不採用。
+- **#215 を「loaded model を inference-only とし再 fit を warn/raise」**: 実装は軽いが、tune→export→load→再 fit という正当なワークフローを塞ぐ。params 復元の方がユーザー価値が高いため不採用（study 完全 resume のみ follow-up 送り）。
+- **#215 で TuningResult 全体（trials 含む）を JSON 直列化**: metadata.json が肥大化し、TrialResult の非自明な直列化が必要。overlay に必要な best_* params + スコアに絞る。
+- **#203 で `validation_ratio` を model_dump から除外**: round-trip は直るが、read-only mirror として dump 出力を読む外部/下流の想定を壊すため不採用。marker 追加の方が additive。
+- **#213 で `lizyml.core.*` を公開パスとして追認**: 内部レイアウトを凍結してしまい将来のリファクタを縛るため不採用。
+
+### 影響範囲 / 互換性
+
+- **format_version は 2 のまま**。#215 の `tuning`・#203 の `inner_valid_explicit` はいずれも additive で、旧 artifact / 旧 dump は従来どおり load・再検証できる。
+- **公開 API**: #213 は re-export の追加のみ（既存 import 不変）。#204 は返却型不変（同一オブジェクト → 独立コピーへ変わるのみ；参照同一性に依存する呼び出し側があれば挙動変化だが、契約は「読み取り専用の独立コピー」を明文化）。
+- **挙動変化**: #203 の修正後、round-trip / load 経由の明示 inner_valid は auto-resolve されず明示戦略を保つ（＝リーク経路を塞ぐ正しい方向の変化）。#215 の修正後、load 後の再 fit は tuned params を再現する。いずれも CHANGELOG に明記。
+
+### 受け入れ基準（テスト観点）
+
+- **#204**: `fit()` の返却値の `metrics` を mutate → 内部 state と後続 `export()` 出力が汚染されないことを固定する回帰テスト。`load()` 後 `_metrics` が返却 metrics と別オブジェクトであること。
+- **#215**: tune → export → load → 再 fit で tuned params が再現される契約テスト（load 前後で `_merge_params` の overlay が一致）。`tuning` キーの無い旧 metadata が load 可能（後方互換）な RED/GREEN テスト。
+- **#203**: `{"inner_valid": {"method": "time_holdout", "ratio": 0.2, ...}}` を dump → reload して `_inner_valid_explicit` が保持される RED テスト（現行 False で落ちる）。`export → load → fit` で明示 inner_valid が auto-resolve されない leakage 観点テスト。純 legacy `{"validation_ratio": 0.1}` は従来どおり auto-resolve（非回帰）。
+- **#213**: `lizyml` の top-level `__all__` を固定するゴールデンテスト（`FitResult` 等が import 可能・set が pin される）。
+

--- a/lizyml/core/_model_persistence.py
+++ b/lizyml/core/_model_persistence.py
@@ -82,6 +82,7 @@ class ModelPersistenceMixin:
             config=state.cfg.model_dump(),
             task=state.cfg.task,
             analysis_context=ctx,
+            tuning=state.tuning_result,
         )
         _log.info("event='export.done' path=%s", resolved_path)
         return resolved_path
@@ -200,6 +201,22 @@ class ModelPersistenceMixin:
         from lizyml.core._model_factories import get_provider
 
         instance._provider = get_provider(instance._cfg.model)
+        # Restore the tuned-param overlay so a re-fit() reproduces the tuned
+        # params instead of silently reverting to config defaults (H-0086,
+        # #215). Absent for non-tuned / pre-#215 artifacts (stays None).
+        tuning_meta = metadata.get("tuning")
+        if tuning_meta is not None:
+            from lizyml.core.types.tuning_result import TuningResult
+
+            instance._tuning_result = TuningResult(
+                best_model_params=tuning_meta["best_model_params"],
+                best_smart_params=tuning_meta["best_smart_params"],
+                best_training_params=tuning_meta["best_training_params"],
+                best_score=tuning_meta["best_score"],
+                trials=[],
+                metric_name=tuning_meta["metric_name"],
+                direction=tuning_meta["direction"],
+            )
         if analysis_context is not None:
             instance._y = analysis_context.y_true
             instance._X = analysis_context.X_for_explain

--- a/lizyml/core/_model_persistence.py
+++ b/lizyml/core/_model_persistence.py
@@ -8,6 +8,7 @@ Model facade as ``Model._resolve_export_path``.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -191,7 +192,10 @@ class ModelPersistenceMixin:
         instance: Any = cls(config)  # type: ignore[call-arg]  # cls is Model at runtime
         instance._fit_result = fit_result
         instance._refit_result = refit_result
-        instance._metrics = fit_result.metrics
+        # Deep-copy the metrics dict so the internal state does not share a
+        # mutable object with the ``fit_result`` copy handed to callers
+        # (#204 / H-0086 — the same isolation fit()/fit_result enforce).
+        instance._metrics = deepcopy(fit_result.metrics)
         # Restore provider for params_table() etc. (H-0054)
         from lizyml.core._model_factories import get_provider
 

--- a/lizyml/core/model.py
+++ b/lizyml/core/model.py
@@ -274,7 +274,11 @@ class Model(ModelPlotsMixin, ModelTablesMixin, ModelPersistenceMixin):
 
         self._fit_result = fit_result
         _log.info("event='fit.done' run_id=%s", run_id)
-        return fit_result
+        # Return a selective deep copy (FitResult.__deepcopy__): mutating the
+        # primary return path must not corrupt internal state or a later
+        # export() — the same H-0082 defense as the ``fit_result`` property
+        # (#204 / H-0086). Trained estimators stay shared by reference.
+        return deepcopy(fit_result)
 
     def evaluate(
         self,

--- a/lizyml/persistence/exporter.py
+++ b/lizyml/persistence/exporter.py
@@ -32,9 +32,29 @@ from lizyml.core.types.task import TaskType
 
 if TYPE_CHECKING:
     from lizyml.core.types.fit_result import FitResult
+    from lizyml.core.types.tuning_result import TuningResult
     from lizyml.training.refit_trainer import RefitResult
 
 FORMAT_VERSION = 2
+
+
+def _tuning_metadata(tuning: TuningResult) -> dict[str, Any]:
+    """Serialize the tuned-param overlay for ``metadata.json`` (H-0086, #215).
+
+    Only the values ``Model._merge_params`` needs to reproduce the tuned fit are
+    recorded (``best_*`` params + score/metric/direction). The full trial list
+    and optuna study are intentionally omitted — restoring those (for a complete
+    ``tune(resume=True)`` from a loaded model) is a separate follow-up.
+    """
+    return {
+        "best_model_params": dict(tuning.best_model_params),
+        "best_smart_params": dict(tuning.best_smart_params),
+        "best_training_params": dict(tuning.best_training_params),
+        "best_score": tuning.best_score,
+        "metric_name": tuning.metric_name,
+        "direction": tuning.direction,
+    }
+
 
 #: Checksum algorithm recorded in ``metadata.json`` and verified on load.
 CHECKSUM_ALGORITHM = "sha256"
@@ -61,6 +81,7 @@ def export(
     task: TaskType,
     *,
     analysis_context: AnalysisContext | None = None,
+    tuning: TuningResult | None = None,
 ) -> None:
     """Serialize Model artifacts to *path*.
 
@@ -72,6 +93,9 @@ def export(
         task: ML task string (``"regression"``, ``"binary"``, ``"multiclass"``).
         analysis_context: Optional y_true and X data for diagnostic APIs
             after ``Model.load()``.
+        tuning: Optional tuning result. When present, the tuned-param overlay
+            is recorded under ``metadata["tuning"]`` so a re-``fit()`` after
+            ``Model.load()`` reproduces the tuned params (H-0086, #215).
 
     Raises:
         LizyMLError with SERIALIZATION_FAILED on any I/O or serialization error.
@@ -105,6 +129,10 @@ def export(
                 "files": {name: sha256_file(out / name) for name in pkl_names},
             },
         }
+        if tuning is not None:
+            # Additive (H-0086, #215): absent for non-tuned models and pre-#215
+            # artifacts, which load with ``_tuning_result = None`` as before.
+            metadata["tuning"] = _tuning_metadata(tuning)
         (out / "metadata.json").write_text(
             json.dumps(metadata, indent=2, default=str), encoding="utf-8"
         )

--- a/tests/test_core/test_result_isolation.py
+++ b/tests/test_core/test_result_isolation.py
@@ -88,3 +88,52 @@ def test_mutating_evaluate_does_not_contaminate_export(
     metadata = json.loads((out / "metadata.json").read_text(encoding="utf-8"))
 
     assert metadata["metrics"]["raw"]["oof"][key] != _SENTINEL
+
+
+# --- #204: fit() return value and load()'s metrics must also be isolated ------
+
+
+def test_fit_return_value_is_independent_copy() -> None:
+    """``fit()`` — the primary access path — must not hand out the internal
+    object (H-0086 / #204). Mutating its return must not corrupt internal state.
+    """
+    model = Model(make_config("regression"))
+    returned = model.fit(data=make_regression_df(n=120))
+
+    assert returned is not model._fit_result
+    key = _oof_key(returned.metrics)
+    returned.metrics["raw"]["oof"][key] = _SENTINEL
+
+    assert model.evaluate()["raw"]["oof"][key] != _SENTINEL
+    # Selective copy: trained estimators stay shared by reference.
+    assert returned.models[0] is model._fit_result.models[0]
+
+
+def test_mutating_fit_return_does_not_contaminate_export(tmp_path) -> None:
+    model = Model(make_config("regression"))
+    returned = model.fit(data=make_regression_df(n=120))
+    key = _oof_key(returned.metrics)
+    returned.metrics["raw"]["oof"][key] = _SENTINEL
+
+    out = model.export(path=tmp_path / "artifact")
+    metadata = json.loads((out / "metadata.json").read_text(encoding="utf-8"))
+
+    assert metadata["metrics"]["raw"]["oof"][key] != _SENTINEL
+
+
+def test_load_metrics_not_shared_with_returned_fit_result(tmp_path) -> None:
+    """After ``load()``, the internal ``_metrics`` dict must not be the same
+    object the ``fit_result`` copy exposes, so mutating a public return cannot
+    corrupt the reloaded internal state (#204).
+    """
+    model = Model(make_config("regression"))
+    model.fit(data=make_regression_df(n=120))
+    out = model.export(path=tmp_path / "artifact")
+
+    loaded = Model.load(out)
+    returned = loaded.fit_result
+    key = _oof_key(returned.metrics)
+    returned.metrics["raw"]["oof"][key] = _SENTINEL
+
+    assert loaded.evaluate()["raw"]["oof"][key] != _SENTINEL
+    assert loaded._metrics is not loaded._fit_result.metrics

--- a/tests/test_persistence/test_tuning_persistence.py
+++ b/tests/test_persistence/test_tuning_persistence.py
@@ -1,0 +1,95 @@
+"""Persistence of tuned parameters across export/load (H-0086, #215).
+
+Before this fix, tuned best params lived only in the in-memory ``_tuning_result``
+overlay applied at fit time. ``export()`` never wrote them and ``load()`` never
+restored them, so a re-``fit()`` after ``Model.load()`` silently trained with
+config defaults — a silent reproducibility drift (the artifact predicts with
+tuned params but retrains with defaults).
+
+These tests pin the contract: the tuned overlay survives export → load, and a
+loaded model re-``fit()``s with the tuned params. Legacy artifacts without a
+``tuning`` block still load (additive, ``format_version`` unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+
+from lizyml.core.model import Model
+from tests._helpers import make_config, make_regression_df
+
+
+def _tuned_model() -> Model:
+    df = make_regression_df(n=200, seed=0)
+    cfg = make_config("regression", n_estimators=30, n_splits=2, tuning_n_trials=3)
+    model = Model(cfg)
+    model.tune(data=df)
+    model.fit(data=df)
+    return model
+
+
+def test_tuning_block_written_to_metadata(tmp_path) -> None:
+    model = _tuned_model()
+    out = model.export(path=tmp_path / "artifact")
+    metadata = json.loads((out / "metadata.json").read_text(encoding="utf-8"))
+
+    assert "tuning" in metadata
+    tuning = metadata["tuning"]
+    assert set(tuning) >= {
+        "best_model_params",
+        "best_smart_params",
+        "best_training_params",
+        "best_score",
+        "metric_name",
+        "direction",
+    }
+    # format_version stays 2 (additive block).
+    assert metadata["format_version"] == 2
+
+
+def test_load_restores_tuning_result(tmp_path) -> None:
+    model = _tuned_model()
+    expected = model._tuning_result
+    assert expected is not None
+
+    out = model.export(path=tmp_path / "artifact")
+    loaded = Model.load(out)
+
+    assert loaded._tuning_result is not None
+    assert loaded._tuning_result.best_model_params == expected.best_model_params
+    assert loaded._tuning_result.best_smart_params == expected.best_smart_params
+    assert loaded._tuning_result.best_training_params == expected.best_training_params
+
+
+def test_refit_after_load_reproduces_tuned_params(tmp_path) -> None:
+    """The core silent-drift fix: ``_merge_params`` overlay must match before
+    and after a save/load round-trip, so a re-``fit()`` uses the tuned params.
+    """
+    model = _tuned_model()
+    provider = model._provider
+    assert provider is not None
+    params_before, smart_before = model._merge_params(provider)
+
+    out = model.export(path=tmp_path / "artifact")
+    loaded = Model.load(out)
+
+    params_after, smart_after = loaded._merge_params(loaded._provider)
+    assert params_after == params_before
+    assert smart_after == smart_before
+
+
+def test_legacy_artifact_without_tuning_block_still_loads(tmp_path) -> None:
+    """A non-tuned artifact (or a pre-#215 one) has no ``tuning`` key; load must
+    succeed and leave ``_tuning_result`` as ``None`` (back-compat)."""
+    df = make_regression_df(n=120, seed=0)
+    model = Model(make_config("regression", n_estimators=20, n_splits=2))
+    model.fit(data=df)
+    out = model.export(path=tmp_path / "artifact")
+
+    metadata_path = out / "metadata.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata.pop("tuning", None)  # simulate a pre-#215 artifact
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+    loaded = Model.load(out)
+    assert loaded._tuning_result is None


### PR DESCRIPTION
## Summary

Persists the tuned-param overlay so a re-`fit()` after `Model.load()` no longer silently reverts to config defaults (#215, decided in **H-0086**).

Before: tuned best params lived only in the in-memory `_tuning_result` overlay applied at fit time. `export()` wrote fit/refit/config/metrics but no tuning artifact, and `load()` never restored `_tuning_result`. Result: a loaded artifact *predicts* with tuned params but *retrains* with defaults — a silent reproducibility drift.

Now:
- `export()` records an additive `tuning` block in `metadata.json` — `best_model_params` / `best_smart_params` / `best_training_params` + `best_score` / `metric_name` / `direction`.
- `Model.load()` reconstructs a minimal `TuningResult` (empty trials/rounds) and restores `_tuning_result`, so `_merge_params` reapplies the tuned overlay on re-`fit()`.

Additive and back-compatible: non-tuned and pre-#215 artifacts have no `tuning` block and load with `_tuning_result = None`. **`format_version` stays 2** (same additive pattern as H-0083 checksums).

**Out of scope (follow-up):** restoring the full optuna study for a complete `tune(resume=True)` from a loaded model. This PR restores the params (which seeds resume) but not the trial history.

## Relevant SKILL

`skills/persistence-and-migration` (additive metadata, format_version), `skills/tuning`.

## Changes

- `lizyml/persistence/exporter.py` — new `tuning` param + `_tuning_metadata()` serializer; writes `metadata["tuning"]`.
- `lizyml/core/_model_persistence.py` — `export()` passes `state.tuning_result`; `load()` restores `_tuning_result`.
- `tests/test_persistence/test_tuning_persistence.py` — 4 tests (block written, restore, re-fit overlay identity, legacy no-block load).
- `CHANGELOG.md` — Unreleased / Added.

## DoD

- [x] Persistence contract: additive block, `format_version` unchanged, legacy load path preserved.
- [x] Reproducibility test: `_merge_params` overlay identical before/after round-trip.
- [x] Back-compat test: artifact without `tuning` key loads (`_tuning_result = None`).
- [x] `ruff` / `mypy` clean; `test_persistence` + `test_tune_fit_identity` (76) pass.

## Test plan

- `pytest tests/test_persistence/test_tuning_persistence.py` — 4 passed.
- `pytest tests/test_persistence tests/test_tuning/test_tune_fit_identity.py` — 76 passed.

## Notes

Stacked on `fix/204-fit-return-deepcopy` (PR #230) → `docs/history-h0086-phase3-contracts` (PR #229). Merge #229 → #230 → this; GitHub auto-retargets.
