### PR TITLE
chore(release): finalize CHANGELOG for v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.17.0] - 2026-07-04
+
+Full-package review remediation release: leakage-safe codegen retrain, metrics
+transparency, and facade decomposition (issues [#203](https://github.com/nbx-liz/LizyML/issues/203)–[#218](https://github.com/nbx-liz/LizyML/issues/218), [#228](https://github.com/nbx-liz/LizyML/issues/228), [#237](https://github.com/nbx-liz/LizyML/issues/237); H-0085–H-0091).
 
 ### Added
 


### PR DESCRIPTION
## Summary

Release prep for **v0.17.0**. Renames the accumulated `## [Unreleased]` CHANGELOG section to `## [0.17.0] - 2026-07-04` with a short release intro, so `auto-release.yml` can awk-extract the release notes by the `## [0.17.0]` header on the develop→main merge.

Bundles the 2026-07 full-package review remediation (H-0085–H-0091): leakage-safe codegen retrain (#228), calibrated-metrics transparency + plot/codegen cleanups (#218), and the tuning-orchestrator facade decomposition (#237).

## Test Plan

- [x] CHANGELOG top header is `## [0.17.0] - 2026-07-04`; awk extraction between it and `## [0.16.1]` yields the intended release notes (auto-release simulation).
- [x] `git diff origin/main origin/develop -- .github/workflows/` is empty (no dependabot drift; merge-commit history-connection invariant holds).
- [ ] CI (docs-adjacent; full matrix still runs) — must pass before merge.

## DoD

- CHANGELOG finalized for v0.17.0; next step is the `develop→main` merge-commit release PR.

[docs-only]
