### PR TITLE
fix(policy): cover protected-branch Ruff boundary

### DIFF
--- a/tests/test-ruff-policy-boundary.sh
+++ b/tests/test-ruff-policy-boundary.sh
@@ -7,6 +7,9 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ROGUE_REL=".githooks/not-managed.py"
 ROGUE="$ROOT/$ROGUE_REL"
 
+# shellcheck source=../.githooks/protected-refs.sh
+. "$ROOT/.githooks/protected-refs.sh"
+
 [ ! -e "$ROGUE" ] || {
     echo "FAIL: mutation path already exists: $ROGUE_REL" >&2
     exit 1
@@ -44,12 +47,28 @@ set -e
     echo "FAIL: staged hook accepted $ROGUE_REL" >&2
     exit 1
 }
-unset fail_reason
-case "$staged_out" in *F401*) ;; *) fail_reason="missing F401" ;; esac
-case "$staged_out" in *"$ROGUE_REL"*) ;; *) fail_reason="${fail_reason:+$fail_reason; }missing path" ;; esac
-[ -z "${fail_reason:-}" ] || {
-    echo "FAIL: staged refusal was not the seeded F401 ($fail_reason)" >&2
-    exit 1
-}
+
+current_ref="$(git -C "$ROOT" symbolic-ref --quiet HEAD || true)"
+if [ -n "$current_ref" ] && protected_ref "$current_ref"; then
+    # A real default-branch push checks out main/master as a branch. The
+    # protected-ref refusal intentionally runs before staged Ruff, so assert
+    # that fail-closed boundary here. Pull-request/detached and feature-branch
+    # runs take the other arm and prove the staged-file Ruff routing itself.
+    case "$staged_out" in
+        *"BLOCKED: commit on protected branch '${current_ref#refs/heads/}'"*) ;;
+        *)
+            echo "FAIL: staged hook did not refuse protected $current_ref" >&2
+            exit 1
+            ;;
+    esac
+else
+    unset fail_reason
+    case "$staged_out" in *F401*) ;; *) fail_reason="missing F401" ;; esac
+    case "$staged_out" in *"$ROGUE_REL"*) ;; *) fail_reason="${fail_reason:+$fail_reason; }missing path" ;; esac
+    [ -z "${fail_reason:-}" ] || {
+        echo "FAIL: staged refusal was not the seeded F401 ($fail_reason)" >&2
+        exit 1
+    }
+fi
 
 echo "Ruff policy boundary mutations: passed"


### PR DESCRIPTION
## Summary

- Make the Ruff policy mutation test respect the intentional protected-branch refusal order.
- On a real protected-branch checkout, assert the fail-closed protected-commit refusal that occurs before staged Ruff.
- On pull-request/detached and feature-branch checkouts, continue requiring the seeded F401 and exact rogue path from the staged hook.

## Root cause

PR #251 was green because pull-request checks use a detached merge checkout. After merge, real `main` push run `30723567804` checked out `main` as a branch, so the owned pre-commit correctly refused the protected branch before reaching staged Ruff. The test incorrectly required F401 in both contexts.

## Test plan

- `bash tests/test-ruff-policy-boundary.sh` on the fix branch (staged F401 arm)
- `bash tests/test-ruff-policy-boundary.sh` in an isolated clone renamed to `main` (protected-ref arm)
- `bash tests/test-owned-githooks-policy.sh`
- `bash tests/test-artifact-language.sh`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- Require exact-head CI and an independent exact-head review before merge.

## Traceability

- Production failure: [CI run 30723567804](https://github.com/nbx-liz/LizyML/actions/runs/30723567804)
- Default promotion: #251
- Portfolio acceptance: nbx-liz/claude-code-config#147
