### PR TITLE
fix(ci): bump twine to 7.0 on main (mirror of #256)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ dev = [
     "pandas-stubs>=2.0",
     "types-PyYAML>=6.0",
     "build>=1.0",
-    "twine>=6.0",
+    # >=7.0: twine 6.x monkeypatches packaging's metadata-version allowlist to
+    # cap it at 2.4, so `twine check` rejects the Metadata-Version 2.5 that
+    # current hatchling emits. 7.0.0 fixed it.
+    "twine>=7.0",
     "pyarrow>=14.0",
     "optuna>=3.0",
     "shap>=0.44",

--- a/uv.lock
+++ b/uv.lock
@@ -1123,7 +1123,7 @@ dev = [
     { name = "ruff", specifier = ">=0.8" },
     { name = "scipy", specifier = ">=1.10" },
     { name = "shap", specifier = ">=0.44" },
-    { name = "twine", specifier = ">=6.0" },
+    { name = "twine", specifier = ">=7.0" },
     { name = "types-pyyaml", specifier = ">=6.0" },
     { name = "vulture", specifier = ">=2.15" },
 ]
@@ -1675,11 +1675,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ wheels = [
 
 [[package]]
 name = "twine"
-version = "6.2.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "id" },
@@ -3153,9 +3153,9 @@ dependencies = [
     { name = "rich" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/3c/58f808a359700f39a967dffede33efeac809262c03303fa3eec6afff8f49/twine-7.0.0.tar.gz", hash = "sha256:85cdb29c518efef867360ae4acd4b0dfd61c8654a22fca08e6f8539f05022177", size = 215032, upload-time = "2026-07-27T15:59:00.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/ddcdc06225eaad6de0e48e1002b06d919dbde20582d0662c7af51308e5d6/twine-7.0.0-py3-none-any.whl", hash = "sha256:b854164df26db268af05f49aa5c0344b10e27a494343ff05b1e0bad3b135f5a7", size = 43204, upload-time = "2026-07-27T15:58:59.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Mirrors #256 (already merged into `develop`) onto `main`, so `main`'s push CI stops
failing before the next release. Same mirroring pattern as #250 -> #251/#253.

`main` currently still pins `twine>=6.0`, and twine 6.x monkeypatches `packaging`'s
metadata-version allowlist to cap it at 2.4 (`twine/package.py`, comment "Monkeypatch
Metadata 2.0 support"). Current hatchling — resolved fresh from PyPI by `uv build`,
because `[build-system].requires` pins no versions — emits `Metadata-Version: 2.5`, so
`Distribution check` fails on every push to `main`:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

twine 7.0.0 (2026-07-27) fixes exactly this. `uv lock` moves twine 6.2.0 -> 7.0.0 and
packaging 26.0 -> 26.3 (twine 7.0 requires `packaging>=26.1`). twine 7.0.0 declares
`requires-python >=3.10`, matching this project's floor.

The commit is a cherry-pick of the merged `develop` commit, and the resulting
`pyproject.toml` / `uv.lock` are byte-identical to `origin/develop`, so the next
`develop -> main` release merge has nothing to reconcile.

Relevant SKILL: skills/dev-environment/SKILL.md (uv lock / CI quality gates)

DoD:
- `Distribution check` green on this PR.
- `git diff origin/develop origin/main -- pyproject.toml uv.lock` empty after merge.

Test plan:
- Verified on #256: `uv build` produces a `Metadata-Version: 2.5` wheel and `twine check`
  reports `PASSED` under twine 7.0.0, where 6.2.0 raised the error above.
- Full CI matrix on this PR is the authoritative gate.
