### PR TITLE
chore(deps): bump actions/checkout from 4 to 7 in artifact-language

### DIFF
--- a/.github/workflows/artifact-language.yml
+++ b/.github/workflows/artifact-language.yml
@@ -19,7 +19,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Validate selected artifact boundary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mirrors the Dependabot bump merged into `main` as #254 (`actions/checkout` v4 -> v7 in `.github/workflows/artifact-language.yml`) onto `develop`, so the workflow definitions stay identical on both branches.

Dependabot targets `main` directly, so without this sync `develop` would keep the stale `@v4` pin indefinitely: the next `develop -> main` merge commit takes `main`'s side (only `main` changed the line), leaving the drift permanent. This is the same mirroring pattern used for #250/#253.

Relevant SKILL: skills/dev-environment/SKILL.md (CI configuration)

DoD:
- `.github/workflows/` diff between `origin/main` and `origin/develop` is empty after merge.
- All remaining `actions/checkout@` pins in the repository are `@v7`.

Test plan:
- CI on this PR exercises the bumped workflow (`artifact-language` runs on `pull_request`).
- `git diff origin/main origin/develop -- .github/workflows/` verified empty post-merge.
