### PR TITLE
fix(policy): align protected-branch Ruff boundary

### DIFF
--- a/tests/test-ruff-policy-boundary.sh
+++ b/tests/test-ruff-policy-boundary.sh
@@ -7,6 +7,9 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ROGUE_REL=".githooks/not-managed.py"
 ROGUE="$ROOT/$ROGUE_REL"
 
+# shellcheck source=../.githooks/protected-refs.sh
+. "$ROOT/.githooks/protected-refs.sh"
+
 [ ! -e "$ROGUE" ] || {
     echo "FAIL: mutation path already exists: $ROGUE_REL" >&2
     exit 1
@@ -44,12 +47,28 @@ set -e
     echo "FAIL: staged hook accepted $ROGUE_REL" >&2
     exit 1
 }
-unset fail_reason
-case "$staged_out" in *F401*) ;; *) fail_reason="missing F401" ;; esac
-case "$staged_out" in *"$ROGUE_REL"*) ;; *) fail_reason="${fail_reason:+$fail_reason; }missing path" ;; esac
-[ -z "${fail_reason:-}" ] || {
-    echo "FAIL: staged refusal was not the seeded F401 ($fail_reason)" >&2
-    exit 1
-}
+
+current_ref="$(git -C "$ROOT" symbolic-ref --quiet HEAD || true)"
+if [ -n "$current_ref" ] && protected_ref "$current_ref"; then
+    # A real default-branch push checks out main/master as a branch. The
+    # protected-ref refusal intentionally runs before staged Ruff, so assert
+    # that fail-closed boundary here. Pull-request/detached and feature-branch
+    # runs take the other arm and prove the staged-file Ruff routing itself.
+    case "$staged_out" in
+        *"BLOCKED: commit on protected branch '${current_ref#refs/heads/}'"*) ;;
+        *)
+            echo "FAIL: staged hook did not refuse protected $current_ref" >&2
+            exit 1
+            ;;
+    esac
+else
+    unset fail_reason
+    case "$staged_out" in *F401*) ;; *) fail_reason="missing F401" ;; esac
+    case "$staged_out" in *"$ROGUE_REL"*) ;; *) fail_reason="${fail_reason:+$fail_reason; }missing path" ;; esac
+    [ -z "${fail_reason:-}" ] || {
+        echo "FAIL: staged refusal was not the seeded F401 ($fail_reason)" >&2
+        exit 1
+    }
+fi
 
 echo "Ruff policy boundary mutations: passed"


### PR DESCRIPTION
## Summary

- Backport the independently reviewed real-default-push test correction from #252 to `develop`.
- Keep the long-lived development branch aligned with the fixed `main` policy suite.
- Preserve the staged F401 assertion on detached/feature checkouts and the earlier fail-closed protected-ref assertion on protected checkouts.

## Test plan

- `bash tests/test-ruff-policy-boundary.sh`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- Require all exact-head GitHub checks and an independent exact-head review before merge.

## Traceability

- Default-branch fix: #252
- Original default-push failure: [run 30723567804](https://github.com/nbx-liz/LizyML/actions/runs/30723567804)
- Portfolio acceptance: nbx-liz/claude-code-config#147
